### PR TITLE
feat: Select events in AB-test

### DIFF
--- a/backend/app/api/platform/endpoints/explore.py
+++ b/backend/app/api/platform/endpoints/explore.py
@@ -793,6 +793,7 @@ async def get_ab_tests_comparison(
         project_id=project_id,
         versionA=versions.versionA,
         versionB=versions.versionB,
+        selected_events_ids=versions.selected_events_ids,
     )
     return output
 

--- a/backend/app/api/platform/models/explore.py
+++ b/backend/app/api/platform/models/explore.py
@@ -19,6 +19,7 @@ class EventsMetricsFilter(BaseModel):
 class ABTestVersions(BaseModel):
     versionA: Optional[str]
     versionB: Optional[str]
+    selected_events_ids: Optional[List[str]]
 
 
 class ClusteringEmbeddingCloud(BaseModel):

--- a/platform/components/abtesting/abtesting-dataviz.tsx
+++ b/platform/components/abtesting/abtesting-dataviz.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
@@ -24,7 +25,6 @@ import { authFetcher } from "@/lib/fetcher";
 import { ABTest, Project } from "@/models/models";
 import { navigationStateStore } from "@/store/store";
 import { useUser } from "@propelauth/nextjs/client";
-import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu";
 import {
   Check,
   ChevronDown,
@@ -202,6 +202,66 @@ export const ABTestingDataviz = () => {
           <div className="flex  space-x-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="px-2">
+                  <EllipsisVertical className="size-6" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="overflow-y-auto max-h-[40rem]"
+              >
+                <DropdownMenuLabel className="flex flex-row items-center ">
+                  Displayed analytics
+                </DropdownMenuLabel>
+                {events && Object.keys(events).length > 0 ? (
+                  <>
+                    <Separator />
+                    <DropdownMenuItem
+                      className="flex items-center gap-x-2"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        toggleAllEvents(!allEventsSelected);
+                      }}
+                    >
+                      <Checkbox id="select-all" checked={allEventsSelected} />
+                      <span>Select All</span>
+                    </DropdownMenuItem>
+                    <Separator />
+                    {Object.entries(events).map(([, event]) => {
+                      if (!event.id) return null;
+                      return (
+                        <DropdownMenuItem
+                          key={event.id}
+                          className="flex items-center gap-x-2"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            if (event.id) {
+                              toggleEventSelection(event.id);
+                            }
+                          }}
+                        >
+                          <Checkbox
+                            id={event.id}
+                            checked={
+                              selectedEventsIds !== null
+                                ? selectedEventsIds.includes(event.id)
+                                : true
+                            }
+                          />
+                          <span>{event.event_name}</span>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </>
+                ) : (
+                  <DropdownMenuItem disabled>
+                    <p>No events found</p>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button variant="outline">
                   <div className="flex flex-row items-center justify-between min-w-[10rem]">
                     <span className="font-semibold mr-1">Reference A: </span>
@@ -273,78 +333,6 @@ export const ABTestingDataviz = () => {
               </DropdownMenuContent>
             </DropdownMenu>
             <CreateNewABTestButton />
-          </div>
-          <div className="flex justify-end w-full">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost">
-                  <div className="flex flex-row items-center justify-between">
-                    <EllipsisVertical />
-                  </div>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="overflow-y-auto max-h-[40rem]">
-                <div className="space-y-2 mr-2 ml-2">
-                  <DropdownMenuLabel className="flex flex-row items-center mt-1 mb-1 ml-6 font-semibold">
-                    Displayed analytics
-                  </DropdownMenuLabel>
-                  {events && Object.keys(events).length > 0 ? (
-                    <>
-                      <Separator className="my-4" />
-                      <div className="flex items-center space-x-2 mb-2">
-                        <Checkbox
-                          id="select-all"
-                          checked={allEventsSelected}
-                          onCheckedChange={(checked) =>
-                            toggleAllEvents(checked as boolean)
-                          }
-                        />
-                        <label
-                          htmlFor="select-all"
-                          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                        >
-                          Select All
-                        </label>
-                      </div>
-                      <Separator className="my-4" />
-                      {Object.entries(events).map(([, event]) => {
-                        if (!event.id) return null;
-                        return (
-                          <div
-                            key={event.id}
-                            className="flex items-center space-x-2"
-                          >
-                            <Checkbox
-                              id={event.id}
-                              checked={
-                                selectedEventsIds !== null
-                                  ? selectedEventsIds.includes(event.id)
-                                  : true
-                              }
-                              onCheckedChange={() => {
-                                if (event.id) {
-                                  toggleEventSelection(event.id);
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor={event.id}
-                              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                            >
-                              {event.event_name}
-                            </label>
-                          </div>
-                        );
-                      })}
-                    </>
-                  ) : (
-                    <DropdownMenuItem disabled>
-                      <p>No events found</p>
-                    </DropdownMenuItem>
-                  )}
-                </div>
-              </DropdownMenuContent>
-            </DropdownMenu>
           </div>
         </div>
         <div className="flex flex-col items-center my-2">

--- a/platform/components/abtesting/abtesting-dataviz.tsx
+++ b/platform/components/abtesting/abtesting-dataviz.tsx
@@ -32,7 +32,8 @@ import { ABTest, Project } from "@/models/models";
 import { navigationStateStore } from "@/store/store";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useUser } from "@propelauth/nextjs/client";
-import { Check, ChevronDown, ChevronRight } from "lucide-react";
+import { DropdownMenuLabel } from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronDown, ChevronRight, GripVertical } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useCallback } from "react";
@@ -184,137 +185,145 @@ export const ABTestingDataviz = () => {
     <>
       <AlertDialog open={open}>
         <SendDataAlertDialog setOpen={setOpen} key="ab_testing" />
-        <div className="flex z-0 space-x-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline">
-                <div className="flex flex-row items-center justify-between min-w-[10rem]">
-                  <span className="font-semibold mr-1">Reference A: </span>
-                  {versionIDA} <ChevronDown className="h-4 w-4 ml-2" />
-                </div>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="overflow-y-auto max-h-[40rem] ">
-              {abTests?.map((abTest) => (
-                <DropdownMenuItem
-                  key={`${abTest.version_id}_A`}
-                  onClick={() => setVersionIDA(abTest.version_id)}
-                  asChild
-                >
-                  <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
-                    <div className="flex flex-row gap-x-2 items-center">
-                      {abTest.version_id === versionIDA && (
-                        <Check className="h-4 w-4 mr-2 text-green-500" />
-                      )}
-                      {abTest.version_id}
-                    </div>
-                    <InteractiveDatetime timestamp={abTest.first_task_ts} />
+        <div className="flex flex-row items-center z-0 space-x-2">
+          <div className="flex  space-x-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">
+                  <div className="flex flex-row items-center justify-between min-w-[10rem]">
+                    <span className="font-semibold mr-1">Reference A: </span>
+                    {versionIDA} <ChevronDown className="h-4 w-4 ml-2" />
                   </div>
-                </DropdownMenuItem>
-              ))}
-              {abTests?.length === 0 && (
-                <DropdownMenuItem disabled className="min-w-[10rem]">
-                  <p>
-                    No <code>version_id</code> found
-                  </p>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline">
-                <div className="flex flex-row items-center justify-between min-w-[10rem]">
-                  <span className="font-semibold mr-1">Candidate B:</span>
-                  {versionIDB} <ChevronDown className="h-4 w-4 ml-2" />
-                </div>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="overflow-y-auto max-h-[40rem]">
-              {abTests?.map((abTest) => (
-                <DropdownMenuItem
-                  key={`${abTest.version_id}_B`}
-                  onClick={() => setVersionIDB(abTest.version_id)}
-                  asChild
-                >
-                  <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
-                    <div className="flex flex-row gap-x-2 items-center">
-                      {abTest.version_id === versionIDB && (
-                        <Check className="h-4 w-4 mr-2 text-green-500" />
-                      )}
-                      {abTest.version_id}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="overflow-y-auto max-h-[40rem] ">
+                {abTests?.map((abTest) => (
+                  <DropdownMenuItem
+                    key={`${abTest.version_id}_A`}
+                    onClick={() => setVersionIDA(abTest.version_id)}
+                    asChild
+                  >
+                    <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
+                      <div className="flex flex-row gap-x-2 items-center">
+                        {abTest.version_id === versionIDA && (
+                          <Check className="h-4 w-4 mr-2 text-green-500" />
+                        )}
+                        {abTest.version_id}
+                      </div>
+                      <InteractiveDatetime timestamp={abTest.first_task_ts} />
                     </div>
-                    <InteractiveDatetime timestamp={abTest.first_task_ts} />
+                  </DropdownMenuItem>
+                ))}
+                {abTests?.length === 0 && (
+                  <DropdownMenuItem disabled className="min-w-[10rem]">
+                    <p>
+                      No <code>version_id</code> found
+                    </p>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">
+                  <div className="flex flex-row items-center justify-between min-w-[10rem]">
+                    <span className="font-semibold mr-1">Candidate B:</span>
+                    {versionIDB} <ChevronDown className="h-4 w-4 ml-2" />
                   </div>
-                </DropdownMenuItem>
-              ))}
-              {abTests?.length === 0 && (
-                <DropdownMenuItem disabled>
-                  <p>
-                    No <code>version_id</code> found
-                  </p>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <CreateNewABTestButton />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline">
-                <div className="flex flex-row items-center justify-between">
-                  <span className="font-semibold mr-1">Select events</span>{" "}
-                  <ChevronDown className="h-4 w-4 ml-2" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="overflow-y-auto max-h-[40rem]">
+                {abTests?.map((abTest) => (
+                  <DropdownMenuItem
+                    key={`${abTest.version_id}_B`}
+                    onClick={() => setVersionIDB(abTest.version_id)}
+                    asChild
+                  >
+                    <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
+                      <div className="flex flex-row gap-x-2 items-center">
+                        {abTest.version_id === versionIDB && (
+                          <Check className="h-4 w-4 mr-2 text-green-500" />
+                        )}
+                        {abTest.version_id}
+                      </div>
+                      <InteractiveDatetime timestamp={abTest.first_task_ts} />
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+                {abTests?.length === 0 && (
+                  <DropdownMenuItem disabled>
+                    <p>
+                      No <code>version_id</code> found
+                    </p>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <CreateNewABTestButton />
+          </div>
+          <div className="flex justify-end w-full">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost">
+                  <div className="flex flex-row items-center justify-between">
+                    <GripVertical />
+                  </div>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="overflow-y-auto max-h-[40rem]">
+                <div className="space-y-2 mr-2 ml-2">
+                  <DropdownMenuLabel className=" flex flex-row items-center mt-1 mb-3 ml-6 font-semibold">
+                    Displayed analytics
+                  </DropdownMenuLabel>
+                  {events && Object.keys(events).length > 0 ? (
+                    <Form {...form}>
+                      <form className="space-y-8">
+                        <FormField
+                          control={form.control}
+                          name="selectedEventsIds"
+                          render={({ field }) => (
+                            <FormItem>
+                              {Object.entries(events).map(([, event]) => {
+                                if (!event.id) return null; // Skip if id is undefined
+                                return (
+                                  <FormItem
+                                    key={event.id}
+                                    className="flex flex-row items-start space-x-3 space-y-0"
+                                  >
+                                    <FormControl>
+                                      <Checkbox
+                                        checked={field.value.includes(event.id)}
+                                        onCheckedChange={(checked) => {
+                                          const updatedValue = checked
+                                            ? [...field.value, event.id]
+                                            : field.value.filter(
+                                                (value) => value !== event.id,
+                                              );
+                                          field.onChange(updatedValue);
+                                        }}
+                                      />
+                                    </FormControl>
+                                    <FormLabel className="font-normal">
+                                      {event.event_name}
+                                    </FormLabel>
+                                  </FormItem>
+                                );
+                              })}
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      </form>
+                    </Form>
+                  ) : (
+                    <DropdownMenuItem disabled>
+                      <p>No events found</p>
+                    </DropdownMenuItem>
+                  )}
                 </div>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent className="overflow-y-auto max-h-[40rem]">
-              {events && Object.keys(events).length > 0 ? (
-                <Form {...form}>
-                  <form className="space-y-8">
-                    <FormField
-                      control={form.control}
-                      name="selectedEventsIds"
-                      render={({ field }) => (
-                        <FormItem>
-                          {Object.entries(events).map(([, event]) => {
-                            if (!event.id) return null; // Skip if id is undefined
-                            return (
-                              <FormItem
-                                key={event.id}
-                                className="flex flex-row items-start space-x-3 space-y-0"
-                              >
-                                <FormControl>
-                                  <Checkbox
-                                    checked={field.value.includes(event.id)}
-                                    onCheckedChange={(checked) => {
-                                      const updatedValue = checked
-                                        ? [...field.value, event.id]
-                                        : field.value.filter(
-                                            (value) => value !== event.id,
-                                          );
-                                      field.onChange(updatedValue);
-                                    }}
-                                  />
-                                </FormControl>
-                                <FormLabel className="font-normal">
-                                  {event.event_name}
-                                </FormLabel>
-                              </FormItem>
-                            );
-                          })}
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </form>
-                </Form>
-              ) : (
-                <DropdownMenuItem disabled>
-                  <p>No events found</p>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
         <div className="flex flex-col items-center my-2">
           {graphData === undefined && (

--- a/platform/components/abtesting/create-new-ab-test-button.tsx
+++ b/platform/components/abtesting/create-new-ab-test-button.tsx
@@ -66,7 +66,7 @@ const CreateNewABTestButton = () => {
   return (
     <>
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-        <div className="flex">
+        <div className="flex min-w-[10rem]">
           <PopoverTrigger asChild>
             <Button>
               <PlusIcon className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary

You can select the events you want in AB-test.

### What's here now

- Zod form with checkbox in a dropdownMenu
- Add a parameter in the endpoint /ab-tests/compare-versions to filter on the selected events

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
