### PR TITLE
Feat: Export users data

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -60,6 +60,12 @@ AZURE_OPENAI_KEY=""
 AZURE_OPENAI_ENDPOINT=""
 ```
 
+### Run backend server
+
+```
+poetry run uvicorn app.main:app --reload
+```
+
 ### Run tests
 
 1. Make sure you have setup your environment variables. To load the .env files:
@@ -119,11 +125,7 @@ In the Python backend, we use the async client [Motor](https://motor.readthedocs
 
 In tests and other scripts, you can use [Pymongo](https://pymongo.readthedocs.io/en/stable/tutorial.html). It is synchronous and installed when you install Motor. It's useful when you need to wait for the response anyways.
 
-### Run backend server
 
-```
-uvicorn app.main:app --reload
-```
 
 ## Deployment
 

--- a/backend/app/api/platform/endpoints/projects.py
+++ b/backend/app/api/platform/endpoints/projects.py
@@ -43,7 +43,7 @@ from app.services.mongo.projects import (
     collect_languages,
     delete_project_from_id,
     delete_project_related_resources,
-    email_project_tasks,
+    email_project_data,
     get_project_by_id,
     update_project,
 )
@@ -254,9 +254,29 @@ async def email_tasks(
     propelauth.require_org_member(user, project.org_id)
     # Trigger the email sending in the background
     background_tasks.add_task(
-        email_project_tasks, project_id=project_id, uid=user.user_id
+        email_project_data, project_id=project_id, uid=user.user_id, scope="tasks"
     )
     logger.info(f"Emailing tasks of project {project_id} to {user.email}")
+    return {"status": "ok"}
+
+
+@router.get(
+    "/projects/{project_id}/users/email",
+    description="Get an email with the users data of a project in csv and xlsx format",
+)
+async def email_users(
+    project_id: str,
+    background_tasks: BackgroundTasks,
+    user: User = Depends(propelauth.require_user),
+) -> dict:
+    logger.debug("C'est bien le bon endpoint")
+    project = await get_project_by_id(project_id)
+    propelauth.require_org_member(user, project.org_id)
+    # Trigger the email sending in the background
+    background_tasks.add_task(
+        email_project_data, project_id=project_id, uid=user.user_id, scope="users"
+    )
+    logger.info(f"Emailing users of project {project_id} to {user.email}")
     return {"status": "ok"}
 
 

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -331,7 +331,7 @@ async def email_project_data(
     uid: str,
     limit: Optional[int] = 5_000,
     scope: Literal["tasks", "users"] = "tasks",
-    filters: Optional[ProjectDataFilters] = None,
+    # filters: Optional[ProjectDataFilters] = None, Not supported yet
 ) -> None:
     def send_error_message():
         # Send an error message to the user
@@ -381,8 +381,13 @@ async def email_project_data(
 
             elif scope == "users":
                 # Convert task list to Pandas DataFrame
-                if filters is None:
-                    filters = ProjectDataFilters()
+                # if filters is None:
+                #     filters = ProjectDataFilters()
+
+                # For now we only fetch all users
+                # TODO: Implement filters
+
+                filters = ProjectDataFilters()
                 flattened_users = await fetch_users_metadata(
                     project_id=project_id,
                     filters=filters,

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -20,6 +20,11 @@ from app.services.mongo.tasks import (
     get_all_tasks,
     label_sentiment_analysis,
 )
+
+from app.services.mongo.users import fetch_users_metadata
+from phospho.models import ProjectDataFilters
+
+
 from app.services.mongo.sessions import get_all_sessions
 from app.services.slack import slack_notification
 from app.utils import generate_timestamp, generate_uuid
@@ -321,18 +326,20 @@ async def add_project_events(project_id: str, events: List[EventDefinition]) -> 
     return updated_project
 
 
-async def email_project_tasks(
+async def email_project_data(
     project_id: str,
     uid: str,
     limit: Optional[int] = 5_000,
-):
+    scope: Literal["tasks", "users"] = "tasks",
+    filters: Optional[ProjectDataFilters] = None,
+) -> None:
     def send_error_message():
         # Send an error message to the user
         params = {
             "from": "phospho <contact@phospho.ai>",
             "to": [user.get("email")],
-            "subject": "Error exporting your tasks",
-            "html": f"""<p>Hello!<br><br>We could not export your tasks for the project with id {project_id} (timestamp: {datetime.datetime.now().isoformat()})</p>
+            "subject": "Error exporting your data",
+            "html": f"""<p>Hello!<br><br>We could not export your data for the project with id {project_id} (timestamp: {datetime.datetime.now().isoformat()})</p>
             <p><br>Please contact the support at contact@phospho.ai</p>
             <p>Best,<br>
             The Phospho Team</p>
@@ -350,80 +357,106 @@ async def email_project_tasks(
         resend.api_key = config.RESEND_API_KEY
 
         try:
-            # Convert task list to Pandas DataFrame
-            flattened_tasks = await fetch_flattened_tasks(
-                project_id=project_id,
-                limit=limit,
-                with_events=True,
-                with_sessions=True,
-                with_removed_events=False,
-            )
-            tasks_df = pd.DataFrame(
-                [flat_task.model_dump() for flat_task in flattened_tasks]
-            )
+            if scope == "tasks":
+                # Convert task list to Pandas DataFrame
+                flattened_tasks = await fetch_flattened_tasks(
+                    project_id=project_id,
+                    limit=limit,
+                    with_events=True,
+                    with_sessions=True,
+                    with_removed_events=False,
+                )
+                data_df = pd.DataFrame(
+                    [flat_task.model_dump() for flat_task in flattened_tasks]
+                )
 
-            # Convert timestamps to datetime
-            for col in [
-                "task_created_at",
-                "task_eval_at",
-                "event_created_at",
-            ]:
-                if col in tasks_df.columns:
-                    tasks_df[col] = pd.to_datetime(tasks_df[col], unit="s")
+                # Convert timestamps to datetime
+                for col in [
+                    "task_created_at",
+                    "task_eval_at",
+                    "event_created_at",
+                ]:
+                    if col in data_df.columns:
+                        data_df[col] = pd.to_datetime(data_df[col], unit="s")
+
+            elif scope == "users":
+                # Convert task list to Pandas DataFrame
+                if filters is None:
+                    filters = ProjectDataFilters()
+                flattened_users = await fetch_users_metadata(
+                    project_id=project_id,
+                    filters=filters,
+                )
+
+                data_df = pd.DataFrame(
+                    [flat_user.model_dump() for flat_user in flattened_users]
+                )
+
+                # TODO: Change the name of the columns to match the user model
+                # Convert timestamps to datetime
+                for col in [
+                    "user_created_at",
+                    "user_eval_at",
+                ]:
+                    if col in data_df.columns:
+                        data_df[col] = pd.to_datetime(data_df[col], unit="s")
+            else:
+                raise NotImplementedError(f"Scope {scope} not implemented")
 
         except Exception as e:
-            error_message = f"Error converting tasks to DataFrame for {user.get('email')} project id {project_id}: {e}"
+            error_message = f"Error converting {scope} to DataFrame for {user.get('email')} project id {project_id}: {e}"
             logger.error(error_message)
             await slack_notification(error_message)
 
         exports = []
         # Convert the DataFrame to a CSV string, then to bytes
         try:
-            csv_string = tasks_df.to_csv(index=False)
+            csv_string = data_df.to_csv(index=False)
             csv_bytes = csv_string.encode()
             exports.append(
                 {
-                    "filename": "tasks.csv",
+                    "filename": f"{scope}.csv",
                     "content": list(csv_bytes),
                 }
             )
         except Exception as e:
-            error_message = f"Error converting tasks to CSV for {user.get('email')} project id {project_id}: {e}"
+            error_message = f"Error converting {scope} to CSV for {user.get('email')} project id {project_id}: {e}"
             logger.error(error_message)
             await slack_notification(error_message)
 
         # Get the excel file buffer
         try:
             excel_buffer = io.BytesIO()
-            tasks_df.to_excel(excel_buffer, index=False, engine="xlsxwriter")
+            data_df.to_excel(excel_buffer, index=False, engine="xlsxwriter")
             excel_data = excel_buffer.getvalue()
             # encoded_excel = base64.b64encode(excel_data).decode()
             exports.append(
                 {
-                    "filename": "tasks.xlsx",
+                    "filename": f"{scope}.xlsx",
                     "content": list(excel_data),
                 }
             )
         except Exception as e:
-            error_message = f"Error converting tasks to Excel for {user.get('email')} project id {project_id}: {e}"
+            error_message = f"Error converting {scope} to Excel for {user.get('email')} project id {project_id}: {e}"
             logger.error(error_message)
             await slack_notification(error_message)
 
-        # TODO : Add .parquet file export for large datasets
+        # Add .parquet file export for large datasets
         try:
             parquet_buffer = io.BytesIO()
             # For the parquet export, convert task_metadata to a string
-            tasks_df["task_metadata"] = tasks_df["task_metadata"].apply(str)
-            tasks_df.to_parquet(parquet_buffer, index=False)
+            if "task_metadata" in data_df.columns:
+                data_df["task_metadata"] = data_df["task_metadata"].apply(str)
+            data_df.to_parquet(parquet_buffer, index=False)
             parquet_data = parquet_buffer.getvalue()
             exports.append(
                 {
-                    "filename": "tasks.parquet",
+                    "filename": f"{scope}.parquet",
                     "content": list(parquet_data),
                 }
             )
         except Exception as e:
-            error_message = f"Error converting tasks to Parquet for {user.get('email')} project id {project_id}: {e}"
+            error_message = f"Error converting {scope} to Parquet for {user.get('email')} project id {project_id}: {e}"
             logger.error(error_message)
             await slack_notification(error_message)
 
@@ -436,7 +469,7 @@ async def email_project_tasks(
             "from": "phospho <contact@phospho.ai>",
             "to": [user.get("email")],
             "subject": "Your data is ready",
-            "html": f"""<p>Hello!<br><br>Please find your exported messages below for your project with id {project_id} (timestamp: {datetime.datetime.now().isoformat()})</p>
+            "html": f"""<p>Hello!<br><br>Please find your exported {scope} below for your project with id {project_id} (timestamp: {datetime.datetime.now().isoformat()})</p>
             <p><br>Let us know your thoughts about phospho! You can directly respond to this email address !</p>
             <p>Enjoy,<br>
             The Phospho Team</p>
@@ -446,7 +479,7 @@ async def email_project_tasks(
 
         try:
             resend.Emails.send(params)  # type: ignore
-            logger.info(f"Successfully sent tasks by email to {user.get('email')}")
+            logger.info(f"Successfully sent {scope} by email to {user.get('email')}")
         except Exception as e:
             error_message = f"Error sending email to {user.get('email')} project_id {project_id}: {e}"
             logger.error(error_message)

--- a/platform/README.md
+++ b/platform/README.md
@@ -35,7 +35,7 @@ PROPELAUTH_VERIFIER_KEY=-----BEGIN PUBLIC KEY-----
 
 ## Install dependencies
 
-Using Node 21
+Using Node 20.17
 
 ```
 npm i

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -6,6 +6,12 @@ import { useUser } from "@propelauth/nextjs/client";
 import { Download } from "lucide-react";
 import React from "react";
 
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "../ui/hover-card";
+
 const ExportUsersButton: React.FC = () => {
   // PropelAuth
   const project_id = navigationStateStore((state) => state.project_id);
@@ -48,10 +54,14 @@ const ExportUsersButton: React.FC = () => {
   };
 
   return (
-    <Button onClick={handleButtonClick}>
-      <Download className="mr-1 size-4" />
-      Export data
-    </Button>
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger asChild>
+        <Button size="icon" variant="ghost" onClick={handleButtonClick}>
+          <Download className="size-4" />
+        </Button>
+      </HoverCardTrigger>
+      <HoverCardContent className="text-xs">Download as CSV</HoverCardContent>
+    </HoverCard>
   );
 };
 

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { navigationStateStore } from "@/store/store";
+// PropelAuth
+import { useUser } from "@propelauth/nextjs/client";
+import { Download } from "lucide-react";
+import React from "react";
+
+const ExportUsersButton: React.FC = () => {
+  // PropelAuth
+  const project_id = navigationStateStore((state) => state.project_id);
+
+  const { user, accessToken } = useUser();
+  const { toast } = useToast();
+
+  if (!user) {
+    return <></>;
+  }
+
+  const handleButtonClick = async () => {
+    try {
+      const response = await fetch(`/api/projects/${project_id}/users/email`, {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer " + accessToken,
+        },
+      });
+
+      const data = await response.json();
+      if (data.error) {
+        toast({
+          title: "Error exporting data",
+          description: data.error,
+        });
+      } else {
+        toast({
+          // Add a mail emoji
+          title: "✉️ Your data is on the way!",
+          description: `After processing, we'll send the files to ${user.email}`,
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Error exporting data",
+        description: `${error}`,
+      });
+    }
+  };
+
+  return (
+    <Button onClick={handleButtonClick}>
+      <Download className="mr-1 size-4" />
+      Export data
+    </Button>
+  );
+};
+
+export { ExportUsersButton };

--- a/platform/components/users/users-table.tsx
+++ b/platform/components/users/users-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import FilterComponent from "@/components/filters";
 import { CenteredSpinner } from "@/components/small-spinner";
 import { TableNavigation } from "@/components/table-navigation";
 import { Input } from "@/components/ui/input";
@@ -28,7 +29,7 @@ import {
 import React, { useState } from "react";
 import useSWR from "swr";
 
-import FilterComponent from "../filters";
+import { ExportUsersButton } from "./download-users";
 import { UserPreview } from "./user-preview";
 
 export function UsersTable({
@@ -112,6 +113,7 @@ export function UsersTable({
       <div className="flex flex-col gap-y-2 mb-2">
         <div className="flex flex-row gap-x-2 items-end justify-between">
           <FilterComponent variant="users" />
+          <ExportUsersButton />
           <TableNavigation table={table} />
         </div>
         {showSearchBar && (

--- a/platform/components/users/users-table.tsx
+++ b/platform/components/users/users-table.tsx
@@ -113,8 +113,10 @@ export function UsersTable({
       <div className="flex flex-col gap-y-2 mb-2">
         <div className="flex flex-row gap-x-2 items-end justify-between">
           <FilterComponent variant="users" />
-          <ExportUsersButton />
-          <TableNavigation table={table} />
+          <div className="flex gap-x-2">
+            <ExportUsersButton />
+            <TableNavigation table={table} />
+          </div>
         </div>
         {showSearchBar && (
           <Input


### PR DESCRIPTION
## Summary

### Situation before
There was a button to export tasks but not with user granularity
### What's here now
There is button in the users Table to export users data
## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
