### PR TITLE
refactor: Update API endpoints in test_onboarding.py

### DIFF
--- a/backend/tests/integration/python/test_onboarding.py
+++ b/backend/tests/integration/python/test_onboarding.py
@@ -47,7 +47,7 @@ def test_onboarding(backend_url, org_id, access_token, api_key):
 
     # # Call the export analytics API
     # response = requests.post(
-    #     f"{backend_url}/api/v3/export/analytics",
+    #     f"{backend_url}/v3/export/analytics",
     #     json={
     #         "pivot_query": {
     #             "project_id": project_id,
@@ -63,7 +63,7 @@ def test_onboarding(backend_url, org_id, access_token, api_key):
 
     # Call the export users API
     response = requests.post(
-        f"{backend_url}/api/v3/export/projects/{project_id}/users",
+        f"{backend_url}/v3/export/projects/{project_id}/users",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == 200, response.reason


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
