### PR TITLE
fix: infinite renders when exploring cluster/explore A/B test

### DIFF
--- a/backend/app/api/platform/endpoints/explore.py
+++ b/backend/app/api/platform/endpoints/explore.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Optional, Union, cast
+from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from loguru import logger

--- a/platform/app/org/ab-testing/[id]/page.tsx
+++ b/platform/app/org/ab-testing/[id]/page.tsx
@@ -5,15 +5,18 @@ import { Button } from "@/components/ui/button";
 import { navigationStateStore } from "@/store/store";
 import { ChevronLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 
 export default function Page({ params }: { params: { id: string } }) {
   const router = useRouter();
   const version_id = decodeURIComponent(params.id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
   const setDataFilters = navigationStateStore((state) => state.setDataFilters);
+  const setDateRangePreset = navigationStateStore(
+    (state) => state.setDateRangePreset,
+  );
 
   if (dataFilters.metadata?.version_id !== version_id) {
+    setDateRangePreset("all-time");
     setDataFilters({
       ...dataFilters,
       metadata: {
@@ -22,19 +25,20 @@ export default function Page({ params }: { params: { id: string } }) {
     });
   }
 
-  // On component unmount, remove the version_id filter
-  useEffect(() => {
-    return () => {
-      delete dataFilters.metadata?.version_id;
-      setDataFilters({
-        ...dataFilters,
-      });
-    };
-  }, [dataFilters, setDataFilters]);
+  function backClick() {
+    setDateRangePreset("last-7-days");
+    setDataFilters({
+      ...dataFilters,
+      metadata: {
+        version_id: null,
+      },
+    });
+    router.back();
+  }
 
   return (
     <>
-      <Button onClick={() => router.back()}>
+      <Button onClick={backClick}>
         <ChevronLeft className="w-4 h-4 mr-1" /> Back
       </Button>
       {

--- a/platform/app/org/ab-testing/[id]/page.tsx
+++ b/platform/app/org/ab-testing/[id]/page.tsx
@@ -19,6 +19,8 @@ export default function Page({ params }: { params: { id: string } }) {
     setDateRangePreset("all-time");
     setDataFilters({
       ...dataFilters,
+      created_at_start: null,
+      created_at_end: null,
       metadata: {
         version_id: version_id,
       },
@@ -26,13 +28,13 @@ export default function Page({ params }: { params: { id: string } }) {
   }
 
   function backClick() {
-    setDateRangePreset("last-7-days");
     setDataFilters({
       ...dataFilters,
-      metadata: {
-        version_id: null,
-      },
+      created_at_end: undefined,
+      created_at_start: Date.now() / 1000 - 7 * 24 * 60 * 60,
     });
+    setDateRangePreset("last-7-days");
+    // TODO: For some reason, the metadata is not being reset here
     router.back();
   }
 

--- a/platform/app/org/insights/clusters/[id]/page.tsx
+++ b/platform/app/org/insights/clusters/[id]/page.tsx
@@ -16,6 +16,8 @@ export default function Page({ params }: { params: { id: string } }) {
   const { accessToken } = useUser();
   const project_id = navigationStateStore((state) => state.project_id);
   const cluster_id = decodeURIComponent(params.id);
+  const dataFilters = navigationStateStore((state) => state.dataFilters);
+  const setDataFilters = navigationStateStore((state) => state.setDataFilters);
 
   // todo: fetch from server
   const { data: cluster }: { data: Cluster | undefined | null } = useSWR(
@@ -28,9 +30,18 @@ export default function Page({ params }: { params: { id: string } }) {
   const tasks_ids = cluster?.tasks_ids;
   const sessions_ids = cluster?.sessions_ids;
 
+  function backClick() {
+    setDataFilters({
+      ...dataFilters,
+      clustering_id: null,
+      clusters_ids: null,
+    });
+    router.back();
+  }
+
   return (
     <>
-      <Button onClick={() => router.back()}>
+      <Button onClick={backClick}>
         <ChevronLeft className="w-4 h-4 mr-1" /> Back
       </Button>
       <div>

--- a/platform/app/org/insights/clusters/[id]/page.tsx
+++ b/platform/app/org/insights/clusters/[id]/page.tsx
@@ -18,6 +18,9 @@ export default function Page({ params }: { params: { id: string } }) {
   const cluster_id = decodeURIComponent(params.id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
   const setDataFilters = navigationStateStore((state) => state.setDataFilters);
+  const setDateRangePreset = navigationStateStore(
+    (state) => state.setDateRangePreset,
+  );
 
   // todo: fetch from server
   const { data: cluster }: { data: Cluster | undefined | null } = useSWR(
@@ -31,6 +34,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const sessions_ids = cluster?.sessions_ids;
 
   function backClick() {
+    setDateRangePreset("last-7-days");
     setDataFilters({
       ...dataFilters,
       clustering_id: null,

--- a/platform/app/org/insights/clusters/[id]/page.tsx
+++ b/platform/app/org/insights/clusters/[id]/page.tsx
@@ -39,6 +39,8 @@ export default function Page({ params }: { params: { id: string } }) {
       ...dataFilters,
       clustering_id: null,
       clusters_ids: null,
+      created_at_end: undefined,
+      created_at_start: Date.now() / 1000 - 7 * 24 * 60 * 60,
     });
     router.back();
   }

--- a/platform/components/clusters/clusters-cards.tsx
+++ b/platform/components/clusters/clusters-cards.tsx
@@ -36,6 +36,9 @@ function ClusterCard({
   const setDataFilters = navigationStateStore((state) => state.setDataFilters);
   const orgMetadata = dataStateStore((state) => state.selectedOrgMetadata);
   const selectedOrgId = navigationStateStore((state) => state.selectedOrgId);
+  const setDateRangePreset = navigationStateStore(
+    (state) => state.setDateRangePreset,
+  );
 
   const [sheetEventOpen, setSheetEventOpen] = useState(false);
 
@@ -134,7 +137,10 @@ function ClusterCard({
               ...dataFilters,
               clustering_id: cluster.clustering_id,
               clusters_ids: [cluster.id],
+              created_at_start: null,
+              created_at_end: null,
             });
+            setDateRangePreset("all-time");
             router.push(
               `/org/insights/clusters/${encodeURIComponent(cluster.id)}`,
             );

--- a/platform/components/events/event-analytics.tsx
+++ b/platform/components/events/event-analytics.tsx
@@ -27,10 +27,7 @@ function EventAnalytics({ eventId }: { eventId: string }) {
     },
   );
 
-  const eventFilters = {
-    // created_at_start: dateRange?.created_at_start,
-    // created_at_end: dateRange?.created_at_end,
-  };
+  const eventFilters = {};
 
   // In the Record, find the event with the same id as the one passed in the props
   const eventsAsArray = Object.entries(selectedProject.settings?.events || {});


### PR DESCRIPTION
Couldn't get the filter resetting to work on component unmount without getting infinite re-renders, associating them to back button as a temporary fix