### PR TITLE
fix: Optimize top 5 events, metadata values

### DIFF
--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -391,15 +391,9 @@ async def get_most_detected_tagger_name(
     main_filter["removed"] = {"$ne": True}
     pipeline: List[Dict[str, object]] = [
         {"$match": main_filter},
-        {
-            "$lookup": {
-                "from": "tasks",
-                "localField": "task_id",
-                "foreignField": "id",
-                "as": "tasks",
-            },
-        },
     ]
+
+    # Tasks filter
     tasks_filter: Dict[str, object] = {}
     # Filter on flag
     if flag is not None:
@@ -425,9 +419,17 @@ async def get_most_detected_tagger_name(
             tasks_filter["tasks.last_eval.source"] = {"$regex": "^(?!phospho).*"}
 
     if tasks_filter != {}:
-        pipeline.append(
+        pipeline += [
+            {
+                "$lookup": {
+                    "from": "tasks",
+                    "localField": "task_id",
+                    "foreignField": "id",
+                    "as": "tasks",
+                },
+            },
             {"$match": tasks_filter},
-        )
+        ]
 
     pipeline.extend(
         [

--- a/platform/components/filters.tsx
+++ b/platform/components/filters.tsx
@@ -59,6 +59,7 @@ import {
 import Link from "next/link";
 import React from "react";
 import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 interface LanguageFilterOption {
   value: string;
@@ -76,7 +77,7 @@ const FilterComponent = ({
   const setShowSearchBar = navigationStateStore(
     (state) => state.setShowSearchBar,
   );
-  const { accessToken } = useUser();
+  const { accessToken, isLoggedIn } = useUser();
 
   if (variant === "messages") {
     variant = "tasks";
@@ -155,18 +156,15 @@ const FilterComponent = ({
   }));
 
   // Metadata filters: {"string": {metadata_key: [unique_metadata_values]}}
-  const { data: metadataFieldsToValues } = useSWR(
+  const { data: metadataFieldsToValues } = useSWRImmutable(
     selectedProject?.id
       ? [
           `/api/metadata/${selectedProject?.id}/fields/values`,
-          accessToken,
+          isLoggedIn,
           "unique_metadata_fields_to_values",
         ]
       : null,
-    ([url, accessToken]) => authFetcher(url, accessToken, "POST"),
-    {
-      keepPreviousData: true,
-    },
+    ([url]) => authFetcher(url, accessToken, "POST"),
   );
   const stringFields: MetadataFieldsToUniqueValues | undefined =
     metadataFieldsToValues?.string;

--- a/platform/components/tasks/tasks-dataviz.tsx
+++ b/platform/components/tasks/tasks-dataviz.tsx
@@ -31,6 +31,7 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent";
 import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 interface NbDailyTasks {
   day: string;
@@ -58,7 +59,7 @@ const TasksDataviz: React.FC<TasksDatavizProps> = ({ forcedDataFilters }) => {
   /*
   Note: This is not displayed if there are no tasks in the project.
   */
-  const { accessToken } = useUser();
+  const { accessToken, isLoggedIn } = useUser();
   const project_id = navigationStateStore((state) => state.project_id);
   const dataFilters = navigationStateStore((state) => state.dataFilters);
   const mergedDataFilters = {
@@ -226,14 +227,16 @@ const TasksDataviz: React.FC<TasksDatavizProps> = ({ forcedDataFilters }) => {
     );
 
   const { data: eventsRanking }: { data: EventsRanking[] | null | undefined } =
-    useSWR(
-      [
-        project_id ? `/api/explore/${project_id}/aggregated/tasks` : "",
-        accessToken,
-        "events_ranking",
-        JSON.stringify(mergedDataFilters),
-      ],
-      ([url, accessToken]) =>
+    useSWRImmutable(
+      project_id
+        ? [
+            `/api/explore/${project_id}/aggregated/tasks`,
+            isLoggedIn,
+            "events_ranking",
+            JSON.stringify(mergedDataFilters),
+          ]
+        : null,
+      ([url]) =>
         authFetcher(url, accessToken, "POST", {
           metrics: ["events_ranking"],
           filters: mergedDataFilters,


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
