### PR TITLE
Fix: issue with none values in event KPI ; fix: display session metadata filters

### DIFF
--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1418,26 +1418,17 @@ async def get_y_pred_y_true(
 
     # Convert to DataFrame
     df = pd.DataFrame(query_result)
+
+    # Fill empty values
+    df["removed"] = df["removed"].astype(bool).fillna(False)
+    df["confirmed"] = df["confirmed"].astype(bool).fillna(False)
+    df = df.dropna(subset=["score_range"])
+
     if event_type == "confidence":
         mask_y_pred_true = (
-            (
-                (df["source"] != "owner")
-                & (df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] != "owner")
-                & (df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] != "owner")
-                & (~df["confirmed"])
-                & (df["removed"])
-                & (df["score_range"].notna())
-            )
+            ((df["source"] != "owner") & (df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] != "owner") & (df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] != "owner") & (~df["confirmed"]) & (df["removed"]))
         )
 
         mask_y_pred_false = (
@@ -1456,42 +1447,12 @@ async def get_y_pred_y_true(
 
     elif event_type == "category":
         mask = (
-            (
-                (df["source"] != "owner")
-                & (df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] != "owner")
-                & (df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] != "owner")
-                & (~df["confirmed"])
-                & (df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] == "owner")
-                & (~df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] == "owner")
-                & (df["confirmed"])
-                & (~df["removed"])
-                & (df["score_range"].notna())
-            )
-            | (
-                (df["source"] == "owner")
-                & (df["confirmed"])
-                & (df["removed"])
-                & (df["score_range"].notna())
-            )
+            ((df["source"] != "owner") & (df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] != "owner") & (df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] != "owner") & (~df["confirmed"]) & (df["removed"]))
+            | ((df["source"] == "owner") & (~df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] == "owner") & (df["confirmed"]) & (~df["removed"]))
+            | ((df["source"] == "owner") & (df["confirmed"]) & (df["removed"]))
         )
         df = df[mask]
 
@@ -1525,12 +1486,7 @@ async def get_y_pred_y_true(
     elif event_type == "range":
         mask = (
             (df["source"] == "owner") & (~df["removed"]) & (df["score_range"].notna())
-        ) | (
-            (df["source"] != "owner")
-            & (df["confirmed"])
-            & (~df["removed"])
-            & (df["score_range"].notna())
-        )
+        ) | ((df["source"] != "owner") & (df["confirmed"]) & (~df["removed"]))
 
         df = df[mask]
 

--- a/backend/app/services/mongo/query_builder.py
+++ b/backend/app/services/mongo/query_builder.py
@@ -571,7 +571,7 @@ class QueryBuilder:
         if filters.metadata is not None:
             self.merge_tasks()
             for key, value in filters.metadata.items():
-                match[f"metadata.{key}"] = value
+                match[f"tasks.metadata.{key}"] = value
 
         if filters.excluded_users is not None:
             self.merge_tasks()

--- a/platform/components/filters.tsx
+++ b/platform/components/filters.tsx
@@ -848,62 +848,60 @@ const FilterComponent = ({
               </DropdownMenuSub>
             )}
           </div>
-          {variant == "tasks" && (
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <Code className="size-4 mr-2" />
-                <span>Metadata</span>
-              </DropdownMenuSubTrigger>
-              <DropdownMenuPortal>
-                <DropdownMenuSubContent className="overflow-y-auto max-h-[40rem]">
-                  {stringFields && Object.entries(stringFields).length == 0 && (
-                    <DropdownMenuItem disabled>
-                      No metadata available
-                    </DropdownMenuItem>
-                  )}
-                  {stringFields &&
-                    Object.entries(stringFields).map(([field, values]) => {
-                      return (
-                        <DropdownMenuSub key={field}>
-                          <DropdownMenuSubTrigger>
-                            <span>{field}</span>
-                          </DropdownMenuSubTrigger>
-                          <DropdownMenuPortal>
-                            <DropdownMenuSubContent className="overflow-y-auto max-h-[40rem]">
-                              {values.map((value) => {
-                                return (
-                                  <DropdownMenuItem
-                                    key={value}
-                                    onClick={() => {
-                                      setDataFilters({
-                                        ...dataFilters,
-                                        metadata: {
-                                          ...dataFilters.metadata,
-                                          [field]: value,
-                                        },
-                                      });
-                                      resetPagination();
-                                    }}
-                                  >
-                                    {field !== "language"
-                                      ? value
-                                        ? value.length > 50
-                                          ? value.substring(0, 50) + "..."
-                                          : value
-                                        : "-"
-                                      : getLanguageLabel(value)}
-                                  </DropdownMenuItem>
-                                );
-                              })}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuPortal>
-                        </DropdownMenuSub>
-                      );
-                    })}
-                </DropdownMenuSubContent>
-              </DropdownMenuPortal>
-            </DropdownMenuSub>
-          )}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Code className="size-4 mr-2" />
+              <span>Metadata</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuSubContent className="overflow-y-auto max-h-[40rem]">
+                {stringFields && Object.entries(stringFields).length == 0 && (
+                  <DropdownMenuItem disabled>
+                    No metadata available
+                  </DropdownMenuItem>
+                )}
+                {stringFields &&
+                  Object.entries(stringFields).map(([field, values]) => {
+                    return (
+                      <DropdownMenuSub key={field}>
+                        <DropdownMenuSubTrigger>
+                          <span>{field}</span>
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuPortal>
+                          <DropdownMenuSubContent className="overflow-y-auto max-h-[40rem]">
+                            {values.map((value) => {
+                              return (
+                                <DropdownMenuItem
+                                  key={value}
+                                  onClick={() => {
+                                    setDataFilters({
+                                      ...dataFilters,
+                                      metadata: {
+                                        ...dataFilters.metadata,
+                                        [field]: value,
+                                      },
+                                    });
+                                    resetPagination();
+                                  }}
+                                >
+                                  {field !== "language"
+                                    ? value
+                                      ? value.length > 50
+                                        ? value.substring(0, 50) + "..."
+                                        : value
+                                      : "-"
+                                    : getLanguageLabel(value)}
+                                </DropdownMenuItem>
+                              );
+                            })}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuPortal>
+                      </DropdownMenuSub>
+                    );
+                  })}
+              </DropdownMenuSubContent>
+            </DropdownMenuPortal>
+          </DropdownMenuSub>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <Boxes className="size-4 mr-2" />


### PR DESCRIPTION
## Summary

### Situation before

Sessions metadata filters were implemented but not displayed

### What's here now

Display session metadata filters

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
