### PR TITLE
Adds scorer_id to dashboard tiles

### DIFF
--- a/phospho-python/phospho/models.py
+++ b/phospho-python/phospho/models.py
@@ -260,6 +260,7 @@ class DashboardTile(BaseModel):
     metric: str
     breakdown_by: str
     metadata_metric: Optional[str] = None
+    scorer_id: Optional[str] = None
     # Position
     x: Optional[int] = None
     y: Optional[int] = None

--- a/platform/app/org/dataviz/studio/page.tsx
+++ b/platform/app/org/dataviz/studio/page.tsx
@@ -468,6 +468,7 @@ const MetadataForm: React.FC = () => {
                 metric: selectedMetric,
                 metadata_metric: metadata_metric,
                 breakdown_by: breakdown_by,
+                scorer_id: selectedScorerId,
               } as DashboardTile;
               selectedProject.settings.dashboard_tiles.push(newTile);
 

--- a/platform/components/dashboard/dashboard.tsx
+++ b/platform/components/dashboard/dashboard.tsx
@@ -391,6 +391,7 @@ const Dashboard: React.FC = () => {
                 metric={tile.metric}
                 metadata_metric={tile.metadata_metric}
                 breakdown_by={tile.breakdown_by}
+                scorer_id={tile.scorer_id ?? null}
               />
             </DashboardTileCard>
           ))}

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -196,6 +196,7 @@ export interface DashboardTile {
   metric: string;
   breakdown_by: string;
   metadata_metric?: string;
+  scorer_id?: string;
   x?: number;
   y?: number;
   w: number;


### PR DESCRIPTION
## Summary

Support for scoring_id in dashboard tiles

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
