### PR TITLE
fix: Adds missing env variable in prod

### DIFF
--- a/.github/workflows/backend-deploy-production.yml
+++ b/.github/workflows/backend-deploy-production.yml
@@ -222,6 +222,7 @@ jobs:
           TEMPORAL_MTLS_TLS_CERT_BASE64: ${{ secrets.TEMPORAL_MTLS_TLS_CERT_BASE64 }}
           TEMPORAL_MTLS_TLS_KEY_BASE64: ${{ secrets.TEMPORAL_MTLS_TLS_KEY_BASE64 }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
         run: |
           gcloud run deploy phospho-ai-hub \
@@ -235,6 +236,7 @@ jobs:
             --set-env-vars TEMPORAL_HOST_URL=$TEMPORAL_HOST_URL,TEMPORAL_NAMESPACE=$TEMPORAL_NAMESPACE \
             --set-env-vars TEMPORAL_MTLS_TLS_CERT_BASE64=$TEMPORAL_MTLS_TLS_CERT_BASE64,TEMPORAL_MTLS_TLS_KEY_BASE64=$TEMPORAL_MTLS_TLS_KEY_BASE64 \
             --set-env-vars STRIPE_SECRET_KEY=$STRIPE_SECRET_KEY \
+            --set-env-vars STRIPE_WEBHOOK_SECRET=$STRIPE_WEBHOOK_SECRET \
             --set-env-vars RESEND_API_KEY=$RESEND_API_KEY \
             --max-instances 10 \
             --min-instances 1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       context: ./
       dockerfile: ./ai-hub/Dockerfile
     ports:
-      - "8080:8080" # Expose AI-Hub service on port 8080
+      - "8081:8081" # Expose AI-Hub service on port 8081
     env_file:
       - ./.env.docker
     networks:


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
