### PR TITLE
Fix: Breadown by tagger_name ; style: hover card 

### DIFF
--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1393,6 +1393,7 @@ async def get_y_pred_y_true(
     query_result = (
         await mongo_db["events"]
         .find(main_filter)
+        .sort("created_at", -1)
         .to_list(
             # Hardcoded limit to avoid memory issues
             # TODO : Perform all the filtering in the query (or multiple)

--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1390,7 +1390,16 @@ async def get_y_pred_y_true(
 
     main_filter["event_definition.id"] = {"$in": filters.event_id}
 
-    query_result = await mongo_db["events"].find(main_filter).to_list(length=None)
+    query_result = (
+        await mongo_db["events"]
+        .find(main_filter)
+        .to_list(
+            # Hardcoded limit to avoid memory issues
+            # TODO : Perform all the filtering in the query (or multiple)
+            # to avoid this limit
+            length=5_000,
+        )
+    )
     if query_result is None or len(query_result) == 0:
         logger.info("No events found")
         return None, None

--- a/platform/components/dataviz-tagger.tsx
+++ b/platform/components/dataviz-tagger.tsx
@@ -106,7 +106,7 @@ const DatavizTaggerGraph = ({
   });
 
   return (
-    <div className="w-[200px] pt-2">
+    <div className="w-[280px] pt-2">
       {isLoading && <Spinner className="text-green-500" />}
       <ResponsiveContainer
         width={"100%"}
@@ -117,7 +117,7 @@ const DatavizTaggerGraph = ({
           layout={"vertical"} // this actually displays the bar horizontally
           margin={{
             top: 0,
-            right: 0,
+            right: 40,
             bottom: 0,
             left: 0,
           }}
@@ -152,7 +152,7 @@ const DatavizTaggerGraph = ({
           <XAxis
             fontSize={12}
             type="number"
-            domain={[0, "dataMax + 12"]}
+            domain={[0, "dataMax"]}
             tickLine={false}
             axisLine={false}
             height={0}


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

Breakdown by tagger_name and metric avg_scorer_value works

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
