### PR TITLE
feat: Adds last message and first message

### DIFF
--- a/backend/app/api/v2/models/projects.py
+++ b/backend/app/api/v2/models/projects.py
@@ -40,6 +40,8 @@ class UserMetadata(BaseModel):
     events: Optional[List[Event]] = Field(default_factory=list)
     tasks_id: Optional[List[str]] = Field(default_factory=list)
     sessions: Optional[List[Session]] = Field(default_factory=list)
+    first_message_ts: float
+    last_message_ts: float
 
 
 class Users(BaseModel):

--- a/backend/app/services/mongo/metadata.py
+++ b/backend/app/services/mongo/metadata.py
@@ -210,6 +210,9 @@ async def fetch_user_metadata(
                 "tasks": {"$push": "$$ROOT"},
                 "total_tokens": {"$sum": "$metadata.total_tokens"},
                 "events": {"$push": "$events"},
+                # First and last message timestamp
+                "first_message_ts": {"$min": "$created_at"},
+                "last_message_ts": {"$max": "$created_at"},
             }
         },
         {
@@ -302,6 +305,8 @@ async def fetch_user_metadata(
                 "sessions": 1,
                 # "sessions_id": "$sessions.id",
                 "total_tokens": 1,
+                "first_message_ts": 1,
+                "last_message_ts": 1,
             }
         },
         # Sort by user_id

--- a/platform/app/org/settings/project/page.tsx
+++ b/platform/app/org/settings/project/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import CreateProjectDialog from "@/components/projects/create-project-form";
 import AlertDialogDeleteProject from "@/components/projects/delete-project-popup";
 import DisableAnalytics from "@/components/settings/disable-analytics";
@@ -67,6 +68,7 @@ export default function Page() {
             Your project id:{" "}
             <code className="bg-secondary p-1.5">{project_id}</code>
           </div>
+
           <HoverCard openDelay={0} closeDelay={0}>
             <HoverCardTrigger>
               <Button
@@ -85,6 +87,12 @@ export default function Page() {
               {copied ? "Copied!" : "Copy"}
             </HoverCardContent>
           </HoverCard>
+        </div>
+        <div className="flex flex-row gap-x-4">
+          Creation date:{" "}
+          <div>
+            <InteractiveDatetime timestamp={selectedProject.created_at} />
+          </div>
         </div>
         <div>
           <AlertDialog open={open} onOpenChange={setOpen}>

--- a/platform/components/clusters/clusters.tsx
+++ b/platform/components/clusters/clusters.tsx
@@ -2,6 +2,7 @@
 
 import { ClusteringLoading } from "@/components/clusters/clusters-loading";
 import RunClusteringSheet from "@/components/clusters/clusters-sheet";
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -280,16 +281,15 @@ const Clusters: React.FC = () => {
           {selectedClustering && (
             <div className="space-x-2 my-2">
               <Badge variant="secondary">
-                {`Instruction: ${selectedClustering?.instruction}` ??
-                  "No instruction"}
+                {`Instruction: ${selectedClustering?.instruction}`}
               </Badge>
               <Badge variant="secondary">
                 {selectedClustering?.nb_clusters ?? "No"} clusters
               </Badge>
               <Badge variant="secondary">
-                {formatUnixTimestampToLiteralDatetime(
-                  selectedClustering.created_at,
-                )}
+                <InteractiveDatetime
+                  timestamp={selectedClustering.created_at}
+                />
               </Badge>
               <Badge variant="secondary">
                 scope: {selectedClustering.scope}

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -19,6 +19,7 @@ function InteractiveDatetime({
   timestamp: number | undefined | null;
 }) {
   if (!timestamp) return <></>;
+  if (typeof timestamp !== "number") return <></>;
 
   const date = moment(timestamp * 1000);
   const timeAgo = moment.duration(moment().diff(date));

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -18,7 +18,7 @@ function InteractiveDatetime({
 }: {
   timestamp: number | undefined | null;
 }) {
-  if (!timestamp) return null;
+  if (!timestamp) return <></>;
 
   const date = moment(timestamp * 1000);
   const timeAgo = moment.duration(moment().diff(date));

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -33,7 +33,7 @@ function InteractiveDatetime({
           {timeAgo.humanize()} ago
         </div>
       </HoverCardTrigger>
-      <HoverCardContent>{longDate}</HoverCardContent>
+      <HoverCardContent className="text-xs">{longDate}</HoverCardContent>
     </HoverCard>
   );
 }

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -1,0 +1,41 @@
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import moment from "moment";
+
+/**
+ * Display a datetime in a human-readable format.
+ * - First row is "25 sept. 2021"
+ * - Second row is "2 weeks ago" or "2 days ago" or "2 hours ago"
+ * - When hovering, display the full human readable datetime: "25 sept. 2021, 14:30 UTC"
+ * @param timestamp Unix timestamp in seconds
+ * @returns
+ * **/
+function InteractiveDatetime({
+  timestamp,
+}: {
+  timestamp: number | undefined | null;
+}) {
+  if (!timestamp) return null;
+
+  const date = moment(timestamp * 1000);
+  const timeAgo = moment.duration(moment().diff(date));
+  const shortDate = date.format("MMM D, YYYY");
+  const longDate = date.format("MMM D, YYYY HH:mm:ss UTC");
+
+  return (
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger>
+        <div>{shortDate}</div>
+        <div className="text-xs text-muted-foreground">
+          {timeAgo.humanize()} ago
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent>{longDate}</HoverCardContent>
+    </HoverCard>
+  );
+}
+
+export { InteractiveDatetime };

--- a/platform/components/sessions/sessions-table-columns.tsx
+++ b/platform/components/sessions/sessions-table-columns.tsx
@@ -1,3 +1,4 @@
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   AddEventDropdownForSessions,
   InteractiveEventBadgeForSessions,
@@ -17,7 +18,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { authFetcher } from "@/lib/fetcher";
-import { formatUnixTimestampToLiteralDatetime } from "@/lib/time";
 import { getLanguageLabel } from "@/lib/utils";
 import { Event, EventDefinition, SessionWithEvents } from "@/models/models";
 import { Project } from "@/models/models";
@@ -137,13 +137,10 @@ export function useColumns({
         );
       },
       accessorKey: "created_at",
-      cell: ({ row }) => (
-        <span>
-          {formatUnixTimestampToLiteralDatetime(
-            Number(row.original.created_at),
-          )}
-        </span>
-      ),
+      cell: ({ row }) => {
+        const created_at = row.original.created_at;
+        return <InteractiveDatetime timestamp={created_at} />;
+      },
     },
     // Preview
     {

--- a/platform/components/tasks/tasks-table-columns.tsx
+++ b/platform/components/tasks/tasks-table-columns.tsx
@@ -1,3 +1,4 @@
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   AddEventDropdownForTasks,
   InteractiveEventBadgeForTasks,
@@ -17,7 +18,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { authFetcher } from "@/lib/fetcher";
-import { formatUnixTimestampToLiteralDatetime } from "@/lib/time";
 import { getLanguageLabel } from "@/lib/utils";
 import {
   Event,
@@ -131,13 +131,10 @@ export function useColumns({
         );
       },
       accessorKey: "created_at",
-      cell: ({ row }) => (
-        <div>
-          {formatUnixTimestampToLiteralDatetime(
-            Number(row.original.created_at),
-          )}
-        </div>
-      ),
+      cell: ({ row }) => {
+        const value = row.original.created_at;
+        return <InteractiveDatetime timestamp={value} />;
+      },
     },
     // Input
     {

--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -1,3 +1,4 @@
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   EventBadge,
   EventDetectionDescription,
@@ -120,7 +121,7 @@ export function useColumns() {
             variant="ghost"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            avg_success_rate
+            Avg. success rate
             <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
         );
@@ -138,7 +139,7 @@ export function useColumns() {
             variant="ghost"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            avg_session_length
+            Avg. session length
             <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
         );
@@ -165,6 +166,44 @@ export function useColumns() {
       cell: (row) => {
         const output = row.getValue();
         return output;
+      },
+    },
+    {
+      header: ({ column }) => {
+        return (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            First message
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        );
+      },
+      accessorKey: "first_message_ts",
+      cell: (row) => {
+        const value = row.getValue();
+        if (typeof value !== "number") return <></>;
+        return <InteractiveDatetime timestamp={value} />;
+      },
+    },
+    {
+      header: ({ column }) => {
+        return (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Last message
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        );
+      },
+      accessorKey: "last_message_ts",
+      cell: (row) => {
+        const value = row.getValue();
+        if (typeof value !== "number") return <></>;
+        return <InteractiveDatetime timestamp={value} />;
       },
     },
     {

--- a/platform/lib/time.ts
+++ b/platform/lib/time.ts
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 // Utility function to format Unix timestamp to a short date format
 export function formatUnixTimestampToShortDate(timestamp: number): string {
   const date = new Date(timestamp * 1000); // Convert Unix timestamp to milliseconds
-  return format(date, "MM/dd/yyyy");
+  return format(date, "yyyy-MM-dd");
 }
 
 // Utility function to format Unix timestamp to "Mon dd yyyy" format

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -99,6 +99,8 @@ export interface UserMetadata {
   events: Event[];
   tasks_id: string[];
   sessions: Session[];
+  first_message_ts: number;
+  last_message_ts: number;
 }
 
 export interface ScoreRange {

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-config-next": "^14.2.7",
         "gridstack": "^10.2.1",
         "lucide-react": "^0.378.0",
+        "moment": "^2.30.1",
         "next": "^14.2.7",
         "next-themes": "^0.2.1",
         "node-fetch": "^3.3.2",
@@ -11942,6 +11943,14 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
       "license": "MIT"
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/mouse-change": {
       "version": "1.4.0",

--- a/platform/package.json
+++ b/platform/package.json
@@ -51,6 +51,7 @@
     "eslint-config-next": "^14.2.7",
     "gridstack": "^10.2.1",
     "lucide-react": "^0.378.0",
+    "moment": "^2.30.1",
     "next": "^14.2.7",
     "next-themes": "^0.2.1",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary

### Situation before

Hard to read dates, no activity info for users

### What's here now

- Interactive date display component, with different level of information
- Last message and first message dates of users
- Project creation date and interactive cluster date

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
