### PR TITLE
Feat: Adds Session.last_message_ts

### DIFF
--- a/backend/app/api/platform/models/abtests.py
+++ b/backend/app/api/platform/models/abtests.py
@@ -3,11 +3,12 @@ from pydantic import BaseModel
 
 
 class ABTest(BaseModel):
+    first_task_ts: int
+    last_task_ts: int
     version_id: Optional[str] = "None"
     score: float
     score_std: Optional[float] = None
     nb_tasks: int
-    first_task_timestamp: int
     confidence_interval: Optional[List[float]] = None
 
 

--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1260,7 +1260,8 @@ async def create_ab_tests_table(project_id: str, limit: int = 1000) -> List[ABTe
                             "$avg": {"$cond": [{"$eq": ["$flag", "success"]}, 1, 0]}
                         },
                         "nb_tasks": {"$sum": 1},
-                        "first_task_timestamp": {"$min": "$created_at"},
+                        "first_task_ts": {"$min": "$created_at"},
+                        "last_task_ts": {"$max": "$created_at"},
                         # "score_std": {
                         #     "$stdDevSamp": {
                         #         "$cond": [{"$eq": ["$flag", "success"]}, 1, 0]
@@ -1274,8 +1275,9 @@ async def create_ab_tests_table(project_id: str, limit: int = 1000) -> List[ABTe
                         "version_id": "$_id",
                         "score": 1,
                         "nb_tasks": 1,
-                        "first_task_timestamp": 1,
                         "score_std": 1,
+                        "first_task_ts": 1,
+                        "last_task_ts": 1,
                     }
                 },
                 {"$sort": {"first_task_timestamp": -1}},

--- a/platform/app/org/ab-testing/[version_id]/page.tsx
+++ b/platform/app/org/ab-testing/[version_id]/page.tsx
@@ -19,20 +19,14 @@ export default function Page({ params }: { params: { version_id: string } }) {
   }, [setDateRangePreset]);
 
   return (
-    <>
-      <Button onClick={() => router.back()}>
+    <div className="flex flex-col space-y-4">
+      <Button onClick={() => router.back()} className="max-w-[10rem]">
         <ChevronLeft className="w-4 h-4 mr-1" /> Back
       </Button>
-      <div>
-        <div className="pb-4">
-          <div className="text-2xl font-bold tracking-tight mr-8">
-            Messages of version &apos;{version_id}&apos;
-          </div>
-        </div>
-        <div className="hidden h-full flex-1 flex-col space-y-2 md:flex relative">
-          <TasksTable forcedDataFilters={{ version_id: version_id }} />
-        </div>
+      <div className="text-2xl font-bold tracking-tight">
+        Messages of version &apos;{version_id}&apos;
       </div>
-    </>
+      <TasksTable forcedDataFilters={{ version_id: version_id }} />
+    </div>
   );
 }

--- a/platform/components/abtesting/abtesting-columns.tsx
+++ b/platform/components/abtesting/abtesting-columns.tsx
@@ -10,9 +10,25 @@ import { ColumnDef } from "@tanstack/react-table";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 
+import { InteractiveDatetime } from "../interactive-datetime";
+
 export function getColumns() {
   // Create the columns for the data table
   const columns: ColumnDef<ABTest>[] = [
+    {
+      header: "Start date",
+      accessorKey: "first_task_ts",
+      cell: ({ row }) => {
+        return <InteractiveDatetime timestamp={row.original.first_task_ts} />;
+      },
+    },
+    {
+      header: "Last update",
+      accessorKey: "last_task_ts",
+      cell: ({ row }) => {
+        return <InteractiveDatetime timestamp={row.original.last_task_ts} />;
+      },
+    },
     // version_id
     {
       header: "Version ID",
@@ -52,7 +68,8 @@ export function getColumns() {
       },
       accessorKey: "score",
       cell: ({ row }) => {
-        return <div>{row.original.score}%</div>;
+        const roundedScore = Number((row.original.score * 100).toFixed(2));
+        return <div>{roundedScore}%</div>;
       },
     },
     {
@@ -116,7 +133,8 @@ export function getColumns() {
         if (!row.original.score_std) {
           return <div>-</div>;
         }
-        return <div>{row.original.score_std}%</div>;
+        const roundedStd = Number((row.original.score_std * 100).toFixed(4));
+        return <div>{roundedStd}%</div>;
       },
     },
     {

--- a/platform/components/abtesting/abtesting-dataviz.tsx
+++ b/platform/components/abtesting/abtesting-dataviz.tsx
@@ -83,9 +83,8 @@ export const ABTestingDataviz = () => {
     let currVersionA = null;
     let currVersionB = null;
 
-    if (!abTests) {
-      return { currVersionA, currVersionB };
-    }
+    if (!abTests) return { currVersionA, currVersionB };
+    if (!abTestJSON) return { currVersionA, currVersionB };
 
     if (abTests.length === 1) {
       currVersionA = abTests[0].version_id;

--- a/platform/components/abtesting/abtesting.tsx
+++ b/platform/components/abtesting/abtesting.tsx
@@ -83,7 +83,7 @@ function ABTesting() {
         <h1 className="text-2xl font-bold">AB Testing</h1>
       )}
       <div className="pb-10">
-        <ABTestingDataviz versionIDs={versionIDs} />
+        <ABTestingDataviz />
         <div className="flex flex-row items-center mb-2 justify-end">
           <TableNavigation table={table} />
         </div>

--- a/platform/components/abtesting/abtesting.tsx
+++ b/platform/components/abtesting/abtesting.tsx
@@ -59,9 +59,6 @@ function ABTesting() {
     },
   );
 
-  // We create a list of all the version IDs
-  const versionIDs = abTests?.map((abtest) => abtest.version_id) ?? [];
-
   const columns = getColumns();
 
   const table = useReactTable({

--- a/platform/components/sessions/session.tsx
+++ b/platform/components/sessions/session.tsx
@@ -96,7 +96,7 @@ const SessionStats = ({
 
   return (
     <>
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-end">
         <span className="text-xl font-bold tracking-tight">Session</span>
         <div className="flex flex-row gap-x-2">
           {showGoToSession && (

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -178,7 +178,8 @@ export interface ABTest {
   score: number;
   score_std?: number;
   nb_tasks: number;
-  first_task_timestamp: number;
+  first_task_ts: number;
+  last_task_ts: number;
   confidence_interval?: number[];
 }
 


### PR DESCRIPTION
## Summary

### Situation before

No Session metadata about last updated time

### What's here now

- Session.last_message_ts carries the latest Task.created_at
- Endpoint to recompute it on past data
- Fix sorting issue in AB tests

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
