### PR TITLE
Fix: Use start_workflow instad of execute_workflow in extractor

### DIFF
--- a/backend/app/services/mongo/ai_hub.py
+++ b/backend/app/services/mongo/ai_hub.py
@@ -146,7 +146,7 @@ class AIHubClient:
                 # Generate a random id
                 unique_id = generate_uuid()
 
-            await client.execute_workflow(
+            await client.start_workflow(
                 endpoint, data, id=unique_id, task_queue="ai-hub"
             )
 

--- a/backend/app/services/mongo/extractor.py
+++ b/backend/app/services/mongo/extractor.py
@@ -165,7 +165,7 @@ class ExtractorClient:
                 ).hexdigest()
             )
 
-            response = await client.execute_workflow(
+            response = await client.start_workflow(
                 endpoint, data, id=unique_id, task_queue="default"
             )
 

--- a/extractor/README.md
+++ b/extractor/README.md
@@ -26,26 +26,7 @@ Install the dependencies if you are running loccaly in dev mode:
 poetry install --with dev
 ```
 
-## Generating New Certificates
-
-To generate new certificates, we recommend you use tcld: https://learn.temporal.io/getting_started/python/run_workers_with_cloud_python/
-
-Follow these lines
-
-```bash
-tcld gen ca --org "your-organisation" -d 365d --ca-cert ca.pem --ca-key ca.key
-tcld gen leaf --org "your-organsation" -d 364d --ca-cert ca.pem --ca-key ca.key --cert client.pem --key client.key
-openssl x509 -in ca.pem -text -noout
-```
-
-You then have to encrypt the client key and client certificate in base 64 like so, using openssl
-
-```bash
-openssl base64 -in client.pem -out client-base64-pem
-openssl base64 -in client.key -out client-base64-key
-```
-
-# Running the worker locally
+## Running the worker locally
 
 You first need to install temporal locally to create a local workflow queue
 
@@ -75,6 +56,27 @@ Go to `localhost:8080` to access the UI and monitor the workflows.
 
 **Warning:** You have to put your EXTRACTOR_SECRET_KEY in your backend .env.
 
+# Deploying to production
+
 ## Security
 
 Requests to this server are considered already authenticated and authorized. This is because the server is behind our phospho backend. Any request will be rejected if the secret key is not provided in the request headers.
+
+## Generating New Certificates
+
+To generate new certificates, we recommend you use tcld: https://learn.temporal.io/getting_started/python/run_workers_with_cloud_python/
+
+Follow these lines
+
+```bash
+tcld gen ca --org "your-organisation" -d 365d --ca-cert ca.pem --ca-key ca.key
+tcld gen leaf --org "your-organsation" -d 364d --ca-cert ca.pem --ca-key ca.key --cert client.pem --key client.key
+openssl x509 -in ca.pem -text -noout
+```
+
+You then have to encrypt the client key and client certificate in base 64 like so, using openssl
+
+```bash
+openssl base64 -in client.pem -out client-base64-pem
+openssl base64 -in client.key -out client-base64-key
+```

--- a/extractor/app/temporal/workflows.py
+++ b/extractor/app/temporal/workflows.py
@@ -72,19 +72,19 @@ class BaseWorkflow:
         self.request_class = request_class
         self.bill = bill
         self.max_retries = max_retries
-
-    async def run_activity(self, request: dict) -> None:
-        retry_policy = RetryPolicy(
+        self.retry_policy = RetryPolicy(
             maximum_attempts=self.max_retries,
             maximum_interval=timedelta(minutes=5),
             non_retryable_error_types=["ValueError"],
         )
+
+    async def run_activity(self, request: dict) -> None:
         request_model = self.request_class(**request)
         response = await workflow.execute_activity(
             self.activity_func,
             request,
             start_to_close_timeout=timedelta(minutes=15),
-            retry_policy=retry_policy,
+            retry_policy=self.retry_policy,
         )
         if self.bill:
             await workflow.execute_activity(

--- a/platform/components/insights/clusters/clusters-cards.tsx
+++ b/platform/components/insights/clusters/clusters-cards.tsx
@@ -74,7 +74,7 @@ function ClusterCard({
   return (
     <Card
       key={cluster.id}
-      className="rounded-lg shadow-md p-4 flex flex-col justify-between h-full"
+      className="rounded-lg shadow-md p-4 flex flex-col justify-between"
     >
       <HoverCard openDelay={0} closeDelay={0}>
         <div className="flex justify-between items-start space-x-2 mb-2">


### PR DESCRIPTION
Don't wait for the return values

https://github.com/uber-go/cadence-client/issues/866

+ Various fixes