### PR TITLE
feat: route to get users table in API v3

### DIFF
--- a/backend/app/api/v3/endpoints/export.py
+++ b/backend/app/api/v3/endpoints/export.py
@@ -11,7 +11,15 @@ from app.security import (
 from app.services.mongo.dataviz import breakdown_by_sum_of_metadata_field
 
 from phospho.models import ProjectDataFilters
-from app.api.v3.models.analytics import AnalyticsQuery, AnalyticsResponse
+from app.api.v3.models.analytics import (
+    AnalyticsQuery,
+    AnalyticsResponse,
+    Users,
+    QueryUserMetadataRequest,
+    Sorting,
+)
+from app.utils import cast_datetime_or_timestamp_to_timestamp
+from app.services.mongo.users import fetch_users_metadata
 
 router = APIRouter(tags=["Export"])
 
@@ -51,3 +59,48 @@ async def post_metadata_pivot(
     )
 
     return AnalyticsResponse(pivot_table=pivot_table)
+
+
+@router.post(
+    "/export/projects/{project_id}/users",
+    response_model=Users,
+    description="Get all the metadata about the end-users of a project",
+)
+async def get_users(
+    project_id: str,
+    query: QueryUserMetadataRequest,
+    org: dict = Depends(authenticate_org_key),
+) -> Users:
+    """
+    Get metadata about the end-users of a project
+    """
+    await verify_propelauth_org_owns_project_id(org, project_id)
+
+    filters = query.filters
+    if isinstance(filters.created_at_start, datetime.datetime):
+        filters.created_at_start = cast_datetime_or_timestamp_to_timestamp(
+            filters.created_at_start
+        )
+    if isinstance(filters.created_at_end, datetime.datetime):
+        filters.created_at_end = cast_datetime_or_timestamp_to_timestamp(
+            filters.created_at_end
+        )
+
+    if query.sorting is None:
+        query.sorting = [
+            Sorting(id="last_message_ts", desc=True),
+            Sorting(id="user_id", desc=True),
+        ]
+    else:
+        # Always resort by user_id to ensure the same order
+        # when multiple users have the same last_timestamp_ts or values
+        query.sorting.append(Sorting(id="user_id", desc=True))
+
+    users = await fetch_users_metadata(
+        project_id=project_id,
+        filters=filters,
+        sorting=query.sorting,
+        pagination=query.pagination,
+        user_id_search=query.user_id_search,
+    )
+    return Users(users=users)

--- a/backend/app/api/v3/models/analytics.py
+++ b/backend/app/api/v3/models/analytics.py
@@ -2,6 +2,8 @@ from app.api.platform.models.metadata import (
     MetadataPivotResponse,
     MetadataPivotQuery,
 )
+from app.api.platform.models import Users, QueryUserMetadataRequest
+from app.api.platform.models.explore import Sorting
 
 
 class AnalyticsQuery(MetadataPivotQuery):


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [x ] typing, linting, docstrings (cicd will fail)
- [x ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ x] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ x] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
