### PR TITLE
feat: Avoid duplicate API calls when token is refreshed in data studio

### DIFF
--- a/backend/app/services/mongo/dataviz.py
+++ b/backend/app/services/mongo/dataviz.py
@@ -179,7 +179,7 @@ async def breakdown_by_sum_of_metadata_field(
     query_builder = QueryBuilder(
         project_id=project_id,
         fetch_objects="tasks",
-        filters=pivot_query.filters,
+        filters=filters,
     )
     pipeline = await query_builder.build()
 
@@ -275,7 +275,7 @@ async def breakdown_by_sum_of_metadata_field(
             }
         ]
     elif breakdown_by == "session_length":
-        await compute_session_length(project_id=project_id)
+        # await compute_session_length(project_id=project_id)
         _merge_sessions(pipeline)
         breakdown_by_col = "session_length"
     elif breakdown_by is None:
@@ -393,7 +393,7 @@ async def breakdown_by_sum_of_metadata_field(
         breakdown_by_col = "classifier_label"
 
     if breakdown_by == "task_position":
-        await compute_task_position(project_id=project_id, filters=filters)
+        # await compute_task_position(project_id=project_id, filters=filters)
         breakdown_by_col = "task_position"
 
     if metric == "nb_messages":

--- a/platform/components/dataviz-tagger.tsx
+++ b/platform/components/dataviz-tagger.tsx
@@ -31,7 +31,7 @@ const DatavizTaggerGraph = ({
   breakdown_by_event_id?: string | null;
   scorer_id: string | null;
 }) => {
-  const { accessToken } = useUser();
+  const { accessToken, isLoggedIn } = useUser();
 
   const project_id = navigationStateStore((state) => state.project_id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
@@ -46,7 +46,7 @@ const DatavizTaggerGraph = ({
   const { data: pivotData, isLoading } = useSWRImmutable(
     [
       `/api/metadata/${project_id}/pivot/`,
-      accessToken,
+      isLoggedIn,
       metric,
       metadata_metric,
       breakdown_by,
@@ -54,7 +54,7 @@ const DatavizTaggerGraph = ({
       scorer_id,
       JSON.stringify(mergedFilters),
     ],
-    ([url, accessToken]) =>
+    ([url]) =>
       authFetcher(url, accessToken, "POST", {
         metric: metric.toLowerCase(),
         metric_metadata: metadata_metric?.toLowerCase(),
@@ -76,15 +76,6 @@ const DatavizTaggerGraph = ({
 
         return pivotTable;
       }),
-    {
-      keepPreviousData: false,
-      refreshInterval: 0,
-      refreshWhenHidden: false,
-      revalidateOnReconnect: true,
-      revalidateOnFocus: false,
-      revalidateOnMount: true,
-      refreshWhenOffline: false,
-    },
   );
 
   // I want to get the value of the metric that is the highest in the pivotData

--- a/platform/components/dataviz.tsx
+++ b/platform/components/dataviz.tsx
@@ -110,7 +110,7 @@ const DatavizGraph = ({
     };
   }
 
-  const { accessToken } = useUser();
+  const { accessToken, isLoggedIn } = useUser();
   const project_id = navigationStateStore((state) => state.project_id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
   const router = useRouter();
@@ -124,17 +124,8 @@ const DatavizGraph = ({
   const mergedFilters = { ...filters, ...nonNullDataFilters };
 
   const { data: selectedProject }: { data: Project } = useSWRImmutable(
-    project_id ? [`/api/projects/${project_id}`, accessToken] : null,
-    ([url, accessToken]) => authFetcher(url, accessToken, "GET"),
-    {
-      keepPreviousData: true,
-      refreshInterval: 0,
-      refreshWhenHidden: false,
-      revalidateOnReconnect: true,
-      revalidateOnFocus: false,
-      revalidateOnMount: true,
-      refreshWhenOffline: false,
-    },
+    project_id ? [`/api/projects/${project_id}`, isLoggedIn] : null,
+    ([url]) => authFetcher(url, accessToken, "GET"),
   );
 
   if (!metadata_metric) {
@@ -142,17 +133,8 @@ const DatavizGraph = ({
   }
 
   const { data } = useSWRImmutable(
-    [`/api/metadata/${project_id}/fields`, accessToken],
-    ([url, accessToken]) => authFetcher(url, accessToken, "POST"),
-    {
-      keepPreviousData: true,
-      refreshInterval: 0,
-      refreshWhenHidden: false,
-      revalidateOnReconnect: true,
-      revalidateOnFocus: false,
-      revalidateOnMount: true,
-      refreshWhenOffline: false,
-    },
+    [`/api/metadata/${project_id}/fields`, isLoggedIn],
+    ([url]) => authFetcher(url, accessToken, "POST"),
   );
   const numberMetadataFields: string[] | undefined = data?.number;
   const categoryMetadataFields: string[] | undefined = data?.string;
@@ -160,7 +142,7 @@ const DatavizGraph = ({
   const { data: pivotData, isLoading: pivotLoading } = useSWRImmutable(
     [
       `/api/metadata/${project_id}/pivot/`,
-      accessToken,
+      isLoggedIn,
       metric,
       metadata_metric,
       breakdown_by,
@@ -168,7 +150,7 @@ const DatavizGraph = ({
       scorer_id,
       JSON.stringify(mergedFilters),
     ],
-    ([url, accessToken]) =>
+    ([url]) =>
       authFetcher(url, accessToken, "POST", {
         metric: metric.toLowerCase(),
         metric_metadata: metadata_metric?.toLowerCase(),
@@ -191,15 +173,6 @@ const DatavizGraph = ({
 
         return pivotTable;
       }),
-    {
-      keepPreviousData: true,
-      refreshInterval: 0,
-      refreshWhenHidden: false,
-      revalidateOnReconnect: true,
-      revalidateOnFocus: false,
-      revalidateOnMount: true,
-      refreshWhenOffline: false,
-    },
   );
 
   const isStacked =


### PR DESCRIPTION
## Summary

### Situation before

Despite being immutable, the SWR data was invalidated due to the accessToken refreshing. This resulted in multiple, concurrent API calls in Data Studio that caused heavy loads on the database. 

### What's here now

- Less duplicate API calls. 
- No recomputing of sessions length and task position
- Remove options to SWRImmutable (they are not used)

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
