### PR TITLE
feat: Store the state of the sidebar in local cache

### DIFF
--- a/platform/store/store.ts
+++ b/platform/store/store.ts
@@ -1,3 +1,4 @@
+import { SidebarState } from "@/components/sidebar/sidebar";
 import {
   CustomDateRange,
   HasEnoughLabelledTasks,
@@ -45,6 +46,9 @@ interface navigationState {
   setmetadata_metric: (metadata: string | null) => void;
   selectedGroupBy: string;
   setSelectedGroupBy: (groupBy: string) => void;
+
+  sidebarState: SidebarState | null;
+  setSidebarState: (sidebarState: SidebarState) => void;
 }
 
 export const navigationStateStore = create(
@@ -246,6 +250,10 @@ export const navigationStateStore = create(
       selectedGroupBy: "flag",
       setSelectedGroupBy: (groupBy: string) =>
         set(() => ({ selectedGroupBy: groupBy })),
+
+      sidebarState: null,
+      setSidebarState: (sidebarState: SidebarState) =>
+        set(() => ({ sidebarState: sidebarState })),
     }),
 
     {


### PR DESCRIPTION
- After reloading the page, the sidebar submenus that were opened are still open. 
- The sidebar submenu corresponding to the current page according to pathname is force opened
- The user can then close the sidebar submenu corresponding to the current page