### PR TITLE
feat: Add filters to export users, handle edge case when no user

### DIFF
--- a/backend/app/api/platform/endpoints/projects.py
+++ b/backend/app/api/platform/endpoints/projects.py
@@ -281,14 +281,11 @@ async def email_users(
             "message": "No users found in the project.",
         }
     # Trigger the email sending in the background
-    try:
-        background_tasks.add_task(
-            email_project_data, project_id=project_id, uid=user.user_id, scope="users"
-        )
-        logger.info(f"Emailing users of project {project_id} to {user.email}")
-        return {"status": "ok"}
-    except Exception as empty_df:
-        return {"status": "error", "message": f"Error: {empty_df}"}
+    background_tasks.add_task(
+        email_project_data, project_id=project_id, uid=user.user_id, scope="users"
+    )
+    logger.info(f"Emailing users of project {project_id} to {user.email}")
+    return {"status": "ok"}
 
 
 @router.post(

--- a/backend/app/api/platform/models/projects.py
+++ b/backend/app/api/platform/models/projects.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List
 
 from app.db.models import EventDefinition
+from phospho.models import ProjectDataFilters
 
 
 class OnboardingSurvey(BaseModel):
@@ -28,3 +29,7 @@ class ConnectLangsmithQuery(BaseModel):
 class ConnectLangfuseQuery(BaseModel):
     langfuse_secret_key: str
     langfuse_public_key: str
+
+
+class EmailUsersQuery(BaseModel):
+    filters: ProjectDataFilters

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -397,7 +397,6 @@ async def email_project_data(
                     [flat_user.model_dump() for flat_user in flattened_users]
                 )
 
-                # TODO: Change the name of the columns to match the user model
                 # Convert timestamps to datetime
                 for col in [
                     "first_message_ts",

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -331,7 +331,7 @@ async def email_project_data(
     uid: str,
     limit: Optional[int] = 5_000,
     scope: Literal["tasks", "users"] = "tasks",
-    # filters: Optional[ProjectDataFilters] = None, Not supported yet
+    filters: Optional[ProjectDataFilters] = None,
 ) -> None:
     def send_error_message():
         # Send an error message to the user
@@ -381,13 +381,9 @@ async def email_project_data(
 
             elif scope == "users":
                 # Convert task list to Pandas DataFrame
-                # if filters is None:
-                #     filters = ProjectDataFilters()
+                if filters is None:
+                    filters = ProjectDataFilters()
 
-                # For now we only fetch all users
-                # TODO: Implement filters
-
-                filters = ProjectDataFilters()
                 flattened_users = await fetch_users_metadata(
                     project_id=project_id,
                     filters=filters,

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -45,8 +45,19 @@ const ExportUsersButton: React.FC = () => {
       if (data.exception_empty_data) {
         toast({
           title: "No user data in this scope",
-          description:
-            "Select other filters or start tracking users by adding user_id when logging \n https://docs.phospho.ai/analytics/sessions-and-users",
+          description: (
+            <div>
+              Select other filters or start tracking users by adding{" "}
+              <code>user_id</code> when logging. For more details, check the{" "}
+              <a
+                href="https://docs.phospho.ai/analytics/sessions-and-users"
+                target="_blank"
+                className="underline"
+              >
+                documentation
+              </a>
+            </div>
+          ),
         });
       } else {
         toast({

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -38,6 +38,12 @@ const ExportUsersButton: React.FC = () => {
           title: "Error exporting data",
           description: data.error,
         });
+      }
+      if (data.exception_empty_data) {
+        toast({
+          title: "No users to export",
+          description: "There are no users to export.",
+        });
       } else {
         toast({
           // Add a mail emoji

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -44,8 +44,9 @@ const ExportUsersButton: React.FC = () => {
       }
       if (data.exception_empty_data) {
         toast({
-          title: "No users to export",
-          description: "There are no users to export.",
+          title: "No user data in this scope",
+          description:
+            "Select other filters or start tracking users by adding user_id when logging \n https://docs.phospho.ai/analytics/sessions-and-users",
         });
       } else {
         toast({

--- a/platform/components/users/download-users.tsx
+++ b/platform/components/users/download-users.tsx
@@ -15,6 +15,7 @@ import {
 const ExportUsersButton: React.FC = () => {
   // PropelAuth
   const project_id = navigationStateStore((state) => state.project_id);
+  const dataFilters = navigationStateStore((state) => state.dataFilters);
 
   const { user, accessToken } = useUser();
   const { toast } = useToast();
@@ -26,10 +27,12 @@ const ExportUsersButton: React.FC = () => {
   const handleButtonClick = async () => {
     try {
       const response = await fetch(`/api/projects/${project_id}/users/email`, {
-        method: "GET",
+        method: "POST",
         headers: {
+          "Content-Type": "application/json",
           Authorization: "Bearer " + accessToken,
         },
+        body: JSON.stringify({ filters: dataFilters }),
       });
 
       const data = await response.json();
@@ -66,7 +69,7 @@ const ExportUsersButton: React.FC = () => {
           <Download className="size-4" />
         </Button>
       </HoverCardTrigger>
-      <HoverCardContent className="text-xs">Download as CSV</HoverCardContent>
+      <HoverCardContent className="text-xs">Export Users Data</HoverCardContent>
     </HoverCard>
   );
 };


### PR DESCRIPTION
## Summary

### Situation before
When there was no user in project data, the download button was sending empty files
### What's here now
If there are no user in a project, a toast appear and no email is sent
## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
