### PR TITLE
fix: Log messages workflow

### DIFF
--- a/backend/app/api/v3/endpoints/log.py
+++ b/backend/app/api/v3/endpoints/log.py
@@ -83,6 +83,9 @@ async def store_batch_of_log_events(
 
     log_reply = LogReply(logged_events=logged_events)
 
+    logger.debug(f"Log reply: {log_reply}")
+    logger.debug(f"Logs to process: {logs_to_process}")
+
     # All the tasks to process were deemed as valid and the org had enough credits to process them
     extractor_client = ExtractorClient(
         project_id=log_request.project_id,

--- a/backend/app/api/v3/endpoints/log.py
+++ b/backend/app/api/v3/endpoints/log.py
@@ -83,9 +83,6 @@ async def store_batch_of_log_events(
 
     log_reply = LogReply(logged_events=logged_events)
 
-    logger.debug(f"Log reply: {log_reply}")
-    logger.debug(f"Logs to process: {logs_to_process}")
-
     # All the tasks to process were deemed as valid and the org had enough credits to process them
     extractor_client = ExtractorClient(
         project_id=log_request.project_id,

--- a/backend/app/api/v3/models/log.py
+++ b/backend/app/api/v3/models/log.py
@@ -7,7 +7,7 @@ from app.utils import generate_uuid, generate_timestamp
 class MinimalLogEventForMessages(BaseModel, extra="allow"):
     session_id: str = Field(default_factory=generate_uuid)
     messages: List[RoleContentMessage] = Field(default_factory=list)
-    merge_mode: Literal["resolve", "append", "replace"] = "resolve"
+    merge_mode: Literal["resolve", "append", "replace"] = "replace"
     created_at: int = Field(default_factory=generate_timestamp)
     metadata: Optional[Dict[str, object]] = None
     version_id: Optional[str] = None

--- a/backend/app/api/v3/models/log.py
+++ b/backend/app/api/v3/models/log.py
@@ -1,11 +1,12 @@
 from typing import Dict, List, Literal, Optional, Union
+from app.api.v3.models.run import RoleContentMessage
 from pydantic import BaseModel, Field
 from app.utils import generate_uuid, generate_timestamp
 
 
 class MinimalLogEventForMessages(BaseModel, extra="allow"):
     session_id: str = Field(default_factory=generate_uuid)
-    messages: List[str] = Field(default_factory=list)
+    messages: List[RoleContentMessage] = Field(default_factory=list)
     merge_mode: Literal["resolve", "append", "replace"] = "resolve"
     created_at: int = Field(default_factory=generate_timestamp)
     metadata: Optional[Dict[str, object]] = None

--- a/backend/app/services/mongo/extractor.py
+++ b/backend/app/services/mongo/extractor.py
@@ -145,8 +145,6 @@ class ExtractorClient:
 
         If return_response is False, the function will return None. This is useful for fire-and-forget workflows.
         """
-
-        logger.debug
         response = None
 
         # We check that "org_id" and"project_id" are present in the data

--- a/backend/app/services/mongo/extractor.py
+++ b/backend/app/services/mongo/extractor.py
@@ -146,6 +146,7 @@ class ExtractorClient:
         If return_response is False, the function will return None. This is useful for fire-and-forget workflows.
         """
 
+        logger.debug
         response = None
 
         # We check that "org_id" and"project_id" are present in the data

--- a/backend/notebooks/.gitignore
+++ b/backend/notebooks/.gitignore
@@ -1,1 +1,2 @@
 tests.ipynb
+v3_log_endpoint.ipynb

--- a/extractor/extractor/models/log.py
+++ b/extractor/extractor/models/log.py
@@ -17,7 +17,7 @@ class TaskProcessRequest(BaseModel):
 class MinimalLogEventForMessages(BaseModel, extra="allow"):
     session_id: str
     messages: List[RoleContentMessage]
-    merge_mode: Literal["resolve", "append", "replace"] = "resolve"
+    merge_mode: Literal["resolve", "append", "replace"] = "replace"
     created_at: int = Field(default_factory=generate_timestamp)
     metadata: Optional[Dict[str, object]] = None
     version_id: Optional[str] = None

--- a/extractor/extractor/models/log.py
+++ b/extractor/extractor/models/log.py
@@ -1,4 +1,6 @@
 from typing import Dict, List, Literal, Optional, Union
+
+from extractor.extractor.models.pipelines import RoleContentMessage
 from extractor.utils import generate_timestamp, generate_uuid
 from pydantic import BaseModel, Field
 
@@ -14,7 +16,7 @@ class TaskProcessRequest(BaseModel):
 
 class MinimalLogEventForMessages(BaseModel, extra="allow"):
     session_id: str
-    messages: List[str]
+    messages: List[RoleContentMessage]
     merge_mode: Literal["resolve", "append", "replace"] = "resolve"
     created_at: int = Field(default_factory=generate_timestamp)
     metadata: Optional[Dict[str, object]] = None

--- a/extractor/extractor/models/log.py
+++ b/extractor/extractor/models/log.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Literal, Optional, Union
 
-from extractor.extractor.models.pipelines import RoleContentMessage
+from extractor.models.pipelines import RoleContentMessage
 from extractor.utils import generate_timestamp, generate_uuid
 from pydantic import BaseModel, Field
 

--- a/extractor/extractor/services/log/tasks.py
+++ b/extractor/extractor/services/log/tasks.py
@@ -495,12 +495,13 @@ async def process_logs_for_messages(
         messages = log_event.messages
 
         if messages[0].role == "system":
-            metadata = log_event.metadata + {
+            metadata = {
+                **(log_event.metadata or {}),
                 "system_prompt": messages[0].content,
             }
+
             logs_events_for_tasks = await convert_messages_to_tasks(
                 project_id=project_id,
-                org_id=org_id,
                 session_id=log_event.session_id,
                 messages=messages[1:],
                 merge_mode=log_event.merge_mode,
@@ -515,7 +516,6 @@ async def process_logs_for_messages(
         else:
             logs_events_for_tasks = await convert_messages_to_tasks(
                 project_id=project_id,
-                org_id=org_id,
                 session_id=log_event.session_id,
                 messages=messages,
                 merge_mode=log_event.merge_mode,
@@ -532,12 +532,12 @@ async def process_logs_for_messages(
         messages = log_event.messages
 
         if messages[0].role == "system":
-            metadata = log_event.metadata + {
+            metadata = {
+                **(log_event.metadata or {}),
                 "system_prompt": messages[0].content,
             }
             logs_events_for_tasks = await convert_messages_to_tasks(
                 project_id=project_id,
-                org_id=org_id,
                 session_id=log_event.session_id,
                 messages=messages[1:],
                 merge_mode=log_event.merge_mode,
@@ -552,7 +552,6 @@ async def process_logs_for_messages(
         else:
             logs_events_for_tasks = await convert_messages_to_tasks(
                 project_id=project_id,
-                org_id=org_id,
                 session_id=log_event.session_id,
                 messages=messages,
                 merge_mode=log_event.merge_mode,
@@ -584,7 +583,7 @@ async def convert_messages_to_tasks(
     version_id: Optional[str] = None,
     created_at: Optional[int] = None,
     user_id: Optional[str] = None,
-    flag: Optional[str] = None,
+    flag: Optional[Literal["success", "failure"]] = None,
     test_id: Optional[str] = None,
 ) -> List[LogEventForTasks]:
     """

--- a/extractor/extractor/services/log/tasks.py
+++ b/extractor/extractor/services/log/tasks.py
@@ -553,8 +553,8 @@ async def convert_messages_to_tasks(
         )
     log_events = []
     last_role = None
-    input = ""
-    output = ""
+    input_list: List[str] = []
+    output_list: List[str] = []
     for i, message in enumerate(messages):
         role = message.role
         if role not in ["system", "assistant", "user"]:
@@ -567,8 +567,8 @@ async def convert_messages_to_tasks(
             log_event = LogEventForTasks(
                 project_id=project_id,
                 session_id=session_id,
-                input=input,
-                output=output,
+                input="\n".join(input_list),
+                output="\n".join(output_list),
                 created_at=created_at,
                 user_id=user_id,
                 metadata=metadata,
@@ -577,33 +577,33 @@ async def convert_messages_to_tasks(
                 test_id=test_id,
             )
             log_events.append(log_event)
-            input = ""
-            output = ""
+            input_list = []
+            output_list = []
         # We put the system prompt in the metadata
         if role == "system":
             if metadata is not None:
                 if metadata.get("system_prompt") is not None:
-                    metadata["system_prompt"] += message.content
+                    metadata["system_prompt"] += "\n" + message.content
                 else:
                     metadata["system_prompt"] = message.content
             else:
                 metadata = {"system_prompt": message.content}
         # if the role is assistant, we append the content to the output
         elif role == "assistant":
-            output += message.content
+            output_list.append(message.content)
         # if the role is user, we append the content to the input
         elif role == "user":
-            input += message.content
+            input_list.append(message.content)
 
         if role in ["assistant", "user"]:
             last_role = role
 
-    if input != "" or output != "":
+    if len(input_list) > 0 or len(output_list) > 0:
         log_event = LogEventForTasks(
             project_id=project_id,
             session_id=session_id,
-            input=input,
-            output=output,
+            input="\n".join(input_list),
+            output="\n".join(output_list),
             created_at=created_at,
             user_id=user_id,
             metadata=metadata,

--- a/extractor/extractor/services/log/tasks.py
+++ b/extractor/extractor/services/log/tasks.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Any, Tuple, Optional
+from extractor.extractor.models.log import MinimalLogEventForMessages
 from extractor.services.pipelines import MainPipeline
 from extractor.models import LogEventForTasks
 from phospho.models import Task, Session
@@ -474,3 +475,14 @@ async def process_logs_for_tasks(
         )
 
     return None
+
+
+async def process_logs_for_messages(
+    project_id: str,
+    org_id: str,
+    logs_to_process: List[MinimalLogEventForMessages],
+    extra_logs_to_save: List[MinimalLogEventForMessages],
+) -> None:
+    """
+    Convert LogEventForMessages to LogEventForTasks and process them using process_logs_for_tasks
+    """

--- a/extractor/extractor/services/log/tasks.py
+++ b/extractor/extractor/services/log/tasks.py
@@ -1,5 +1,6 @@
-from typing import List, Dict, Any, Tuple, Optional
-from extractor.extractor.models.log import MinimalLogEventForMessages
+from typing import List, Dict, Any, Literal, Tuple, Optional
+from extractor.models.log import MinimalLogEventForMessages
+from extractor.models.pipelines import RoleContentMessage
 from extractor.services.pipelines import MainPipeline
 from extractor.models import LogEventForTasks
 from phospho.models import Task, Session
@@ -484,5 +485,142 @@ async def process_logs_for_messages(
     extra_logs_to_save: List[MinimalLogEventForMessages],
 ) -> None:
     """
-    Convert LogEventForMessages to LogEventForTasks and process them using process_logs_for_tasks
+    Convert MinimalLogEventForMessages to LogEventForTasks and process them using process_logs_for_tasks
     """
+
+    logs_to_process_for_tasks = []
+    extra_logs_to_save_for_tasks = []
+
+    for log_event in logs_to_process:
+        messages = log_event.messages
+
+        if messages[0].role == "system":
+            metadata = log_event.metadata + {
+                "system_prompt": messages[0].content,
+            }
+            logs_events_for_tasks = await convert_messages_to_tasks(
+                project_id=project_id,
+                org_id=org_id,
+                session_id=log_event.session_id,
+                messages=messages[1:],
+                merge_mode=log_event.merge_mode,
+                created_at=log_event.created_at,
+                metadata=metadata,
+                version_id=log_event.version_id,
+                user_id=log_event.user_id,
+                flag=log_event.flag,
+                test_id=log_event.test_id,
+            )
+
+        else:
+            logs_events_for_tasks = await convert_messages_to_tasks(
+                project_id=project_id,
+                org_id=org_id,
+                session_id=log_event.session_id,
+                messages=messages,
+                merge_mode=log_event.merge_mode,
+                created_at=log_event.created_at,
+                metadata=log_event.metadata,
+                version_id=log_event.version_id,
+                user_id=log_event.user_id,
+                flag=log_event.flag,
+                test_id=log_event.test_id,
+            )
+        logs_to_process_for_tasks.extend(logs_events_for_tasks)
+
+    for log_event in extra_logs_to_save:
+        messages = log_event.messages
+
+        if messages[0].role == "system":
+            metadata = log_event.metadata + {
+                "system_prompt": messages[0].content,
+            }
+            logs_events_for_tasks = await convert_messages_to_tasks(
+                project_id=project_id,
+                org_id=org_id,
+                session_id=log_event.session_id,
+                messages=messages[1:],
+                merge_mode=log_event.merge_mode,
+                created_at=log_event.created_at,
+                metadata=metadata,
+                version_id=log_event.version_id,
+                user_id=log_event.user_id,
+                flag=log_event.flag,
+                test_id=log_event.test_id,
+            )
+
+        else:
+            logs_events_for_tasks = await convert_messages_to_tasks(
+                project_id=project_id,
+                org_id=org_id,
+                session_id=log_event.session_id,
+                messages=messages,
+                merge_mode=log_event.merge_mode,
+                created_at=log_event.created_at,
+                metadata=log_event.metadata,
+                version_id=log_event.version_id,
+                user_id=log_event.user_id,
+                flag=log_event.flag,
+                test_id=log_event.test_id,
+            )
+        extra_logs_to_save_for_tasks.extend(logs_events_for_tasks)
+
+    await process_logs_for_tasks(
+        project_id=project_id,
+        org_id=org_id,
+        logs_to_process=logs_to_process_for_tasks,
+        extra_logs_to_save=extra_logs_to_save_for_tasks,
+    )
+
+    return None
+
+
+async def convert_messages_to_tasks(
+    project_id: str,
+    session_id: str,
+    messages: List[RoleContentMessage],
+    merge_mode: Literal["resolve", "append", "replace"] = "resolve",
+    metadata: Optional[Dict[str, Any]] = None,
+    version_id: Optional[str] = None,
+    created_at: Optional[int] = None,
+    user_id: Optional[str] = None,
+    flag: Optional[str] = None,
+    test_id: Optional[str] = None,
+) -> List[LogEventForTasks]:
+    """
+    Convert messages to LogEventForTasks
+    """
+    log_events = []
+    for i, message in enumerate(messages):
+        if i % 2 == 0:
+            input_message = message.content
+        if i % 2 == 1:
+            output_message = message.content
+            log_event = LogEventForTasks(
+                project_id=project_id,
+                input=input_message,
+                output=output_message,
+                session_id=session_id,
+                created_at=created_at,
+                metadata=metadata,
+                version_id=version_id,
+                user_id=user_id,
+                flag=flag,
+                test_id=test_id,
+            )
+            log_events.append(log_event)
+    if len(messages) % 2 == 1:
+        log_event = LogEventForTasks(
+            project_id=project_id,
+            input=messages[-1].content,
+            output=None,
+            session_id=session_id,
+            created_at=created_at,
+            metadata=metadata,
+            version_id=version_id,
+            user_id=user_id,
+            flag=flag,
+            test_id=test_id,
+        )
+        log_events.append(log_event)
+    return log_events

--- a/extractor/extractor/temporal/activities.py
+++ b/extractor/extractor/temporal/activities.py
@@ -9,8 +9,12 @@ from extractor.services.connectors import (
     LangfuseConnector,
     OpenTelemetryConnector,
 )
-from extractor.services.log.tasks import process_tasks_id
-from extractor.models.log import TaskProcessRequest
+from extractor.services.log.tasks import process_logs_for_messages, process_tasks_id
+from extractor.models.log import (
+    LogProcessRequestForMessages,
+    TaskProcessRequest,
+    LogProcessRequestForTasks,
+)
 from extractor.models import (
     PipelineLangfuseRequest,
     PipelineLangsmithRequest,
@@ -22,7 +26,6 @@ from extractor.models import (
     BillOnStripeRequest,
 )
 from extractor.services.projects import get_project_by_id
-from extractor.models.log import LogProcessRequestForTasks
 from loguru import logger
 from extractor.services.log.tasks import process_logs_for_tasks
 
@@ -281,6 +284,25 @@ async def run_process_logs_for_tasks(
         f"Project {request_body.project_id} org {request_body.org_id}: processing {len(request_body.logs_to_process)} logs and saving {len(request_body.extra_logs_to_save)} extra logs."
     )
     await process_logs_for_tasks(
+        project_id=request_body.project_id,
+        org_id=request_body.org_id,
+        logs_to_process=request_body.logs_to_process,
+        extra_logs_to_save=request_body.extra_logs_to_save,
+    )
+    return {
+        "status": "ok",
+        "nb_job_results": len(request_body.logs_to_process),
+    }
+
+
+@activity.defn(name="run_process_logs_for_messages")
+async def run_process_logs_for_messages(
+    request_body: LogProcessRequestForMessages,
+):
+    logger.info(
+        f"Project {request_body.project_id} org {request_body.org_id}: processing {len(request_body.logs_to_process)} logs and saving {len(request_body.extra_logs_to_save)} extra logs."
+    )
+    await process_logs_for_messages(
         project_id=request_body.project_id,
         org_id=request_body.org_id,
         logs_to_process=request_body.logs_to_process,

--- a/extractor/extractor/temporal/workflows.py
+++ b/extractor/extractor/temporal/workflows.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Type
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
-from extractor.extractor.temporal.activities import run_process_logs_for_messages
+from extractor.temporal.activities import run_process_logs_for_messages
 
 with workflow.unsafe.imports_passed_through():
     import stripe

--- a/extractor/extractor/temporal/workflows.py
+++ b/extractor/extractor/temporal/workflows.py
@@ -19,8 +19,6 @@ from typing import Any, Callable, Type
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
-from extractor.temporal.activities import run_process_logs_for_messages
-
 with workflow.unsafe.imports_passed_through():
     import stripe
     import asyncio
@@ -47,6 +45,7 @@ with workflow.unsafe.imports_passed_through():
         run_main_pipeline_on_task,
         bill_on_stripe,
         run_process_logs_for_tasks,
+        run_process_logs_for_messages,
     )
     from extractor.models.log import (
         LogProcessRequestForMessages,

--- a/extractor/extractor/temporal/workflows.py
+++ b/extractor/extractor/temporal/workflows.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Type
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 
+from extractor.extractor.temporal.activities import run_process_logs_for_messages
+
 with workflow.unsafe.imports_passed_through():
     import stripe
     import asyncio
@@ -187,6 +189,23 @@ class RunProcessLogsForTasksWorkflow(BaseWorkflow):
     async def run(self, request):
         logger.info(
             f"Running run_process_logs_for_tasks_workflow with request: {request}"
+        )
+        await super().run_activity(request)
+
+
+@workflow.defn(name="run_process_logs_for_tasks_workflow")
+class RunProcessLogsForMessagesWorkflow(BaseWorkflow):
+    def __init__(self):
+        super().__init__(
+            activity_func=run_process_logs_for_messages,
+            request_class=LogProcessRequestForMessages,
+            max_retries=2,
+        )
+
+    @workflow.run
+    async def run(self, request):
+        logger.info(
+            f"Running run_process_logs_for_messages_workflow with request: {request}"
         )
         await super().run_activity(request)
 

--- a/extractor/extractor/temporal/workflows.py
+++ b/extractor/extractor/temporal/workflows.py
@@ -193,7 +193,7 @@ class RunProcessLogsForTasksWorkflow(BaseWorkflow):
         await super().run_activity(request)
 
 
-@workflow.defn(name="run_process_logs_for_tasks_workflow")
+@workflow.defn(name="run_process_logs_for_messages_workflow")
 class RunProcessLogsForMessagesWorkflow(BaseWorkflow):
     def __init__(self):
         super().__init__(

--- a/extractor/main.py
+++ b/extractor/main.py
@@ -13,6 +13,7 @@ from extractor.temporal.activities import (
     extract_langsmith_data,
     run_main_pipeline_on_messages,
     run_main_pipeline_on_task,
+    run_process_logs_for_messages,
     run_process_logs_for_tasks,
     run_process_tasks,
     run_recipe_on_task,
@@ -28,6 +29,7 @@ from extractor.temporal.workflows import (
     RunProcessTasksWorkflow,
     RunRecipeOnTaskWorkflow,
     StoreOpenTelemetryDataWorkflow,
+    RunProcessLogsForMessagesWorkflow,
 )
 from loguru import logger
 from temporalio.client import Client, TLSConfig
@@ -118,6 +120,7 @@ async def main() -> None:
             RunMainPipelineOnMessagesWorkflow,
             RunMainPipelineOnTaskWorkflow,
             RunProcessTasksWorkflow,
+            RunProcessLogsForMessagesWorkflow,
         ],
         activities=[  # And the linked activities here
             extract_langsmith_data,
@@ -129,6 +132,7 @@ async def main() -> None:
             run_main_pipeline_on_task,
             run_process_tasks,
             run_process_logs_for_tasks,
+            run_process_logs_for_messages,
         ],
         workflow_runner=new_sandbox_runner(),
         interceptors=[SentryInterceptor()]


### PR DESCRIPTION
## Summary

The v3/log endpoint was not implemented.

### Situation before

### What's here now

## Check list

- [x] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
