### PR TITLE
feat: Adds last update ts for sessions

### DIFF
--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1280,7 +1280,7 @@ async def create_ab_tests_table(project_id: str, limit: int = 1000) -> List[ABTe
                         "last_task_ts": 1,
                     }
                 },
-                {"$sort": {"first_task_timestamp": -1}},
+                {"$sort": {"first_task_timestamp": 1}},
             ]
         )
         .to_list(length=limit)

--- a/backend/app/services/mongo/triggers.py
+++ b/backend/app/services/mongo/triggers.py
@@ -18,11 +18,17 @@ def aggregate_tasks_into_sessions(tasks: List[Task], project_id: str) -> List[Se
                 session_length=1,
                 tasks=[task],
                 preview=task.preview(),
+                last_message_ts=task.created_at,
             )
         else:
             if task.created_at < sessions[task.session_id].created_at:
                 sessions[task.session_id].created_at = task.created_at
                 sessions[task.session_id].preview = task.preview()
+            if (
+                sessions[task.session_id].last_message_ts
+                and task.created_at > sessions[task.session_id].last_message_ts
+            ):
+                sessions[task.session_id].last_message_ts = task.created_at
             sessions[task.session_id].session_length += 1
             session_tasks = sessions[task.session_id].tasks
             if session_tasks is not None:

--- a/extractor/extractor/services/pipelines.py
+++ b/extractor/extractor/services/pipelines.py
@@ -468,6 +468,7 @@ class MainPipeline:
         - Most common sentiment label
         - Most common language
         - Most common flag
+        - Last message timestamp
         """
         outputs: Dict[str, SessionStats] = {}
 
@@ -495,6 +496,7 @@ class MainPipeline:
             sentiment_score: list = []
             sentiment_magnitude: list = []
             preview = ""
+            last_message_ts = None
 
             valid_tasks = [Task.model_validate(task) for task in tasks]
             for valid_task in valid_tasks:
@@ -504,6 +506,8 @@ class MainPipeline:
                     if valid_task.sentiment.magnitude is not None:
                         sentiment_magnitude.append(valid_task.sentiment.magnitude)
                 preview += valid_task.preview() + "\n"
+                if last_message_ts is None or valid_task.created_at > last_message_ts:
+                    last_message_ts = valid_task.created_at
 
             if len(valid_tasks) > 0:
                 avg_sentiment_score = None
@@ -550,6 +554,7 @@ class MainPipeline:
                         "$set": {
                             "stats": session_task_info.model_dump(),
                             "preview": preview if preview else None,
+                            "last_message_ts": last_message_ts,
                         }
                     },
                 )

--- a/phospho-python/phospho/models.py
+++ b/phospho-python/phospho/models.py
@@ -221,6 +221,7 @@ class Session(ProjectElementBaseModel):
     # Session length is computed dynamically. It may be None if not computed
     session_length: int = 0
     stats: SessionStats = Field(default_factory=SessionStats)
+    last_message_ts: Optional[int] = None
 
     @field_serializer("metadata")
     def serialize_metadata(self, metadata: dict, _info):
@@ -325,17 +326,17 @@ class Project(DatedBaseModel):
             if "events" in project_data["settings"].keys():
                 for event_name, event in project_data["settings"]["events"].items():
                     if "event_name" not in event.keys():
-                        project_data["settings"]["events"][event_name]["event_name"] = (
-                            event_name
-                        )
+                        project_data["settings"]["events"][event_name][
+                            "event_name"
+                        ] = event_name
                     if "org_id" not in event.keys():
-                        project_data["settings"]["events"][event_name]["org_id"] = (
-                            project_data["org_id"]
-                        )
+                        project_data["settings"]["events"][event_name][
+                            "org_id"
+                        ] = project_data["org_id"]
                     if "project_id" not in event.keys():
-                        project_data["settings"]["events"][event_name]["project_id"] = (
-                            project_data["id"]
-                        )
+                        project_data["settings"]["events"][event_name][
+                            "project_id"
+                        ] = project_data["id"]
 
             # Transition dashboard_tiles to lowercase and new fields
             if "dashboard_tiles" in project_data["settings"].keys():

--- a/phospho-python/phospho/utils.py
+++ b/phospho-python/phospho/utils.py
@@ -27,7 +27,7 @@ def generate_timestamp() -> int:
 
 def generate_uuid(prefix: str = "") -> str:
     """
-    Add a prefiw if needed to the uuid
+    Add a prefix if needed to the uuid
     Example: generate_uuid("file_") to have a file_id
     """
     value = uuid.uuid4().hex

--- a/platform/components/abtesting/abtesting-dataviz.tsx
+++ b/platform/components/abtesting/abtesting-dataviz.tsx
@@ -60,13 +60,6 @@ export const ABTestingDataviz = () => {
         if (res === undefined) return undefined;
         if (!res.abtests) return null;
         const abtests = res.abtests as ABTest[];
-        // Round the score and score_std to 2 decimal places
-        abtests.forEach((abtest) => {
-          abtest.score = Math.round(abtest.score * 10000) / 100;
-          if (abtest.score_std) {
-            abtest.score_std = Math.round(abtest?.score_std * 10000) / 100;
-          }
-        });
         return abtests;
       }),
     {

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -74,6 +74,8 @@ export interface Session {
   environment?: string;
   notes?: string;
   session_length?: number;
+  stats: Stats;
+  last_message_ts?: number;
 }
 
 export interface Stats {
@@ -84,10 +86,10 @@ export interface Stats {
   most_common_flag: string;
   human_eval: string;
 }
+
 export interface SessionWithEvents extends Session {
   events: Event[];
   tasks: Task[];
-  stats: Stats;
   users: UserMetadata[];
 }
 


### PR DESCRIPTION
## Summary

### Situation before

Sessions have no info of the last created_at of a Task.

### What's here now

last_update_ts carries this info 

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
