### PR TITLE
FEAT :  Reformat Exported User Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local/
 temporal-certs/
 your_temporal.db
 notebook_test.ipynb
+users.csv

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ secrets.toml
 local/
 temporal-certs/
 your_temporal.db
+notebook_test.ipynb

--- a/backend/README.md
+++ b/backend/README.md
@@ -125,8 +125,6 @@ In the Python backend, we use the async client [Motor](https://motor.readthedocs
 
 In tests and other scripts, you can use [Pymongo](https://pymongo.readthedocs.io/en/stable/tutorial.html). It is synchronous and installed when you install Motor. It's useful when you need to wait for the response anyways.
 
-
-
 ## Deployment
 
 This app is packaged in a Docker container and is deployed with github actions.

--- a/backend/app/api/v2/models/projects.py
+++ b/backend/app/api/v2/models/projects.py
@@ -26,6 +26,11 @@ class ProjectUpdateRequest(BaseModel):
     settings: Optional[dict] = None
 
 
+class UserEventMetadata(BaseModel):
+    event_name: str
+    nb_events: int
+
+
 class UserMetadata(BaseModel):
     """
     The representation of a end-user of an app.
@@ -37,7 +42,7 @@ class UserMetadata(BaseModel):
     avg_success_rate: Optional[float] = None
     avg_session_length: Optional[float] = None
     total_tokens: Optional[int] = None
-    events: Optional[List[Event]] = Field(default_factory=list)
+    events: Optional[List[UserEventMetadata]] = Field(default_factory=list)
     tasks_id: Optional[List[str]] = Field(default_factory=list)
     first_message_ts: float
     last_message_ts: float

--- a/backend/app/api/v2/models/projects.py
+++ b/backend/app/api/v2/models/projects.py
@@ -28,7 +28,7 @@ class ProjectUpdateRequest(BaseModel):
 
 class UserEventMetadata(BaseModel):
     event_name: str
-    nb_events: int
+    count: int
 
 
 class UserMetadata(BaseModel):

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -422,7 +422,7 @@ async def email_project_data(
                 )
 
                 data_df = data_df.drop(columns="events")
-                data_df = data_df.join(matrix, on="user_id")
+                data_df = data_df.merge(matrix, on="user_id")
                 data_df.fillna(0, inplace=True)
 
             else:

--- a/backend/app/services/mongo/projects.py
+++ b/backend/app/services/mongo/projects.py
@@ -400,6 +400,31 @@ async def email_project_data(
                 ]:
                     if col in data_df.columns:
                         data_df[col] = pd.to_datetime(data_df[col], unit="s")
+
+                # Explode the list of dictionaries into separate rows
+                exploded_df = data_df.explode("events")
+
+                # Drop rows with NaN values in the 'events' column
+                exploded_df = exploded_df.dropna(subset=["events"])
+
+                # Create a new column named with the value of the event_name key
+                exploded_df["event_name"] = exploded_df["events"].apply(
+                    lambda x: x["event_name"]
+                )
+                exploded_df["count"] = exploded_df["events"].apply(lambda x: x["count"])
+
+                matrix = exploded_df.pivot_table(
+                    index="user_id",
+                    columns="event_name",
+                    values="count",
+                    aggfunc="sum",
+                    fill_value=0,
+                )
+
+                data_df = data_df.drop(columns="events")
+                data_df = data_df.join(matrix, on="user_id")
+                data_df.fillna(0, inplace=True)
+
             else:
                 raise NotImplementedError(f"Scope {scope} not implemented")
 

--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -91,6 +91,7 @@ async def fetch_users_metadata(
             }
         },
     ]
+
     all_computed_fields.extend(
         [
             "nb_tasks",
@@ -168,11 +169,22 @@ async def fetch_users_metadata(
                     "user_id": "$_id",
                     "event_id": "$events.event_definition.id",
                 },
-                "events": {"$first": "$events"},
+                "events": {"$": "$events"},
                 **{field: {"$first": f"${field}"} for field in all_computed_fields},
             }
         },
+        {
+            "$set": {
+                "events.nb_occurences": {"$size": "$events"},
+            }
+        },
+        {
+            "$set": {
+                "events": {"$first": "$events"},
+            }
+        },
         # Group by user_id
+        # Add here one field
         {
             "$group": {
                 "_id": "$_id.user_id",
@@ -193,6 +205,7 @@ async def fetch_users_metadata(
             }
         },
     ]
+
     query_builder.deduplicate_tasks_events()
     all_computed_fields.append("events")
 
@@ -230,6 +243,8 @@ async def fetch_users_metadata(
             }
         },
     ]
+
+    logger.debug(f"{pipeline}")
 
     # group made us lose the order. We need to sort again
     if sorting:

--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -169,13 +169,13 @@ async def fetch_users_metadata(
                     "user_id": "$_id",
                     "event_id": "$events.event_definition.id",
                 },
-                "events": {"$": "$events"},
+                "events": {"$push": "$events"},
                 **{field: {"$first": f"${field}"} for field in all_computed_fields},
             }
         },
         {
             "$set": {
-                "events.nb_occurences": {"$size": "$events"},
+                "events.count": {"$size": "$events"},
             }
         },
         {

--- a/backend/app/services/mongo/users.py
+++ b/backend/app/services/mongo/users.py
@@ -173,6 +173,7 @@ async def fetch_users_metadata(
                 **{field: {"$first": f"${field}"} for field in all_computed_fields},
             }
         },
+        # Ajouter une disjonction de cas pour les events non taggers
         {
             "$set": {
                 "events.count": {"$size": "$events"},

--- a/platform/components/label-events.tsx
+++ b/platform/components/label-events.tsx
@@ -22,6 +22,7 @@ import {
   Project,
   SessionWithEvents,
   TaskWithEvents,
+  UserEventMetadata,
 } from "@/models/models";
 import { useUser } from "@propelauth/nextjs/client";
 import { DropdownMenuGroup } from "@radix-ui/react-dropdown-menu";
@@ -104,6 +105,22 @@ export const EventBadge = ({ event }: { event: Event }) => {
           {event?.score_range?.corrected_label ?? event.score_range?.label}
         </span>
       )}
+    </Badge>
+  );
+};
+
+export const UserEventMetadataBadge = ({
+  event,
+}: {
+  event: UserEventMetadata;
+}) => {
+  const badgeStyle = "border hover:border-green-500";
+  //TODO Get this info from the event user data
+  // const score_type = event.score_range?.score_type ?? "confidence";
+
+  return (
+    <Badge variant="outline" className={badgeStyle}>
+      {event.event_name} ({event.count})
     </Badge>
   );
 };

--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -1,8 +1,5 @@
 import { InteractiveDatetime } from "@/components/interactive-datetime";
-import {
-  EventBadge,
-  EventDetectionDescription,
-} from "@/components/label-events";
+import { UserEventMetadataBadge } from "@/components/label-events";
 import { Button } from "@/components/ui/button";
 import {
   HoverCard,
@@ -10,7 +7,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { authFetcher } from "@/lib/fetcher";
-import { Event, Project, UserMetadata } from "@/models/models";
+import { Project, UserEventMetadata, UserMetadata } from "@/models/models";
 import { navigationStateStore } from "@/store/store";
 import { useUser } from "@propelauth/nextjs/client";
 import { Column, ColumnDef } from "@tanstack/react-table";
@@ -169,27 +166,16 @@ export function useColumns() {
       cell: (row) => {
         return (
           <>
-            {(row.getValue() as Event[]).map((event: Event) => {
-              // Find the event definition for this event based on the event_name and selectedProject.settings.events
-              const eventDefinition =
-                selectedProject?.settings?.events[event.event_name];
-
-              if (!eventDefinition) return <></>;
-
-              return (
-                <HoverCard openDelay={0} closeDelay={0} key={event.id}>
-                  <HoverCardTrigger asChild>
-                    <EventBadge key={event.id} event={event} />
-                  </HoverCardTrigger>
-                  <HoverCardContent>
-                    <EventDetectionDescription
-                      event={event}
-                      eventDefinition={eventDefinition}
-                    />
-                  </HoverCardContent>
-                </HoverCard>
-              );
-            })}
+            {(row.getValue() as UserEventMetadata[]).map(
+              (event: UserEventMetadata) => {
+                return (
+                  <UserEventMetadataBadge
+                    key={event.event_name}
+                    event={event}
+                  />
+                );
+              },
+            )}
           </>
         );
       },

--- a/platform/components/users/users-table-columns.tsx
+++ b/platform/components/users/users-table-columns.tsx
@@ -6,10 +6,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { authFetcher } from "@/lib/fetcher";
-import { Project, UserEventMetadata, UserMetadata } from "@/models/models";
-import { navigationStateStore } from "@/store/store";
-import { useUser } from "@propelauth/nextjs/client";
+import { UserEventMetadata, UserMetadata } from "@/models/models";
 import { Column, ColumnDef } from "@tanstack/react-table";
 import {
   ArrowDown,
@@ -18,7 +15,6 @@ import {
   ChevronRight,
   Sparkles,
 } from "lucide-react";
-import useSWR from "swr";
 
 function GenericHeader({
   columnName,
@@ -44,17 +40,6 @@ function GenericHeader({
 }
 
 export function useColumns() {
-  const { accessToken } = useUser();
-  const project_id = navigationStateStore((state) => state.project_id);
-
-  const { data: selectedProject }: { data: Project } = useSWR(
-    project_id ? [`/api/projects/${project_id}`, accessToken] : null,
-    ([url, accessToken]) => authFetcher(url, accessToken, "GET"),
-    {
-      keepPreviousData: true,
-    },
-  );
-
   // Create the columns for the data table
   const columns: ColumnDef<UserMetadata>[] = [
     // id

--- a/platform/models/models.ts
+++ b/platform/models/models.ts
@@ -93,13 +93,19 @@ export interface SessionWithEvents extends Session {
   users: UserMetadata[];
 }
 
+export interface UserEventMetadata {
+  event_name: string;
+  count: number;
+}
+
+
 export interface UserMetadata {
   user_id: string;
   nb_tasks: number;
   avg_success_rate: number;
   avg_session_length: number;
   total_tokens: number;
-  events: Event[];
+  events: UserEventMetadata[];
   tasks_id: string[];
   first_message_ts: number;
   last_message_ts: number;


### PR DESCRIPTION
## Summary

### Situation before
There is a new button to export users data. The exported data contained a column 'events' which contained all the data from the class 'Event', the user query and system response included. 

### What's here now
Users data is now formatted differently. There is a column for each detected event with event_name as a header. The value is the number of occurrences. 

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
