### PR TITLE
feat: Optimize AB test query

### DIFF
--- a/backend/app/services/mongo/explore.py
+++ b/backend/app/services/mongo/explore.py
@@ -1891,13 +1891,11 @@ async def get_ab_tests_versions(
     if filtersA is not None:
         if isinstance(filtersA.created_at_start, datetime.datetime):
             filtersA.created_at_start = int(filtersA.created_at_start.timestamp())
-    if filtersA is not None:
         if isinstance(filtersA.created_at_end, datetime.datetime):
             filtersA.created_at_end = int(filtersA.created_at_end.timestamp())
     if filtersB is not None:
         if isinstance(filtersB.created_at_start, datetime.datetime):
             filtersB.created_at_start = int(filtersB.created_at_start.timestamp())
-    if filtersB is not None:
         if isinstance(filtersB.created_at_end, datetime.datetime):
             filtersB.created_at_end = int(filtersB.created_at_end.timestamp())
 

--- a/platform/components/abtesting/abtesting-dataviz.tsx
+++ b/platform/components/abtesting/abtesting-dataviz.tsx
@@ -41,6 +41,7 @@ import {
   ChevronRight,
   EllipsisVertical,
 } from "lucide-react";
+import moment from "moment";
 import Link from "next/link";
 import React, { useState } from "react";
 import {
@@ -76,9 +77,6 @@ export const ABTestingDataviz = () => {
     created_at_start: undefined,
     created_at_end: undefined,
   });
-
-  const [dateRangeA, setDateRangeA] = useState<string>("Date range");
-  const [dateRangeB, setDateRangeB] = useState<string>("Date range");
 
   const [customDateRangeA, setCustomDateRangeA] = useState<
     CustomDateRange | undefined
@@ -186,15 +184,14 @@ export const ABTestingDataviz = () => {
     selectedEventsIds === null;
 
   const onClickFiltersA = (newDateRange: string) => {
-    if (dateRangeA === newDateRange) {
-      setDateRangeA("Date range");
+    if (versionIDB === newDateRange) {
+      // Unselect the date range
       setVersionIDA(null);
       setFiltersA({
         created_at_start: undefined,
         created_at_end: undefined,
       });
     } else {
-      setDateRangeA(newDateRange);
       if (newDateRange === "This week") {
         setFiltersA({
           created_at_start: Date.now() / 1000 - 7 * 24 * 60 * 60,
@@ -213,15 +210,14 @@ export const ABTestingDataviz = () => {
   };
 
   const onClickFiltersB = (newDateRange: string) => {
-    if (dateRangeB === newDateRange) {
-      setDateRangeB("Date range");
+    if (versionIDB === newDateRange) {
+      // Unselect the date range
       setVersionIDB(null);
       setFiltersB({
         created_at_start: undefined,
         created_at_end: undefined,
       });
     } else {
-      setDateRangeB(newDateRange);
       if (newDateRange === "This week") {
         setFiltersB({
           created_at_start: Date.now() / 1000 - 7 * 24 * 60 * 60,
@@ -241,7 +237,6 @@ export const ABTestingDataviz = () => {
 
   const onClickVersionA = (version_id: string) => {
     setVersionIDA(version_id);
-    setDateRangeA("Date range");
     setFiltersA({
       created_at_start: undefined,
       created_at_end: undefined,
@@ -250,7 +245,6 @@ export const ABTestingDataviz = () => {
 
   const onClickVersionB = (version_id: string) => {
     setVersionIDB(version_id);
-    setDateRangeB("Date range");
     setFiltersB({
       created_at_start: undefined,
       created_at_end: undefined,
@@ -335,13 +329,13 @@ export const ABTestingDataviz = () => {
               </DropdownMenuTrigger>
               <DropdownMenuContent className="overflow-y-auto max-h-[40rem] ">
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>{dateRangeA}</DropdownMenuSubTrigger>
+                  <DropdownMenuSubTrigger>Date range</DropdownMenuSubTrigger>
                   <DropdownMenuPortal>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem
                         onClick={() => onClickFiltersA("This week")}
                       >
-                        {dateRangeA === "This week" && (
+                        {versionIDA === "This week" && (
                           <Check className="h-4 w-4 mr-2 text-green-500" />
                         )}
                         This week
@@ -349,7 +343,7 @@ export const ABTestingDataviz = () => {
                       <DropdownMenuItem
                         onClick={() => onClickFiltersA("Last week")}
                       >
-                        {dateRangeA === "Last week" && (
+                        {versionIDA === "Last week" && (
                           <Check className="h-4 w-4 mr-2 text-green-500" />
                         )}
                         Last week
@@ -380,8 +374,13 @@ export const ABTestingDataviz = () => {
                                       selected.to.getTime() / 1000,
                                   });
                                 }
-                                setDateRangeA("Custom A");
-                                setVersionIDA("Custom A");
+                                const startDate = moment(selected.from).format(
+                                  "YYYY-MM-DD",
+                                );
+                                const endDate = moment(selected.to).format(
+                                  "YYYY-MM-DD",
+                                );
+                                setVersionIDA(`${startDate} - ${endDate}`);
                                 const dateRangeInfo: CustomDateRange = {
                                   from: selected.from,
                                   to: selected.to,
@@ -401,23 +400,24 @@ export const ABTestingDataviz = () => {
                   </DropdownMenuPortal>
                 </DropdownMenuSub>
                 <Separator />
-                {abTests?.map((abTest) => (
-                  <DropdownMenuItem
-                    key={`${abTest.version_id}_A`}
-                    onClick={() => onClickVersionA(abTest.version_id)}
-                    asChild
-                  >
-                    <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
-                      <div className="flex flex-row gap-x-2 items-center">
-                        {abTest.version_id === versionIDA && (
-                          <Check className="size-4 mr-2 text-green-500" />
-                        )}
-                        {abTest.version_id}
+                {abTests &&
+                  abTests?.map((abTest) => (
+                    <DropdownMenuItem
+                      key={`${abTest.version_id}_A`}
+                      onClick={() => onClickVersionA(abTest.version_id)}
+                      asChild
+                    >
+                      <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
+                        <div className="flex flex-row gap-x-2 items-center">
+                          {abTest.version_id === versionIDA && (
+                            <Check className="size-4 mr-2 text-green-500" />
+                          )}
+                          {abTest.version_id}
+                        </div>
+                        <InteractiveDatetime timestamp={abTest.first_task_ts} />
                       </div>
-                      <InteractiveDatetime timestamp={abTest.first_task_ts} />
-                    </div>
-                  </DropdownMenuItem>
-                ))}
+                    </DropdownMenuItem>
+                  ))}
                 {abTests?.length === 0 && (
                   <DropdownMenuItem disabled className="min-w-[10rem]">
                     <p>
@@ -442,13 +442,13 @@ export const ABTestingDataviz = () => {
                 align="start"
               >
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>{dateRangeB}</DropdownMenuSubTrigger>
+                  <DropdownMenuSubTrigger>Date range</DropdownMenuSubTrigger>
                   <DropdownMenuPortal>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem
                         onClick={() => onClickFiltersB("This week")}
                       >
-                        {dateRangeB === "This week" && (
+                        {versionIDB === "This week" && (
                           <Check className="h-4 w-4 mr-2 text-green-500" />
                         )}
                         This week
@@ -456,7 +456,7 @@ export const ABTestingDataviz = () => {
                       <DropdownMenuItem
                         onClick={() => onClickFiltersB("Last week")}
                       >
-                        {dateRangeB === "Last week" && (
+                        {versionIDB === "Last week" && (
                           <Check className="h-4 w-4 mr-2 text-green-500" />
                         )}
                         Last week
@@ -487,8 +487,13 @@ export const ABTestingDataviz = () => {
                                       selected.to.getTime() / 1000,
                                   });
                                 }
-                                setDateRangeB("Custom B");
-                                setVersionIDB("Custom B");
+                                const startDate = moment(selected.from).format(
+                                  "YYYY-MM-DD",
+                                );
+                                const endDate = moment(selected.to).format(
+                                  "YYYY-MM-DD",
+                                );
+                                setVersionIDB(`${startDate} - ${endDate}`);
                                 const dateRangeInfo: CustomDateRange = {
                                   from: selected.from,
                                   to: selected.to,
@@ -508,23 +513,24 @@ export const ABTestingDataviz = () => {
                   </DropdownMenuPortal>
                 </DropdownMenuSub>
                 <Separator />
-                {abTests?.map((abTest) => (
-                  <DropdownMenuItem
-                    key={`${abTest.version_id}_B`}
-                    onClick={() => onClickVersionB(abTest.version_id)}
-                    asChild
-                  >
-                    <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
-                      <div className="flex flex-row gap-x-2 items-center">
-                        {abTest.version_id === versionIDB && (
-                          <Check className="size-4 mr-2 text-green-500" />
-                        )}
-                        {abTest.version_id}
+                {abTests &&
+                  abTests?.map((abTest) => (
+                    <DropdownMenuItem
+                      key={`${abTest.version_id}_B`}
+                      onClick={() => onClickVersionB(abTest.version_id)}
+                      asChild
+                    >
+                      <div className="min-w-[10rem] flex flex-row justify-between gap-x-8">
+                        <div className="flex flex-row gap-x-2 items-center">
+                          {abTest.version_id === versionIDB && (
+                            <Check className="size-4 mr-2 text-green-500" />
+                          )}
+                          {abTest.version_id}
+                        </div>
+                        <InteractiveDatetime timestamp={abTest.first_task_ts} />
                       </div>
-                      <InteractiveDatetime timestamp={abTest.first_task_ts} />
-                    </div>
-                  </DropdownMenuItem>
-                ))}
+                    </DropdownMenuItem>
+                  ))}
                 {abTests?.length === 0 && (
                   <DropdownMenuItem disabled>
                     <p>


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

- Less convoluted frontend
- Earlier filters for AB test query
- Don't merge "tasks" table (instead use the .task object attached to the events documents)

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
