### PR TITLE
style: Keep side tabs open and allow to switch between rows

### DIFF
--- a/platform/components/sessions/session.tsx
+++ b/platform/components/sessions/session.tsx
@@ -139,7 +139,7 @@ const SessionStats = ({
       <Card className="flex flex-col space-y-1 p-2">
         <div className="flex flex-row items-center">
           <code className="bg-secondary p-1.5 text-xs">{session_id}</code>
-          <CopyButton text="session_id" className="ml-2" />
+          <CopyButton text={session_id} className="ml-2" />
         </div>
         <div className="flex flex-row space-x-16">
           <div className="text-xs max-w-48">

--- a/platform/components/sessions/sessions-table.tsx
+++ b/platform/components/sessions/sessions-table.tsx
@@ -67,7 +67,6 @@ function SessionsTable({ forcedDataFilters }: DataTableProps) {
 
   const { accessToken } = useUser();
 
-  const [, setTableIsClickable] = useState<boolean>(true);
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
   const [sheetToOpen, setSheetToOpen] = useState<string | null>(null);
   const [previewSessionId, setPreviewSessionId] = useState<string | null>(null);
@@ -184,7 +183,7 @@ function SessionsTable({ forcedDataFilters }: DataTableProps) {
         </div>
         <TableNavigation table={table} />
       </div>
-      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen} modal={false}>
         {sessionsWithEvents === undefined && <CenteredSpinner />}
         {sessionsWithEvents && (
           <div className="rounded-md border">
@@ -279,17 +278,7 @@ function SessionsTable({ forcedDataFilters }: DataTableProps) {
             </div>
           </Alert>
         )}
-        <SheetContent
-          className="md:w-1/2 overflow-auto"
-          onOpenAutoFocus={(mouseEvent) => {
-            mouseEvent.stopPropagation();
-            setTableIsClickable(false);
-          }}
-          onCloseAutoFocus={(mouseEvent) => {
-            mouseEvent.stopPropagation();
-            setTableIsClickable(true);
-          }}
-        >
+        <SheetContent className="md:w-1/2 overflow-auto" overlay={false}>
           {sheetToOpen === "run" && eventDefinition !== null && (
             <RunEvent setOpen={setSheetOpen} eventToRun={eventDefinition} />
           )}

--- a/platform/components/tasks/tasks-table.tsx
+++ b/platform/components/tasks/tasks-table.tsx
@@ -59,7 +59,6 @@ function TasksTable({ forcedDataFilters }: DataTableProps) {
   );
   const { accessToken } = useUser();
 
-  const [, setTableIsClickable] = useState<boolean>(true);
   const [sheetOpen, setSheetOpen] = useState<boolean>(false);
   const [sheetToOpen, setSheetToOpen] = useState<string | null>(null);
   const [eventDefinition, setEventDefinition] =
@@ -179,18 +178,8 @@ function TasksTable({ forcedDataFilters }: DataTableProps) {
         </div>
         <TableNavigation table={table} />
       </div>
-      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
-        <SheetContent
-          className="md:w-1/2 overflow-auto"
-          onOpenAutoFocus={(mouseEvent) => {
-            mouseEvent.stopPropagation();
-            setTableIsClickable(false);
-          }}
-          onCloseAutoFocus={(mouseEvent) => {
-            mouseEvent.stopPropagation();
-            setTableIsClickable(true);
-          }}
-        >
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen} modal={false}>
+        <SheetContent className="md:w-1/2 overflow-auto" overlay={false}>
           {sheetToOpen === "run" && eventDefinition !== null && (
             <RunEvent setOpen={setSheetOpen} eventToRun={eventDefinition} />
           )}

--- a/platform/components/ui/sheet.tsx
+++ b/platform/components/ui/sheet.tsx
@@ -50,14 +50,16 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  overlay?: boolean;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", overlay = true, className, children, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    {overlay && <SheetOverlay />}
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}

--- a/platform/components/users/users-table.tsx
+++ b/platform/components/users/users-table.tsx
@@ -126,7 +126,7 @@ export function UsersTable({
           }}
         />
       </div>
-      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen} modal={false}>
         {usersMetadata === undefined && <CenteredSpinner />}
         {usersMetadata && (
           <div className="rounded-md border">
@@ -198,7 +198,7 @@ export function UsersTable({
             <TableNavigation table={table} />
           </div>
         )}
-        <SheetContent className="md:w-1/2 overflow-auto">
+        <SheetContent className="md:w-1/2 overflow-auto" overlay={false}>
           <UserPreview user_id={previewUserId} />
         </SheetContent>
       </Sheet>


### PR DESCRIPTION
## Summary

## Before

You had to double click to preview another session, message, user

### What's here now

You can interact with the table below to switch quickly between session, messages, users

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
