### PR TITLE
feat: Enforce limit on recipe run

### DIFF
--- a/backend/app/api/platform/endpoints/recipes.py
+++ b/backend/app/api/platform/endpoints/recipes.py
@@ -1,4 +1,9 @@
+from app.services.mongo.projects import (
+    get_project_by_id,
+    project_check_automatic_analytics_monthly_limit,
+)
 from app.services.mongo.recipes import run_recipe_types_on_tasks
+from app.services.mongo.tasks import get_total_nb_of_tasks
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from propelauth_fastapi import User  # type: ignore
 
@@ -43,6 +48,21 @@ async def post_run_recipes(
         raise HTTPException(
             status_code=402,
             detail="You need to add a payment method to access this service. Please update your payment details: https://platform.phospho.ai/org/settings/billing",
+        )
+
+    nb_tasks = await get_total_nb_of_tasks(
+        project_id=project_id, filters=run_recipe_request.filters
+    )
+
+    is_over_limit = await project_check_automatic_analytics_monthly_limit(
+        project_id=project_id,
+        nb_tasks_to_process=nb_tasks,
+        recipe_type_list=run_recipe_request.recipe_type_list,  # type: ignore
+    )
+    if is_over_limit:
+        raise HTTPException(
+            status_code=402,
+            detail="You have reached the monthly limit of automatic analytics. Please increase your limit.",
         )
 
     logger.debug(

--- a/backend/app/api/platform/endpoints/recipes.py
+++ b/backend/app/api/platform/endpoints/recipes.py
@@ -1,7 +1,4 @@
-from app.services.mongo.projects import (
-    get_project_by_id,
-    project_check_automatic_analytics_monthly_limit,
-)
+from app.services.mongo.projects import project_check_automatic_analytics_monthly_limit
 from app.services.mongo.recipes import run_recipe_types_on_tasks
 from app.services.mongo.tasks import get_total_nb_of_tasks
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException


### PR DESCRIPTION
## Summary

### Situation before

### What's here now



## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
