### PR TITLE
feat: create retention graph

### DIFF
--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -344,7 +344,7 @@ async def get_nb_users_messages(
 
 async def get_user_retention(
     project_id: str,
-    filters: Optional[ProjectDataFilters] = None,
+    filters: Optional[ProjectDataFilters] = ProjectDataFilters(),
 ) -> Optional[Dict[str, int]]:
     mongo_db = await get_mongo_db()
 

--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -344,9 +344,12 @@ async def get_nb_users_messages(
 
 async def get_user_retention(
     project_id: str,
-    filters: Optional[ProjectDataFilters] = ProjectDataFilters(),
+    filters: Optional[ProjectDataFilters] = None,
 ) -> Optional[Dict[str, int]]:
     mongo_db = await get_mongo_db()
+
+    if filters is None:
+        filters = ProjectDataFilters()
 
     if filters.created_at_end is None:
         # Set created_at_end to the current time

--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -404,7 +404,7 @@ async def get_user_retention(
         # Calculate period number for first and last seen
         {
             "$addFields": {
-                "first_period": {
+                "first_message_period": {
                     "$floor": {
                         "$divide": [
                             {
@@ -414,7 +414,7 @@ async def get_user_retention(
                         ]
                     }
                 },
-                "last_period": {
+                "last_message_period": {
                     "$floor": {
                         "$divide": [
                             {"$subtract": ["$last_seen", "$first_seen"]},
@@ -427,9 +427,9 @@ async def get_user_retention(
         # Group all users by their first period, this gives us the cohorts
         {
             "$group": {
-                "_id": "$first_period",
+                "_id": "$first_message_period",
                 "total_users": {"$sum": 1},
-                "users_by_last_period": {"$push": "$last_period"},
+                "users_by_last_message_period": {"$push": "$last_message_period"},
             }
         },
         # Only consider the first cohort (period 0)
@@ -452,9 +452,14 @@ async def get_user_retention(
                             "count": {
                                 "$size": {
                                     "$filter": {
-                                        "input": "$users_by_last_period",
-                                        "as": "last_period",
-                                        "cond": {"$gte": ["$$last_period", "$$period"]},
+                                        "input": "$users_by_last_message_period",
+                                        "as": "last_message_period",
+                                        "cond": {
+                                            "$gte": [
+                                                "$$last_message_period",
+                                                "$$period",
+                                            ]
+                                        },
                                     }
                                 }
                             },

--- a/platform/components/users/user-dataviz-pies.tsx
+++ b/platform/components/users/user-dataviz-pies.tsx
@@ -1,0 +1,163 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card";
+import { ChartContainer, ChartTooltip } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { Pie, PieChart } from "recharts";
+import { Label, TooltipProps } from "recharts";
+import {
+  NameType,
+  ValueType,
+} from "recharts/types/component/DefaultTooltipContent";
+
+interface DataPoint {
+  category: string;
+  count: number;
+  fill?: string;
+}
+
+interface PieChartSectionProps {
+  selectedMetric: "jobTitles" | "industry";
+  setSelectedMetric: (metric: "jobTitles" | "industry") => void;
+  data: DataPoint[] | null | undefined;
+  totalCount: number;
+}
+
+const CustomTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({
+  active,
+  payload,
+}) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-primary shadow-md p-2 rounded-md">
+        <p className="text-secondary font-semibold">{payload[0].name}</p>
+        <p className="text-secondary">{payload[0].value} messages</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+export const PieChartSection: React.FC<PieChartSectionProps> = ({
+  selectedMetric,
+  setSelectedMetric,
+  data,
+  totalCount,
+}) => {
+  console.log("Data: ", data);
+  const renderPieChartContent = () => {
+    // Loading state
+    if (data === undefined) {
+      return <Skeleton className="w-[100%] h-[10rem]" />;
+    }
+
+    // Empty/null state
+    if (data === null) {
+      return (
+        <div className="flex flex-col text-center items-center h-[10rem] justify-center">
+          <p className="text-muted-foreground mb-2 text-sm">
+            Add a classifier named{" "}
+            <code>
+              {selectedMetric === "jobTitles"
+                ? "User job title"
+                : "User industry"}
+            </code>
+            <br /> to get started
+          </p>
+          <Link href="/org/insights/events">
+            <Button variant="outline" size="sm">
+              Setup analytics
+              <ChevronRight className="ml-2 h-4 w-4" />
+            </Button>
+          </Link>
+        </div>
+      );
+    }
+
+    // Data state
+    return (
+      <ChartContainer config={{}} className="w-full h-[10rem]">
+        <PieChart className="w-full h-[10rem]">
+          <ChartTooltip content={CustomTooltip} />
+          <Pie
+            data={data}
+            dataKey="count"
+            nameKey="category"
+            labelLine={false}
+            innerRadius={60}
+            outerRadius={70}
+          >
+            <Label
+              content={({ viewBox }) => {
+                if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                  return (
+                    <text
+                      x={viewBox.cx}
+                      y={viewBox.cy}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                    >
+                      <tspan
+                        x={viewBox.cx}
+                        y={(viewBox.cy || 0) + 5}
+                        className="fill-foreground text-3xl font-bold"
+                      >
+                        {totalCount.toLocaleString()}
+                      </tspan>
+                      <tspan
+                        x={viewBox.cx}
+                        y={(viewBox.cy || 0) + 25}
+                        className="fill-muted-foreground"
+                      >
+                        {selectedMetric === "jobTitles"
+                          ? "job titles"
+                          : "industries"}
+                      </tspan>
+                    </text>
+                  );
+                }
+              }}
+            />
+          </Pie>
+        </PieChart>
+      </ChartContainer>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex justify-between items-center">
+          <CardDescription>
+            {selectedMetric === "jobTitles"
+              ? "Job Title Distribution"
+              : "Industry Distribution"}
+          </CardDescription>
+          <div className="flex gap-2">
+            <Button
+              variant={selectedMetric === "jobTitles" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedMetric("jobTitles")}
+            >
+              Job Titles
+            </Button>
+            <Button
+              variant={selectedMetric === "industry" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedMetric("industry")}
+            >
+              Industry
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>{renderPieChartContent()}</CardContent>
+    </Card>
+  );
+};

--- a/platform/components/users/users-dataviz.tsx
+++ b/platform/components/users/users-dataviz.tsx
@@ -7,12 +7,8 @@ import {
   CardDescription,
   CardHeader,
 } from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-} from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PieChartSection } from "@/components/users/user-dataviz-pies";
 import { authFetcher } from "@/lib/fetcher";
 import { graphColors } from "@/lib/utils";
 import { ProjectDataFilters } from "@/models/models";
@@ -20,16 +16,16 @@ import { navigationStateStore } from "@/store/store";
 import { useUser } from "@propelauth/nextjs/client";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
-import React, { useMemo } from "react";
-import { Label, Pie, PieChart } from "recharts";
-import { TooltipProps } from "recharts";
+import React, { useMemo, useState } from "react";
 import {
-  NameType,
-  ValueType,
-} from "recharts/types/component/DefaultTooltipContent";
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import useSWR from "swr";
-
-const chartConfig: ChartConfig = {};
 
 interface JobTitles {
   category: string;
@@ -52,6 +48,9 @@ const UsersDataviz = ({
   const { accessToken } = useUser();
   const project_id = navigationStateStore((state) => state.project_id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
+  const [selectedMetric, setSelectedMetric] = useState<
+    "jobTitles" | "industry"
+  >("jobTitles");
 
   const dataFiltersMerged = {
     ...dataFilters,
@@ -99,6 +98,33 @@ const UsersDataviz = ({
         if (!data?.avg_nb_tasks_per_user) return null;
         const roundedOutput = Number(data?.avg_nb_tasks_per_user.toFixed(2));
         return roundedOutput;
+      }),
+    {
+      keepPreviousData: true,
+    },
+  );
+
+  const { data: userRetention }: { data: number[] | null | undefined } = useSWR(
+    project_id
+      ? [
+          `/api/explore/${project_id}/aggregated/users`,
+          accessToken,
+          JSON.stringify(dataFiltersMerged),
+          "retention",
+        ]
+      : null,
+    ([url, accessToken]) =>
+      authFetcher(url, accessToken, "POST", {
+        metrics: ["retention"],
+        filters: dataFiltersMerged,
+      }).then((data) => {
+        if (data === undefined) {
+          return undefined;
+        }
+        if (!data?.retention) {
+          return null;
+        }
+        return data.retention;
       }),
     {
       keepPreviousData: true,
@@ -177,26 +203,16 @@ const UsersDataviz = ({
     return userJobTitles?.reduce((acc) => acc + 1, 0) || 0;
   }, [userJobTitles]);
 
-  const CustomTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({
-    active,
-    payload,
-  }) => {
-    if (active && payload && payload.length) {
-      return (
-        <div className="bg-primary shadow-md p-2 rounded-md">
-          <p className="text-secondary font-semibold">{payload[0].name}</p>
-          <p className="text-secondary">{payload[0].value} messages</p>
-        </div>
-      );
-    }
-    return null;
-  };
+  const formatDate = (weekNum: number) => `Week ${weekNum}`;
 
   return (
     <div>
       <div className="container mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="flex flex-col justify-between space-y-4">
+            {/* First card - User Stats */}
+
+            {/* Top card */}
             <Card className="flex-grow">
               <CardHeader>
                 <CardDescription>Number of unique user_id</CardDescription>
@@ -213,6 +229,8 @@ const UsersDataviz = ({
                 )}
               </CardContent>
             </Card>
+
+            {/* Bottom card */}
             <Card className="flex-grow">
               <CardHeader>
                 <CardDescription>
@@ -233,147 +251,62 @@ const UsersDataviz = ({
               </CardContent>
             </Card>
           </div>
+
+          {/* Second card - Combined Pie Charts */}
+
+          <PieChartSection
+            selectedMetric={selectedMetric}
+            setSelectedMetric={setSelectedMetric}
+            data={selectedMetric === "jobTitles" ? userJobTitles : userIndustry}
+            totalCount={totalJobTitles}
+          />
+
+          {/* Third card - Retention Chart */}
+
           <Card>
             <CardHeader>
-              <CardDescription>User job title distribution</CardDescription>
+              <CardDescription>Weekly User Retention</CardDescription>
             </CardHeader>
             <CardContent>
-              {userJobTitles && (
-                <ChartContainer
-                  config={chartConfig}
-                  className="w-[100%] h-[10rem]"
-                >
-                  <PieChart className="w-[100%] h-[10rem]">
-                    <ChartTooltip content={CustomTooltip} />
-                    <Pie
-                      data={userJobTitles}
-                      dataKey="count"
-                      nameKey="category"
-                      labelLine={false}
-                      innerRadius={60}
-                      outerRadius={70}
-                    >
-                      <Label
-                        content={({ viewBox }) => {
-                          if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                            return (
-                              <text
-                                x={viewBox.cx}
-                                y={viewBox.cy}
-                                textAnchor="middle"
-                                dominantBaseline="middle"
-                              >
-                                <tspan
-                                  x={viewBox.cx}
-                                  y={(viewBox.cy || 0) + 5}
-                                  className="fill-foreground text-3xl font-bold"
-                                >
-                                  {totalJobTitles.toLocaleString()}
-                                </tspan>
-                                <tspan
-                                  x={viewBox.cx}
-                                  y={(viewBox.cy || 0) + 25}
-                                  className="fill-muted-foreground"
-                                >
-                                  job titles
-                                </tspan>
-                              </text>
-                            );
-                          }
-                        }}
-                      />
-                    </Pie>
-                  </PieChart>
-                </ChartContainer>
-              )}
-              {userJobTitles === undefined && (
+              {userRetention === undefined && (
                 <Skeleton className="w-[100%] h-[10rem]" />
               )}
-              {userJobTitles === null && (
-                <div className="flex flex-col text-center items-center h-full">
-                  <p className="text-muted-foreground mb-2 text-sm pt-6">
-                    Add a classifier named <code>User job title</code>
-                    <br /> to get started
-                  </p>
-                  <Link href="/org/insights/events">
-                    <Button variant="outline">
-                      Setup analytics
-                      <ChevronRight className="ml-2" />
+              {userRetention === null && (
+                <div className="flex flex-col text-center items-center h-[10rem] justify-center">
+                  <Link href="https://docs.phospho.ai/analytics/sessions-and-users">
+                    <Button variant="outline" size="sm">
+                      Start tracking retention
+                      <ChevronRight className="ml-2 h-4 w-4" />
                     </Button>
                   </Link>
                 </div>
               )}
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader>
-              <CardDescription>User industry distribution</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {userIndustry && (
-                <ChartContainer
-                  config={chartConfig}
-                  className="w-[100%] h-[10rem]"
-                >
-                  <PieChart className="w-[100%] h-[10rem]">
-                    <ChartTooltip content={CustomTooltip} />
-                    <Pie
-                      data={userIndustry}
-                      dataKey="count"
-                      nameKey="category"
-                      labelLine={false}
-                      innerRadius={60}
-                      outerRadius={70}
-                    >
-                      <Label
-                        content={({ viewBox }) => {
-                          if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                            return (
-                              <text
-                                x={viewBox.cx}
-                                y={viewBox.cy}
-                                textAnchor="middle"
-                                dominantBaseline="middle"
-                              >
-                                <tspan
-                                  x={viewBox.cx}
-                                  y={(viewBox.cy || 0) + 5}
-                                  className="fill-foreground text-3xl font-bold"
-                                >
-                                  {totalJobTitles.toLocaleString()}
-                                </tspan>
-                                <tspan
-                                  x={viewBox.cx}
-                                  y={(viewBox.cy || 0) + 25}
-                                  className="fill-muted-foreground"
-                                >
-                                  industries
-                                </tspan>
-                              </text>
-                            );
-                          }
-                        }}
-                      />
-                    </Pie>
-                  </PieChart>
-                </ChartContainer>
-              )}
-              {userIndustry === undefined && (
-                <Skeleton className="w-[100%] h-[10rem]" />
-              )}
-              {userIndustry === null && (
-                <div className="flex flex-col text-center items-center h-full">
-                  <p className="text-muted-foreground mb-2 text-sm pt-6">
-                    Add a classifier named <code>User industry</code>
-                    <br /> to get started
-                  </p>
-                  <Link href="/org/insights/events">
-                    <Button variant="outline">
-                      Setup analytics
-                      <ChevronRight className="ml-2" />
-                    </Button>
-                  </Link>
-                </div>
+              {userRetention && (
+                <ResponsiveContainer width="100%" height={160}>
+                  <LineChart data={userRetention}>
+                    <XAxis
+                      dataKey="week"
+                      tickFormatter={formatDate}
+                      fontSize={12}
+                    />
+                    <YAxis
+                      tickFormatter={(value) => `${value}%`}
+                      domain={[0, 100]}
+                      fontSize={12}
+                    />
+                    <Tooltip
+                      formatter={(value) => [`${value}%`, "Retention"]}
+                      labelFormatter={formatDate}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="retention"
+                      stroke="#72C464"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
               )}
             </CardContent>
           </Card>

--- a/platform/components/users/users-dataviz.tsx
+++ b/platform/components/users/users-dataviz.tsx
@@ -218,12 +218,12 @@ const UsersDataviz = ({
   const formatPeriod = (value: number) => {
     if (userRetention?.length === undefined) return "";
     if (isDaily) {
-      if (value === userRetention?.length - 1) return "Today";
-      if (value === userRetention?.length - 2) return "Yesterday";
+      if (value === userRetention?.length) return "Today";
+      if (value === userRetention?.length - 1) return "Yesterday";
       return `${userRetention?.length - value} days ago`;
     } else {
-      if (value === userRetention?.length - 1) return "This week";
-      if (value === userRetention?.length - 2) return "Last week";
+      if (value === userRetention?.length) return "This week";
+      if (value === userRetention?.length - 1) return "Last week";
       return `${userRetention?.length - value} weeks ago`;
     }
   };
@@ -308,7 +308,7 @@ const UsersDataviz = ({
                   </Link>
                 </div>
               )}
-              {userRetention && (
+              {userRetention && userRetention.length > 1 && (
                 <ResponsiveContainer width="100%" height={160}>
                   <LineChart data={userRetention}>
                     <XAxis
@@ -334,6 +334,14 @@ const UsersDataviz = ({
                     />
                   </LineChart>
                 </ResponsiveContainer>
+              )}
+              {userRetention && userRetention.length < 2 && (
+                <div className="flex flex-col text-center items-center h-[10rem] justify-center">
+                  <p className="text-lg font-bold">Not enough data</p>
+                  <p className="text-sm text-gray-500">
+                    Need at least 2 data points
+                  </p>
+                </div>
               )}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

This improves the user tab with a retention graph

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
