### PR TITLE
fix: __mro_entries__ on threading.local restricted

### DIFF
--- a/extractor/app/temporal/workflows.py
+++ b/extractor/app/temporal/workflows.py
@@ -145,7 +145,7 @@ class StoreOpenTelemetryDataWorkflow(BaseWorkflow):
         await super().run_activity(request)
 
 
-@workflow.defn(name="run_recipe_on_task_workflow")
+@workflow.defn(name="run_recipe_on_task_workflow", sandboxed=False)
 class RunRecipeOnTaskWorkflow(BaseWorkflow):
     def __init__(self):
         super().__init__(
@@ -158,7 +158,7 @@ class RunRecipeOnTaskWorkflow(BaseWorkflow):
         await super().run_activity(request)
 
 
-@workflow.defn(name="run_main_pipeline_on_messages_workflow")
+@workflow.defn(name="run_main_pipeline_on_messages_workflow", sandboxed=False)
 class RunMainPipelineOnMessagesWorkflow(BaseWorkflow):
     def __init__(self):
         super().__init__(
@@ -171,7 +171,7 @@ class RunMainPipelineOnMessagesWorkflow(BaseWorkflow):
         await super().run_activity(request)
 
 
-@workflow.defn(name="run_process_logs_for_messages_workflow")
+@workflow.defn(name="run_process_logs_for_messages_workflow", sandboxed=False)
 class RunProcessLogsForMessagesWorkflow(BaseWorkflow):
     def __init__(self):
         super().__init__(
@@ -184,7 +184,7 @@ class RunProcessLogsForMessagesWorkflow(BaseWorkflow):
         await super().run_activity(request)
 
 
-@workflow.defn(name="run_process_log_for_tasks_workflow")
+@workflow.defn(name="run_process_log_for_tasks_workflow", sandboxed=False)
 class RunProcessLogForTasksWorkflow(BaseWorkflow):
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
temporary fix, need to find root cause of issue
__mro_entries__ on threading.local restricted
Task exception was never retrieved
future: <Task finished name='Task-2286 (workflow: run_process_log_for_tasks_workflow, id: 53a63333f89348279708631deb467424, run: f8a1572e-f8d1-46b5-b1aa-2a92082f69be)' coro=<AsyncClient.aclose() done, defined at /src/.venv/lib/python3.11/site-packages/httpx/_client.py:2011> exception=RestrictedWorkflowAccessError('Cannot access threading.local.__mro_entries__ from inside a workflow. If this is code from a module not used in a workflow or known to only be used deterministically from a workflow, mark the import as pass through.')>