### PR TITLE
fix: call session calculation in extractor without running analytics

### DIFF
--- a/backend/app/services/log.py
+++ b/backend/app/services/log.py
@@ -288,17 +288,21 @@ async def process_log_with_session_id(
         session_ids=list(sessions_to_create.keys()) + sessions_ids_already_in_db,
     )
 
-    if trigger_pipeline:
-        if not await project_check_automatic_analytics_monthly_limit(project_id):
-            logger.info(f"Triggering pipeline for {len(tasks_id_to_process)} tasks")
+    logger.info(f"Triggering pipeline for {len(tasks_id_to_process)} tasks")
 
-            extractor_client = ExtractorClient(
-                project_id=project_id,
-                org_id=org_id,
-            )
-            await extractor_client.run_process_tasks(
-                tasks_id_to_process=tasks_id_to_process
-            )
+    run_analytics = (
+        await project_check_automatic_analytics_monthly_limit(project_id)
+        and trigger_pipeline
+    )
+
+    extractor_client = ExtractorClient(
+        project_id=project_id,
+        org_id=org_id,
+    )
+    await extractor_client.run_process_tasks(
+        tasks_id_to_process=tasks_id_to_process,
+        run_analytics=run_analytics,
+    )
 
 
 def collect_metadata(log_event: LogEvent) -> dict:

--- a/backend/app/services/mongo/extractor.py
+++ b/backend/app/services/mongo/extractor.py
@@ -216,7 +216,9 @@ class ExtractorClient:
 
         return response
 
-    async def run_process_tasks(self, tasks_id_to_process: List[str]) -> None:
+    async def run_process_tasks(
+        self, tasks_id_to_process: List[str], run_analytics: bool = False
+    ) -> None:
         """
         Run the task procesing pipeline on a task asynchronously.
 
@@ -233,6 +235,7 @@ class ExtractorClient:
             "run_process_tasks_workflow",
             {
                 "tasks_id_to_process": tasks_id_to_process,
+                "run_analytics": run_analytics,
             },
         )
 

--- a/extractor/extractor/models/log.py
+++ b/extractor/extractor/models/log.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 class TaskProcessRequest(BaseModel):
     tasks_id_to_process: List[str]
+    run_analytics: bool = False
     project_id: str
     org_id: str
     customer_id: Optional[str] = None

--- a/extractor/extractor/services/log/tasks.py
+++ b/extractor/extractor/services/log/tasks.py
@@ -19,6 +19,7 @@ async def process_tasks_id(
     project_id: str,
     org_id: str,
     tasks_id_to_process: List[str],
+    run_analytics: bool = False,
 ) -> None:
     """
     From tasks id, process the tasks
@@ -32,7 +33,10 @@ async def process_tasks_id(
 
     await main_pipeline.set_input(tasks_ids=tasks_id_to_process)
 
-    await main_pipeline.run()
+    if run_analytics:
+        await main_pipeline.run()
+    else:
+        await main_pipeline.compute_session_info_pipeline()
 
     return None
 

--- a/extractor/extractor/temporal/activities.py
+++ b/extractor/extractor/temporal/activities.py
@@ -210,10 +210,16 @@ async def run_process_tasks(
         project_id=request_body.project_id,
         org_id=request_body.org_id,
         tasks_id_to_process=request_body.tasks_id_to_process,
+        run_analytics=request_body.run_analytics,
     )
+
+    nb_job_results = (
+        len(request_body.tasks_id_to_process) if request_body.run_analytics else 0
+    )
+
     return {
         "status": "ok",
-        "nb_job_results": len(request_body.tasks_id_to_process),
+        "nb_job_results": nb_job_results,
     }
 
 


### PR DESCRIPTION
## Summary

fixes the platform error where the latest message date is not calculated

### Situation before

The extractor was not called when no need to run analytics

### What's here now

We always call the extractor to run the session pipeline without running analytics

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
