### PR TITLE
Remove debug log every tick

### DIFF
--- a/phospho/consumer.py
+++ b/phospho/consumer.py
@@ -49,7 +49,6 @@ class Consumer(Thread):
 
     def send_batch(self) -> None:
         batch = self.log_queue.get_batch()
-        logger.debug(f"Batch: {batch}")
 
         if len(batch) > 0:
             logger.debug(f"Sending {len(batch)} log events to {self.client.base_url}")


### PR DESCRIPTION
If you enable debug logging, you get a log "Batch: []" every tick, which hangs the event loop in notebooks and is annoying in prod settings. This removes it.