### PR TITLE
chore: change fallback to gpt-4o-mini and better type check

### DIFF
--- a/backend/app/services/mongo/sessions.py
+++ b/backend/app/services/mongo/sessions.py
@@ -240,7 +240,7 @@ async def event_suggestion(
     transcript = await format_session_transcript(session)
 
     provider, model_name = get_provider_and_model(model)
-    openai_client = get_sync_client(cast(Literal["openai"], provider))
+    openai_client = get_sync_client(provider)
 
     # We look at the full session
     existing_tags = "\n- ".join(formatted_tags_list)

--- a/phospho-python/phospho/lab/job_library.py
+++ b/phospho-python/phospho/lab/job_library.py
@@ -431,6 +431,8 @@ If the event '{event_name}' is not present in the {the_interaction} or you can't
                 )
                 async_openai_client = get_async_client("openai")
                 # Fallback to OpenAI API
+                if model_name == "gpt-4o":
+                    model_name = "gpt-4o-mini"
                 response = await async_openai_client.chat.completions.create(
                     model=model_name,
                     messages=[


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
