### PR TITLE
style: adds back user ids 

### DIFF
--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -1,4 +1,3 @@
-import { CopyButton } from "@/components/copy-button";
 import { InteractiveDatetime } from "@/components/interactive-datetime";
 import {
   EventBadge,
@@ -37,7 +36,7 @@ function GenericHeader({
       <Button
         variant="ghost"
         size="icon"
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        onClick={() => column.toggleSorting(column.getIsSorted() === "desc")}
       >
         {column.getIsSorted() === false && <ArrowUpDown className="size-4" />}
         {column.getIsSorted() === "asc" && <ArrowUp className="size-4" />}
@@ -68,7 +67,27 @@ export function useColumns() {
       },
       accessorKey: "user_id",
       cell: ({ row }) => {
-        return <CopyButton text={row.original.user_id} />;
+        return (
+          <HoverCard openDelay={0} closeDelay={0}>
+            <HoverCardTrigger asChild>
+              <div
+                className="h-10 flex items-center hover:text-green-500"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  navigator.clipboard.writeText(row.original.user_id);
+                }}
+              >
+                {row.original.user_id}
+              </div>
+            </HoverCardTrigger>
+            <HoverCardContent
+              align="start"
+              className="text-xs text-muted-foreground"
+            >
+              Copy
+            </HoverCardContent>
+          </HoverCard>
+        );
       },
       // enableHiding: true,
     },


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
