### PR TITLE
fix: Clustering loading bar when no clustering ran

### DIFF
--- a/backend/app/services/log.py
+++ b/backend/app/services/log.py
@@ -291,9 +291,8 @@ async def process_log_with_session_id(
     logger.info(f"Triggering pipeline for {len(tasks_id_to_process)} tasks")
 
     run_analytics = (
-        await project_check_automatic_analytics_monthly_limit(project_id)
-        and trigger_pipeline
-    )
+        not await project_check_automatic_analytics_monthly_limit(project_id)
+    ) and trigger_pipeline
 
     extractor_client = ExtractorClient(
         project_id=project_id,

--- a/extractor/extractor/temporal/activities.py
+++ b/extractor/extractor/temporal/activities.py
@@ -51,7 +51,14 @@ async def bill_on_stripe(
         f"Billing organization {request.org_id} for {request.nb_job_results} jobs, project_id {request.project_id}"
     )
     usage_per_log: int = 0
-    project = await get_project_by_id(request.project_id)
+    try:
+        project = await get_project_by_id(request.project_id)
+    except ValueError as e:
+        logger.error(f"Project {request.project_id} error: {e}")
+        return
+    except Exception as e:
+        raise e
+
     if request.recipe_type is not None:
         if request.recipe_type == "event_detection":
             usage_per_log += 1 if project.settings.run_event_detection else 0


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
