### PR TITLE
Feat: Adds go to Sessions and better card formatting

### DIFF
--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -1,0 +1,29 @@
+name: Auto Create PR
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Check for existing PR
+        id: check_pr
+        run: |
+          PR=$(gh pr list --base main --head dev --json number --jq '.[0].number')
+          echo "::set-output name=pr_number::$PR"
+
+      - name: Create Pull Request
+        if: steps.check_pr.outputs.pr_number == ''
+        run: |
+          gh pr create --base main --head dev --title "Auto-merge dev into main" --body "This PR was automatically created by GitHub Actions."

--- a/.github/workflows/autopr.yml
+++ b/.github/workflows/autopr.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           node-version: "14"
 
+      - name: Get last merged PR number
+        id: get_last_pr
+        run: |
+          LAST_PR=$(git log -1 --pretty=format:"%s" | grep -oE '#[0-9]+' | tr -d '#')
+          echo "::set-output name=last_pr_number::$LAST_PR"
+
       - name: Check for existing PR
         id: check_pr
         run: |
@@ -26,4 +32,6 @@ jobs:
       - name: Create Pull Request
         if: steps.check_pr.outputs.pr_number == ''
         run: |
-          gh pr create --base main --head dev --title "Auto-merge dev into main" --body "This PR was automatically created by GitHub Actions."
+          gh pr create --base main --head dev \
+            --title "🧪 AutoPR dev->main" \
+            --body "Automatically created after merging PR #${{ steps.get_last_pr.outputs.last_pr_number }}"

--- a/platform/app/org/transcripts/tasks/[id]/page.tsx
+++ b/platform/app/org/transcripts/tasks/[id]/page.tsx
@@ -10,7 +10,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const router = useRouter();
 
   return (
-    <>
+    <div className="flex flex-col space-y-4">
       <Button
         onClick={() => {
           router.back();
@@ -20,6 +20,6 @@ export default function Page({ params }: { params: { id: string } }) {
         <ChevronLeft className="w-4 h-4 mr-1" /> Back
       </Button>
       <TaskOverview key={params.id} task_id={task_id}></TaskOverview>
-    </>
+    </div>
   );
 }

--- a/platform/components/events/suggest-event.tsx
+++ b/platform/components/events/suggest-event.tsx
@@ -206,7 +206,7 @@ const SuggestEvent: React.FC<SuggestEventProps> = ({ sessionId }) => {
         <HoverCardTrigger asChild>
           <PopoverTrigger asChild>
             <div
-              className={`mr-1 hover:border-green-500 rounded-full p-1 border-2 cursor-pointer`}
+              className="hover:border-green-500 rounded-full p-1.5 border-2 cursor-pointer"
               onClick={() => generateEventSuggestion()}
             >
               <Wand2 className="h-4 w-4" />
@@ -225,7 +225,7 @@ const SuggestEvent: React.FC<SuggestEventProps> = ({ sessionId }) => {
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}
-              className="font-normal space-y-4"
+              className="font-normal space-y-2"
             >
               <FormField
                 control={form.control}

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -3,6 +3,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
 import moment from "moment";
 
 /**
@@ -15,8 +16,10 @@ import moment from "moment";
  * **/
 function InteractiveDatetime({
   timestamp,
+  className,
 }: {
   timestamp: number | undefined | null;
+  className?: string;
 }) {
   if (!timestamp) return <></>;
   if (typeof timestamp !== "number") return <></>;
@@ -28,7 +31,7 @@ function InteractiveDatetime({
 
   return (
     <HoverCard openDelay={0} closeDelay={0}>
-      <HoverCardTrigger>
+      <HoverCardTrigger className={className}>
         <div>{shortDate}</div>
         <div className="text-xs text-muted-foreground">
           {timeAgo.humanize()} ago

--- a/platform/components/interactive-datetime.tsx
+++ b/platform/components/interactive-datetime.tsx
@@ -3,7 +3,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { cn } from "@/lib/utils";
 import moment from "moment";
 
 /**

--- a/platform/components/label-events.tsx
+++ b/platform/components/label-events.tsx
@@ -83,8 +83,8 @@ export const EventBadge = ({ event }: { event: Event }) => {
     : null;
 
   const badgeStyle = event.confirmed
-    ? "border bg-green-500 hover:border-green-500 mb-1"
-    : "border hover:border-green-500 mb-1";
+    ? "border bg-green-500 hover:border-green-500"
+    : "border hover:border-green-500";
 
   const score_type = event.score_range?.score_type ?? "confidence";
 
@@ -397,7 +397,7 @@ export const AddEventDropdownForTasks = ({
       <DropdownMenuTrigger>
         <Badge
           variant="outline"
-          className={cn("hover:border-green-500 mb-1", className)}
+          className={cn("hover:border-green-500", className)}
         >
           +
         </Badge>
@@ -805,7 +805,7 @@ export const AddEventDropdownForSessions = ({
       <DropdownMenuTrigger>
         <Badge
           variant="outline"
-          className={cn(" hover:border-green-500 mb-1", className)}
+          className={cn(" hover:border-green-500", className)}
         >
           +
         </Badge>

--- a/platform/components/sessions/session.tsx
+++ b/platform/components/sessions/session.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import SuggestEvent from "@/components/events/suggest-event";
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   AddEventDropdownForSessions,
   InteractiveEventBadgeForSessions,
@@ -9,20 +10,19 @@ import { Spinner } from "@/components/small-spinner";
 import TaskBox from "@/components/task-box";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { authFetcher } from "@/lib/fetcher";
-import { formatUnixTimestampToLiteralDatetime } from "@/lib/time";
 import { Event, SessionWithEvents, TaskWithEvents } from "@/models/models";
 import { useUser } from "@propelauth/nextjs/client";
 import { ChevronDown, ChevronRight, CopyIcon } from "lucide-react";
@@ -31,14 +31,6 @@ import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import useSWR from "swr";
 import { useSWRConfig } from "swr";
-
-import { InteractiveDatetime } from "../interactive-datetime";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
 
 const SessionStats = ({
   session_id,
@@ -68,13 +60,8 @@ const SessionStats = ({
   );
   const {
     data: sessionTasksData,
-    mutate: mutateSessionTasks,
   }: {
     data: TaskWithEvents[] | undefined;
-    mutate: (
-      data: TaskWithEvents[] | undefined,
-      shouldRevalidate?: boolean,
-    ) => void;
   } = useSWR(
     [`/api/sessions/${session_id}/tasks`, accessToken],
     ([url, accessToken]) =>
@@ -135,6 +122,7 @@ const SessionStats = ({
               <DropdownMenuContent>
                 {uniqueUsers?.map((user_id) => (
                   <DropdownMenuItem
+                    key={`${session_id}-${user_id}`}
                     onClick={() =>
                       router.push(`/org/transcripts/users/${user_id}`)
                     }

--- a/platform/components/sessions/session.tsx
+++ b/platform/components/sessions/session.tsx
@@ -31,6 +31,8 @@ import React, { useState } from "react";
 import useSWR from "swr";
 import { useSWRConfig } from "swr";
 
+import { InteractiveDatetime } from "../interactive-datetime";
+
 const SessionStats = ({
   session_id,
   showGoToSession = false,
@@ -64,122 +66,114 @@ const SessionStats = ({
   );
 
   return (
-    <Card className="mt-4">
-      <CardHeader>
-        <CardTitle className="text-xl font-bold tracking-tight mb-2">
-          <div className="flex justify-between">
-            Session
-            {showGoToSession && (
-              <Link href={`/org/transcripts/sessions/${session_id}`}>
-                <Button variant="secondary">
-                  Go to Session
-                  <ChevronRight />
-                </Button>
-              </Link>
-            )}
-          </div>
-        </CardTitle>
-        <CardDescription>
-          <div className="flex flex-col space-y-1">
-            <div>
-              <code className="bg-secondary p-1.5 text-xs">{session_id}</code>
-              <Button
-                variant="outline"
-                className="m-1.5"
-                size="icon"
-                onClick={() => {
-                  navigator.clipboard.writeText(session_id);
-                }}
-              >
-                <CopyIcon className="w-3 h-3" />
-              </Button>
-            </div>
-            {uniqueEvents && (
-              <div className="flex">
-                <div className="space-x-2 flex items-center">
-                  {sessionData &&
-                    uniqueEvents?.map((event: Event) => (
-                      <InteractiveEventBadgeForSessions
-                        key={event.id}
-                        event={event}
-                        session={sessionData}
-                        setSession={(session: SessionWithEvents) => {
-                          mutateSessionData(session);
-                          // Fetch the session list
-                          mutate((key: string[]) =>
-                            key.includes(
-                              `/api/projects/${sessionData.project_id}/sessions`,
-                            ),
-                          );
-                        }}
-                      />
-                    ))}
-                  {sessionData && (
-                    <AddEventDropdownForSessions
-                      session={sessionData}
-                      setSession={(session: SessionWithEvents) => {
-                        mutateSessionData(session);
-                        // Fetch the session list
-                        mutate((key: string[]) =>
-                          key.includes(
-                            `/api/projects/${sessionData.project_id}/sessions`,
-                          ),
-                        );
-                      }}
-                    />
-                  )}
-                  <SuggestEvent sessionId={session_id} />
-                </div>
-              </div>
-            )}
-            <span>
-              <span className="font-bold">Created at: </span>
-              {sessionData &&
-                formatUnixTimestampToLiteralDatetime(sessionData.created_at)}
-            </span>
-          </div>
-          <div className="space-y-2">
-            {sessionData?.metadata &&
-              Object.entries(sessionData.metadata)
-                .sort(([key1], [key2]) => {
-                  if (key1 < key2) return -1;
-                  if (key1 > key2) return 1;
-                  return 0;
-                })
-                .map(([key, value]) => {
-                  if (typeof value === "string" || typeof value === "number") {
-                    const shortValue =
-                      typeof value === "string" && value.length > 50
-                        ? value.substring(0, 50) + "..."
-                        : value;
-                    return (
-                      <Badge
-                        variant="outline"
-                        className="mx-2 text-xs font-normal"
-                        key={key}
-                      >
-                        <div>
-                          {key}: {shortValue}
-                        </div>
-                      </Badge>
+    <>
+      <div className="flex justify-between items-center">
+        <span className="text-xl font-bold tracking-tight">Session</span>
+        {showGoToSession && (
+          <Link href={`/org/transcripts/sessions/${session_id}`}>
+            <Button variant="secondary">
+              Go to Session
+              <ChevronRight />
+            </Button>
+          </Link>
+        )}
+      </div>
+      <Card className="flex flex-col space-y-1 p-2">
+        <div className="flex flex-row items-center">
+          <code className="bg-secondary p-1.5 text-xs">{session_id}</code>
+          <Button
+            variant="outline"
+            className="m-1.5"
+            size="icon"
+            onClick={() => {
+              navigator.clipboard.writeText(session_id);
+            }}
+          >
+            <CopyIcon className="w-3 h-3" />
+          </Button>
+        </div>
+        <div className="text-xs w-48">
+          Created at:
+          <InteractiveDatetime timestamp={sessionData?.created_at} />
+        </div>
+        <div className="flex">
+          <div className="gap-x-0.5 gap-y-0.5 flex flex-wrap items-center">
+            {uniqueEvents &&
+              sessionData &&
+              uniqueEvents?.map((event: Event) => (
+                <InteractiveEventBadgeForSessions
+                  key={event.id}
+                  event={event}
+                  session={sessionData}
+                  setSession={(session: SessionWithEvents) => {
+                    mutateSessionData(session);
+                    // Fetch the session list
+                    mutate((key: string[]) =>
+                      key.includes(
+                        `/api/projects/${sessionData.project_id}/sessions`,
+                      ),
                     );
-                  }
-                  return null;
-                })}
+                  }}
+                />
+              ))}
+            {sessionData && (
+              <AddEventDropdownForSessions
+                session={sessionData}
+                setSession={(session: SessionWithEvents) => {
+                  mutateSessionData(session);
+                  // Fetch the session list
+                  mutate((key: string[]) =>
+                    key.includes(
+                      `/api/projects/${sessionData.project_id}/sessions`,
+                    ),
+                  );
+                }}
+              />
+            )}
+            <SuggestEvent sessionId={session_id} />
           </div>
-          <Collapsible>
-            <CollapsibleTrigger>
-              <Button variant="link">{">"}Raw Session Data</Button>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <pre className="whitespace-pre-wrap mx-2">
-                {JSON.stringify(sessionData, null, 2)}
-              </pre>
-            </CollapsibleContent>
-          </Collapsible>
-        </CardDescription>
-      </CardHeader>
-    </Card>
+        </div>
+        <div className="gap-x-0.5 gap-y-0.5 flex flex-wrap">
+          {sessionData?.metadata &&
+            Object.entries(sessionData.metadata)
+              .sort(([key1], [key2]) => {
+                if (key1 < key2) return -1;
+                if (key1 > key2) return 1;
+                return 0;
+              })
+              .map(([key, value]) => {
+                if (typeof value === "string" || typeof value === "number") {
+                  const shortValue =
+                    typeof value === "string" && value.length > 50
+                      ? value.substring(0, 50) + "..."
+                      : value;
+                  return (
+                    <Badge
+                      variant="outline"
+                      className="text-xs font-normal"
+                      key={key}
+                    >
+                      <div>
+                        {key}: {shortValue}
+                      </div>
+                    </Badge>
+                  );
+                }
+                return null;
+              })}
+        </div>
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <Button variant="link">{">"}Raw Session Data</Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="whitespace-pre-wrap mx-2 bg-secondary p-2 text-xs">
+              {JSON.stringify(sessionData, null, 2)}
+            </pre>
+          </CollapsibleContent>
+        </Collapsible>
+      </Card>
+    </>
   );
 };
 
@@ -219,46 +213,40 @@ const SessionTranscript = ({ session_id }: { session_id: string }) => {
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-xl font-bold ">Transcript</CardTitle>
-        </CardHeader>
-        <CardContent>
-          {sessionTasksData === undefined && <Spinner />}
-          {sessionTasksData?.map((task: TaskWithEvents, index) => (
-            <TaskBox
-              key={index}
-              task={task}
-              setTask={(task: TaskWithEvents) => {
-                // use mutate session task to change the task with the same id
-                const newTasks = sessionTasksData?.map((t) => {
-                  if (t.id === task.id) {
-                    return task;
-                  }
-                  return t;
-                });
-                mutateSessionTasks(newTasks, false);
-              }}
-              setFlag={(flag: string) => {
-                const newTasks = sessionTasksData?.map((t) => {
-                  if (t.id === task.id) {
-                    t.flag = flag;
-                  }
-                  return t;
-                });
-                mutateSessionTasks(newTasks, false);
-                setRefresh(!refresh);
-              }}
-            />
-          ))}
-        </CardContent>
-      </Card>
+      <div className="text-xl font-bold ">Transcript</div>
+      {sessionTasksData === undefined && <Spinner />}
+      {sessionTasksData?.map((task: TaskWithEvents, index) => (
+        <TaskBox
+          key={index}
+          task={task}
+          setTask={(task: TaskWithEvents) => {
+            // use mutate session task to change the task with the same id
+            const newTasks = sessionTasksData?.map((t) => {
+              if (t.id === task.id) {
+                return task;
+              }
+              return t;
+            });
+            mutateSessionTasks(newTasks, false);
+          }}
+          setFlag={(flag: string) => {
+            const newTasks = sessionTasksData?.map((t) => {
+              if (t.id === task.id) {
+                t.flag = flag;
+              }
+              return t;
+            });
+            mutateSessionTasks(newTasks, false);
+            setRefresh(!refresh);
+          }}
+        />
+      ))}
     </>
   );
 };
 const SessionOverview = ({ session_id }: { session_id: string }) => {
   return (
-    <div className="flex flex-col space-y-4">
+    <div className="flex flex-col space-y-4 mt-4">
       <SessionStats session_id={session_id} />
       <SessionTranscript session_id={session_id} />
     </div>

--- a/platform/components/task-box.tsx
+++ b/platform/components/task-box.tsx
@@ -3,13 +3,20 @@
 import ThumbsUpAndDown from "@/components/thumbs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { getLanguageLabel } from "@/lib/utils";
 import { Task, TaskWithEvents } from "@/models/models";
+import Link from "next/link";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
@@ -18,7 +25,6 @@ import {
   AddEventDropdownForTasks,
   InteractiveEventBadgeForTasks,
 } from "./label-events";
-import { Card } from "./ui/card";
 
 const TaskBox = ({
   task,
@@ -72,7 +78,7 @@ const TaskBox = ({
           <div className="flex justify-start">
             <div className="flex flex-col">
               <div className="text-muted-foreground ml-4 text-xs">
-                System Prompt:
+                System Prompt
               </div>
               <div className="bg-primary text-secondary min-w-[200px] rounded-lg px-2 py-1 mx-2 whitespace-pre-wrap">
                 <ReactMarkdown className="m-1">
@@ -84,7 +90,25 @@ const TaskBox = ({
         )}
         <div className="flex justify-start">
           <div className="flex flex-col">
-            <div className="text-muted-foreground ml-4 text-xs">User:</div>
+            <div className="text-muted-foreground ml-4 text-xs">
+              {task.metadata?.user_id ? (
+                <HoverCard>
+                  <HoverCardTrigger asChild>
+                    <Link
+                      href={`/org/transcripts/users/${encodeURIComponent(task.metadata.user_id)}`}
+                      className="underline cursor-pointer"
+                    >
+                      User
+                    </Link>
+                  </HoverCardTrigger>
+                  <HoverCardContent>
+                    See all messages from user
+                  </HoverCardContent>
+                </HoverCard>
+              ) : (
+                <>User</>
+              )}
+            </div>
             <div className="bg-green-500 text-secondary min-w-[200px] rounded-lg px-2 py-1 mx-2 whitespace-pre-wrap">
               {task.input && (
                 <ReactMarkdown className="m-1">{task.input}</ReactMarkdown>
@@ -96,7 +120,7 @@ const TaskBox = ({
           <div className="flex justify-start">
             <div className="flex flex-col">
               <div className="text-muted-foreground ml-4 text-xs">
-                Assistant:
+                Assistant
               </div>
               <div className="bg-secondary min-w-[200px] rounded-lg px-2 py-1 mx-2 whitespace-pre-wrap">
                 <ReactMarkdown className="m-1">{task.output}</ReactMarkdown>

--- a/platform/components/task-box.tsx
+++ b/platform/components/task-box.tsx
@@ -13,10 +13,12 @@ import { Task, TaskWithEvents } from "@/models/models";
 import React from "react";
 import ReactMarkdown from "react-markdown";
 
+import { InteractiveDatetime } from "./interactive-datetime";
 import {
   AddEventDropdownForTasks,
   InteractiveEventBadgeForTasks,
 } from "./label-events";
+import { Card } from "./ui/card";
 
 const TaskBox = ({
   task,
@@ -28,9 +30,21 @@ const TaskBox = ({
   setFlag: (flag: string) => void;
 }) => {
   return (
-    <div className="flex flex-col space-y-1 p-1 border-2 border-secondary rounded-md mb-2">
+    <Card className="flex flex-col space-y-2 rounded-md p-2">
       <div className="flex justify-between align-top">
-        <div className="space-x-2 flex justify-between items-center">
+        <div className="gap-x-0.5 gap-y-0.5 flex flex-wrap items-center">
+          <InteractiveDatetime
+            timestamp={task.created_at}
+            className="text-xs mx-1"
+          />
+          {task?.language != null && (
+            <Badge variant="outline">
+              User language: {getLanguageLabel(task?.language)}
+            </Badge>
+          )}
+          {task?.sentiment?.label != null && (
+            <Badge variant="outline">Sentiment: {task?.sentiment?.label}</Badge>
+          )}
           {task?.events?.map((event) => {
             return (
               <InteractiveEventBadgeForTasks
@@ -42,14 +56,6 @@ const TaskBox = ({
             );
           })}
           <AddEventDropdownForTasks task={task} setTask={setTask} />
-          {task?.language != null && (
-            <Badge variant="outline">
-              User language: {getLanguageLabel(task?.language)}
-            </Badge>
-          )}
-          {task?.sentiment?.label != null && (
-            <Badge variant="outline">Sentiment: {task?.sentiment?.label}</Badge>
-          )}
         </div>
         <ThumbsUpAndDown
           task={task}
@@ -100,16 +106,16 @@ const TaskBox = ({
         )}
       </div>
       <Collapsible>
-        <CollapsibleTrigger>
+        <CollapsibleTrigger asChild>
           <Button variant="link">{">"}Raw Task Data</Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <pre className="whitespace-pre-wrap mx-2">
+          <pre className="whitespace-pre-wrap mx-2 bg-secondary p-2 text-xs">
             {JSON.stringify(task, null, 2)}
           </pre>
         </CollapsibleContent>
       </Collapsible>
-      <div>
+      <div className="flex flex-wrap gap-x-0.5 gap-y-0.5">
         {task.metadata &&
           Object.entries(task.metadata)
             .sort(
@@ -135,7 +141,7 @@ const TaskBox = ({
                 return (
                   <Badge
                     variant="outline"
-                    className="mx-2 text-xs font-normal"
+                    className="text-xs font-normal"
                     key={"button-" + key}
                   >
                     <p key={key}>
@@ -146,7 +152,7 @@ const TaskBox = ({
               }
             })}
       </div>
-    </div>
+    </Card>
   );
 };
 

--- a/platform/components/tasks/task-preview.tsx
+++ b/platform/components/tasks/task-preview.tsx
@@ -5,9 +5,9 @@ function TaskPreview({ task_id }: { task_id: string | null }) {
     return null;
   }
   return (
-    <>
+    <div className="flex flex-col space-y-4">
       <TaskOverview task_id={task_id} showGoToTask={true} />
-    </>
+    </div>
   );
 }
 

--- a/platform/components/tasks/task.tsx
+++ b/platform/components/tasks/task.tsx
@@ -58,8 +58,17 @@ const TaskOverview: React.FC<TaskProps> = ({
             </Link>
           )}
           {task.session_id && (
-            <Link href={`/org/transcripts/sessions/${task.session_id}`}>
+            <Link
+              href={`/org/transcripts/sessions/${encodeURIComponent(task.session_id)}`}
+            >
               <Button variant="secondary">Go to Session</Button>
+            </Link>
+          )}
+          {task.metadata?.user_id && (
+            <Link
+              href={`/org/transcripts/users/${encodeURIComponent(task.metadata?.user_id)}`}
+            >
+              <Button variant="secondary">Go to User</Button>
             </Link>
           )}
         </div>

--- a/platform/components/tasks/task.tsx
+++ b/platform/components/tasks/task.tsx
@@ -1,19 +1,14 @@
 "use client";
 
+import { InteractiveDatetime } from "@/components/interactive-datetime";
 import { CenteredSpinner } from "@/components/small-spinner";
 import TaskBox from "@/components/task-box";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { authFetcher } from "@/lib/fetcher";
-import { formatUnixTimestampToLiteralDatetime } from "@/lib/time";
 import { Task, TaskWithEvents } from "@/models/models";
 import { useUser } from "@propelauth/nextjs/client";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, CopyIcon } from "lucide-react";
 import Link from "next/link";
 import React, { useState } from "react";
 import useSWR from "swr";
@@ -50,61 +45,73 @@ const TaskOverview: React.FC<TaskProps> = ({
   };
 
   return (
-    <div className="flex flex-col space-y-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-xl font-bold tracking-tight">
-            <div className="flex justify-between">
-              Message
-              <div className="flex flex-row space-x-2">
-                {showGoToTask && (
-                  <Link href={`/org/transcripts/tasks/${task_id}`}>
-                    <Button variant="secondary">
-                      Go to Message
-                      <ChevronRight />
-                    </Button>
-                  </Link>
-                )}
-                {task.session_id && (
-                  <Link href={`/org/transcripts/sessions/${task.session_id}`}>
-                    <Button variant="secondary">Go to Session</Button>
-                  </Link>
-                )}
-              </div>
+    <>
+      <div className="flex justify-between items-center mt-4">
+        <span className="text-xl font-bold">Message</span>
+        <div className="flex flex-row space-x-2">
+          {showGoToTask && (
+            <Link href={`/org/transcripts/tasks/${task_id}`}>
+              <Button variant="secondary">
+                Go to Message
+                <ChevronRight />
+              </Button>
+            </Link>
+          )}
+          {task.session_id && (
+            <Link href={`/org/transcripts/sessions/${task.session_id}`}>
+              <Button variant="secondary">Go to Session</Button>
+            </Link>
+          )}
+        </div>
+      </div>
+      <Card className="flex flex-col sapce-y-1 p-2">
+        <div className="flex flex-row items-center">
+          <code className="bg-secondary p-1.5 text-xs">{task_id}</code>
+          <Button
+            variant="outline"
+            className="m-1.5"
+            size="icon"
+            onClick={() => {
+              navigator.clipboard.writeText(task_id);
+            }}
+          >
+            <CopyIcon className="w-3 h-3" />
+          </Button>
+        </div>
+        <div className="flex flex-row space-x-16">
+          <div className="text-xs max-w-48">
+            <span>Created at:</span>
+            <InteractiveDatetime timestamp={task.created_at} />
+          </div>
+          {task.task_position && (
+            <div className="flex flex-col">
+              <div className="text-xl font-bold">#{task.task_position}</div>
+              <span className="text-muted-foreground text-xs">position</span>
             </div>
-          </CardTitle>
-          <CardDescription>
-            <ul>
-              <li>
-                <span className="font-bold">Task ID:</span> {task.id}
-              </li>
-              <li>
-                <span className="font-bold">Created at:</span>{" "}
-                {formatUnixTimestampToLiteralDatetime(task.created_at)}
-              </li>
-              <li>
-                <span className="font-bold">Last eval source:</span>{" "}
-                {task?.last_eval?.source ?? "None"}
-              </li>
-              <li>
-                <span className="font-bold">Last eval date:</span>{" "}
-                {task?.last_eval?.created_at
-                  ? formatUnixTimestampToLiteralDatetime(
-                      task?.last_eval?.created_at,
-                    )
-                  : "Never"}
-              </li>
-              <li>
-                <span className="font-bold">Message position:</span>{" "}
-                {task.task_position}
-              </li>
-              <li>
-                <span className="font-bold">Is last message:</span>{" "}
-                {task.is_last_task ? "Yes" : "No"}
-              </li>
-            </ul>
-          </CardDescription>
-        </CardHeader>
+          )}
+          <div className="flex flex-col">
+            <div className="text-xl font-bold">
+              {task.is_last_task ? "Yes" : "No"}
+            </div>
+            <span className="text-muted-foreground text-xs">
+              Is last message?
+            </span>
+          </div>
+          {task?.last_eval?.source && (
+            <div className="flex flex-col">
+              <div className="text-xl font-bold">{task?.last_eval?.source}</div>
+              <span className="text-muted-foreground text-xs">
+                Last eval source
+              </span>
+            </div>
+          )}
+          {task?.last_eval?.created_at && (
+            <div className="text-xs max-w-48">
+              <span>Last eval date:</span>
+              <InteractiveDatetime timestamp={task?.last_eval?.created_at} />
+            </div>
+          )}
+        </div>
       </Card>
       <TaskBox
         task={task}
@@ -113,7 +120,7 @@ const TaskOverview: React.FC<TaskProps> = ({
         }}
         setFlag={setFlag}
       />
-    </div>
+    </>
   );
 };
 

--- a/platform/components/thumbs.tsx
+++ b/platform/components/thumbs.tsx
@@ -229,29 +229,29 @@ const ThumbsUpAndDown: React.FC<ThumbsUpAndDownProps> = ({
   );
 
   return (
-    <div className="flex justify-end">
-      {flag === "success" && !task.last_eval && successByPhospho}
-      {flag === "failure" && !task.last_eval && failureByPhospho}
-      {flag === "success" &&
-        task.last_eval &&
-        task.last_eval.source.startsWith("phospho") &&
-        successByPhospho}
-      {flag === "failure" &&
-        task.last_eval &&
-        task.last_eval.source.startsWith("phospho") &&
-        failureByPhospho}
-      {flag === "success" &&
-        task.last_eval &&
-        !task.last_eval.source.startsWith("phospho") &&
-        successByUser}
-      {flag === "failure" &&
-        task.last_eval &&
-        !task.last_eval.source.startsWith("phospho") &&
-        failureByUser}
-      {(flag === null || flag === "undefined") && noEval}
+    <Popover key={key} open={popoverOpen} onOpenChange={setPopoverOpen}>
+      <div className="flex justify-end align-top">
+        {flag === "success" && !task.last_eval && successByPhospho}
+        {flag === "failure" && !task.last_eval && failureByPhospho}
+        {flag === "success" &&
+          task.last_eval &&
+          task.last_eval.source.startsWith("phospho") &&
+          successByPhospho}
+        {flag === "failure" &&
+          task.last_eval &&
+          task.last_eval.source.startsWith("phospho") &&
+          failureByPhospho}
+        {flag === "success" &&
+          task.last_eval &&
+          !task.last_eval.source.startsWith("phospho") &&
+          successByUser}
+        {flag === "failure" &&
+          task.last_eval &&
+          !task.last_eval.source.startsWith("phospho") &&
+          failureByUser}
+        {(flag === null || flag === "undefined") && noEval}
 
-      <Popover key={key} open={popoverOpen} onOpenChange={setPopoverOpen}>
-        <PopoverTrigger>
+        <PopoverTrigger asChild>
           <Button
             variant="outline"
             size="icon"
@@ -260,23 +260,21 @@ const ThumbsUpAndDown: React.FC<ThumbsUpAndDownProps> = ({
             <PenSquare className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-96 h-120">
-          <CardHeader>
-            <div>
-              <Textarea
-                id="description"
-                placeholder={`Write a custom note for this message.\nWhen your users give you feedback, you see it here.`}
-                value={currentNotes}
-                onChange={handleNoteEdit}
-              />
-            </div>
-            <Button className="hover:bg-green-600" onClick={handleSaveButton}>
-              Save
-            </Button>
-          </CardHeader>
-        </PopoverContent>
-      </Popover>
-    </div>
+      </div>
+      <PopoverContent align="end" className="w-96 h-120">
+        <CardHeader>
+          <Textarea
+            id="description"
+            placeholder={`Write a custom note for this message.\nWhen your users give you feedback, you see it here.`}
+            value={currentNotes}
+            onChange={handleNoteEdit}
+          />
+          <Button className="hover:bg-green-600" onClick={handleSaveButton}>
+            Save
+          </Button>
+        </CardHeader>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -88,6 +88,7 @@ export interface SessionWithEvents extends Session {
   events: Event[];
   tasks: Task[];
   stats: Stats;
+  users: UserMetadata[];
 }
 
 export interface UserMetadata {


### PR DESCRIPTION
## Summary

### Situation before

- Issue wrapping
- Lots of nested cards

<img width="759" alt="Capture d’écran 2024-10-15 à 13 21 38" src="https://github.com/user-attachments/assets/22a8109d-815c-484c-a3ea-15d1f6989aca">

### What's here now

- Better format of metadata in frontend
- Wrapping 
- GH workflow to autocreate PR to main

<img width="762" alt="Capture d’écran 2024-10-15 à 13 21 53" src="https://github.com/user-attachments/assets/e3179691-7690-4da3-b2a8-eab12470a027">

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
