### PR TITLE
feat: create copy component

### DIFF
--- a/platform/app/org/settings/account/page.tsx
+++ b/platform/app/org/settings/account/page.tsx
@@ -1,20 +1,15 @@
 "use client";
 
+import { CopyButton } from "@/components/copy-button";
 import { SelectOrgButton } from "@/components/settings/select-org-dropdown";
 import { CenteredSpinner } from "@/components/small-spinner";
 import { Button } from "@/components/ui/button";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import { authFetcher } from "@/lib/fetcher";
 import { OrgMetadata } from "@/models/models";
 import { navigationStateStore } from "@/store/store";
 import { useRedirectFunctions, useUser } from "@propelauth/nextjs/client";
-import { CircleUser, CopyIcon, ExternalLink, UserPlus } from "lucide-react";
+import { CircleUser, ExternalLink, UserPlus } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
 import useSWR from "swr";
 
 export default function Page() {
@@ -22,7 +17,6 @@ export default function Page() {
 
   const { redirectToAccountPage, redirectToOrgPage } = useRedirectFunctions();
   const { accessToken, loading, user } = useUser();
-  const [copied, setCopied] = useState(false);
 
   const { data: selectedOrgMetadata }: { data: OrgMetadata } = useSWR(
     selectedOrgId
@@ -35,14 +29,6 @@ export default function Page() {
   );
 
   const plan = selectedOrgMetadata?.plan ?? "hobby";
-
-  const handleCopy = () => {
-    if (selectedOrgId === null || selectedOrgId === undefined) {
-      return;
-    }
-    navigator.clipboard.writeText(selectedOrgId);
-    setCopied(true);
-  };
 
   if (loading) {
     return <CenteredSpinner />;
@@ -81,24 +67,7 @@ export default function Page() {
               Organization id:{" "}
               <code className="bg-secondary p-1.5">{selectedOrgId}</code>
             </p>
-            <HoverCard openDelay={80} closeDelay={30}>
-              <HoverCardTrigger>
-                <Button
-                  variant="outline"
-                  className="ml-2"
-                  size="icon"
-                  onClick={handleCopy}
-                >
-                  <CopyIcon className="w-3 h-3" />
-                </Button>
-              </HoverCardTrigger>
-              <HoverCardContent
-                side="bottom"
-                className="text-sm text-center ml-2"
-              >
-                {copied ? "Copied!" : "Copy"}
-              </HoverCardContent>
-            </HoverCard>
+            <CopyButton text={selectedOrgId ?? ""} className="ml-2" />
           </div>
         </div>
         <div className="space-y-2 pb-4">

--- a/platform/app/org/settings/project/page.tsx
+++ b/platform/app/org/settings/project/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "@/components/copy-button";
 import { InteractiveDatetime } from "@/components/interactive-datetime";
 import CreateProjectDialog from "@/components/projects/create-project-form";
 import AlertDialogDeleteProject from "@/components/projects/delete-project-popup";
@@ -10,23 +11,17 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
 import { authFetcher } from "@/lib/fetcher";
 import { Project } from "@/models/models";
 import { navigationStateStore } from "@/store/store";
 import { useUser } from "@propelauth/nextjs/client";
-import { BriefcaseBusiness, CopyIcon, Pencil } from "lucide-react";
+import { BriefcaseBusiness, Pencil } from "lucide-react";
 import { useState } from "react";
 import useSWR from "swr";
 
 export default function Page() {
   const { accessToken } = useUser();
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const project_id = navigationStateStore((state) => state.project_id);
   const { data: selectedProject }: { data: Project } = useSWR(
@@ -36,14 +31,6 @@ export default function Page() {
       keepPreviousData: true,
     },
   );
-
-  const handleCopy = () => {
-    if (project_id === null || project_id === undefined) {
-      return;
-    }
-    navigator.clipboard.writeText(project_id);
-    setCopied(true);
-  };
 
   if (project_id === null || project_id === undefined) {
     return <>No project selected</>;
@@ -69,26 +56,9 @@ export default function Page() {
             <code className="bg-secondary p-1.5">{project_id}</code>
           </div>
 
-          <HoverCard openDelay={0} closeDelay={0}>
-            <HoverCardTrigger>
-              <Button
-                variant="outline"
-                className="ml-2"
-                size="icon"
-                onClick={handleCopy}
-              >
-                <CopyIcon className="w-3 h-3" />
-              </Button>
-            </HoverCardTrigger>
-            <HoverCardContent
-              side="bottom"
-              className="text-sm text-center ml-2"
-            >
-              {copied ? "Copied!" : "Copy"}
-            </HoverCardContent>
-          </HoverCard>
+          <CopyButton text={project_id} className="ml-2" />
         </div>
-        <div className="flex flex-row gap-x-4">
+        <div className="flex flex-row gap-x-4 ml-2">
           Creation date:{" "}
           <div>
             <InteractiveDatetime timestamp={selectedProject.created_at} />

--- a/platform/components/callouts/import-data.tsx
+++ b/platform/components/callouts/import-data.tsx
@@ -42,7 +42,6 @@ import { useUser } from "@propelauth/nextjs/client";
 import {
   BarChartBig,
   CloudUpload,
-  CopyIcon,
   Lock,
   Mail,
   MonitorPlay,
@@ -60,6 +59,8 @@ import { FileUploader } from "react-drag-drop-files";
 import { useForm } from "react-hook-form";
 import useSWR from "swr";
 import { z } from "zod";
+
+import { CopyButton } from "../copy-button";
 
 const fileTypes = ["csv", "xlsx", "jsonl", "parquet"];
 
@@ -129,16 +130,7 @@ const APIKeyAndProjectId = () => {
       <div className="flex items-center">
         <span className="w-32">Project id:</span>
         <Input value={project_id}></Input>
-        <Button
-          variant="outline"
-          className="ml-2 p-3"
-          size="icon"
-          onClick={() => {
-            navigator.clipboard.writeText(project_id);
-          }}
-        >
-          <CopyIcon size="14" />
-        </Button>
+        <CopyButton text={project_id} className="ml-2" />
       </div>
     </div>
   );

--- a/platform/components/copy-button.tsx
+++ b/platform/components/copy-button.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+export interface useCopyToClipboardProps {
+  timeout?: number;
+}
+
+export function useCopyToClipboard({
+  timeout = 2000,
+}: useCopyToClipboardProps) {
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+
+  const copyToClipboard = (value: string) => {
+    if (typeof window === "undefined" || !navigator.clipboard?.writeText) {
+      return;
+    }
+
+    if (!value) {
+      return;
+    }
+
+    navigator.clipboard.writeText(value).then(() => {
+      setIsCopied(true);
+
+      setTimeout(() => {
+        setIsCopied(false);
+      }, timeout);
+    });
+  };
+
+  return { isCopied, copyToClipboard };
+}
+
+export type CopyButtonProps = {
+  text: string;
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link"
+    | null
+    | undefined;
+  size?: "default" | "sm" | "lg" | "icon" | null | undefined;
+  className?: string;
+};
+
+export function CopyButton({
+  text,
+  variant,
+  size,
+  className,
+}: CopyButtonProps) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 });
+
+  const onCopy = () => {
+    if (isCopied) return;
+    copyToClipboard(text);
+  };
+
+  return (
+    <HoverCard openDelay={80} closeDelay={30}>
+      <HoverCardTrigger>
+        <Button
+          variant={variant ? variant : "outline"}
+          size={size ? size : "icon"}
+          className={cn(className, "text-xs size-4")}
+          onClick={onCopy}
+        >
+          {isCopied ? (
+            <Check className="w-3 h-3" />
+          ) : (
+            <Copy className="w-3 h-3" />
+          )}
+        </Button>
+      </HoverCardTrigger>
+      <HoverCardContent side="bottom" className="text-sm text-center ml-2">
+        {isCopied ? "Copied!" : "Copy"}
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/platform/components/sessions/session.tsx
+++ b/platform/components/sessions/session.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "@/components/copy-button";
 import SuggestEvent from "@/components/events/suggest-event";
 import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
@@ -25,7 +26,7 @@ import {
 import { authFetcher } from "@/lib/fetcher";
 import { Event, SessionWithEvents, TaskWithEvents } from "@/models/models";
 import { useUser } from "@propelauth/nextjs/client";
-import { ChevronDown, ChevronRight, CopyIcon } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
@@ -138,16 +139,7 @@ const SessionStats = ({
       <Card className="flex flex-col space-y-1 p-2">
         <div className="flex flex-row items-center">
           <code className="bg-secondary p-1.5 text-xs">{session_id}</code>
-          <Button
-            variant="outline"
-            className="m-1.5"
-            size="icon"
-            onClick={() => {
-              navigator.clipboard.writeText(session_id);
-            }}
-          >
-            <CopyIcon className="w-3 h-3" />
-          </Button>
+          <CopyButton text="session_id" className="ml-2" />
         </div>
         <div className="text-xs w-48">
           Created at:

--- a/platform/components/tasks/task.tsx
+++ b/platform/components/tasks/task.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "@/components/copy-button";
 import { InteractiveDatetime } from "@/components/interactive-datetime";
 import { CenteredSpinner } from "@/components/small-spinner";
 import TaskBox from "@/components/task-box";
@@ -8,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { authFetcher } from "@/lib/fetcher";
 import { Task, TaskWithEvents } from "@/models/models";
 import { useUser } from "@propelauth/nextjs/client";
-import { ChevronRight, CopyIcon } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import React, { useState } from "react";
 import useSWR, { KeyedMutator } from "swr";
@@ -80,16 +81,7 @@ const TaskOverview: React.FC<TaskProps> = ({
       <Card className="flex flex-col sapce-y-1 p-2">
         <div className="flex flex-row items-center">
           <code className="bg-secondary p-1.5 text-xs">{task_id}</code>
-          <Button
-            variant="outline"
-            className="m-1.5"
-            size="icon"
-            onClick={() => {
-              navigator.clipboard.writeText(task_id);
-            }}
-          >
-            <CopyIcon className="w-3 h-3" />
-          </Button>
+          <CopyButton text={task_id} className="ml-2" />
         </div>
         <div className="flex flex-row space-x-16">
           <div className="text-xs max-w-48">

--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "@/components/copy-button";
 import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   EventBadge,
@@ -67,27 +68,7 @@ export function useColumns() {
       },
       accessorKey: "user_id",
       cell: ({ row }) => {
-        return (
-          <HoverCard openDelay={0} closeDelay={0}>
-            <HoverCardTrigger asChild>
-              <div
-                className="h-10 flex items-center hover:text-green-500"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  navigator.clipboard.writeText(row.original.user_id);
-                }}
-              >
-                {row.original.user_id}
-              </div>
-            </HoverCardTrigger>
-            <HoverCardContent
-              align="start"
-              className="text-xs text-muted-foreground"
-            >
-              Copy
-            </HoverCardContent>
-          </HoverCard>
-        );
+        return <CopyButton text={row.original.user_id} />;
       },
       // enableHiding: true,
     },


### PR DESCRIPTION
## Summary

Created and upgraded the copy buttons on the platform

### Situation before

Multiple copy buttons, each slightly different and with no feedback on click 

### What's here now

Copy Button in /components

## Check list

- [ x ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
