### PR TITLE
feat: Export users filters & failsafe when no users 

### DIFF
--- a/.github/workflows/phospho-python-test.yaml
+++ b/.github/workflows/phospho-python-test.yaml
@@ -1,6 +1,7 @@
 name: Python package
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "phospho-python/**"

--- a/backend/app/services/log.py
+++ b/backend/app/services/log.py
@@ -8,7 +8,7 @@ from app.utils import generate_timestamp, generate_uuid
 from loguru import logger
 
 from phospho.lab.utils import get_tokenizer, num_tokens_from_messages
-from phospho.models import Session, Task
+from phospho.models import HumanEval, Session, Task
 from phospho.utils import filter_nonjsonable_keys, is_jsonable
 
 
@@ -537,6 +537,15 @@ def create_task_from_logevent(
 
     if log_event.project_id is None:
         log_event.project_id = project_id
+
+    # Create a human eval if flag is set
+    if log_event.flag:
+        human_eval = HumanEval(
+            flag=log_event.flag,
+        )
+    else:
+        human_eval = None
+
     task = Task(
         id=log_event.task_id,
         project_id=log_event.project_id,
@@ -557,6 +566,7 @@ def create_task_from_logevent(
         data=None,
         flag=log_event.flag,
         test_id=log_event.test_id,
+        human_eval=human_eval,
     )
     return task
 

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -400,8 +400,8 @@ async def email_project_data(
                 # TODO: Change the name of the columns to match the user model
                 # Convert timestamps to datetime
                 for col in [
-                    "user_created_at",
-                    "user_eval_at",
+                    "first_message_ts",
+                    "last_message_ts",
                 ]:
                     if col in data_df.columns:
                         data_df[col] = pd.to_datetime(data_df[col], unit="s")


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
