### PR TITLE
feat: route to get users table in API v3

### DIFF
--- a/platform/components/dataviz.tsx
+++ b/platform/components/dataviz.tsx
@@ -203,8 +203,9 @@ const DatavizGraph = ({
 
   // Sort the pivot table according to the sorting
   if (pivotData) {
-    if (sorting.id === "breakdown_by") {
+    if (sorting !== undefined && sorting.id === "breakdown_by") {
       pivotData.sort((a, b) => {
+        if (sorting === undefined) return -1;
         if (sorting.desc) {
           return a.breakdown_by > b.breakdown_by ? -1 : 1;
         } else {
@@ -212,8 +213,9 @@ const DatavizGraph = ({
         }
       });
     }
-    if (sorting.id === "metric") {
+    if (sorting !== undefined && sorting.id === "metric") {
       pivotData.sort((a, b) => {
+        if (sorting === undefined) return -1;
         if (a?.metric === null) return -1;
         if (b?.metric === null) return -1;
         if (sorting.desc) {

--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -127,9 +127,7 @@ export function useColumns() {
     {
       accessorKey: "total_tokens",
       header: ({ column }) => {
-        return (
-          <GenericHeader column={column} columnName="Total tokens earned" />
-        );
+        return <GenericHeader column={column} columnName="Total tokens" />;
       },
       cell: (row) => {
         const output = row.getValue();


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [x] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [x] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [x] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
