### PR TITLE
fix: downgrade extractor

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -104,6 +104,12 @@ or
 docker build --file <./filename> -t <name ie frontend, backend, etc...> .
 ```
 
+## Running temporal locally
+
+```bash
+temporal server start-dev --db-filename your_temporal.db --ui-port 8080
+```
+
 ## Pull Requests
 
 In github, create a Pull Request targeting the `dev` branch.

--- a/extractor/Dockerfile
+++ b/extractor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13
+FROM python:3.11
 
 # Steps are cached with Kaniko in GCP Artifcat registry
 # The cache is kept 72 hours (see cloudbuild.yaml)


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
