### PR TITLE
fix: Hide export clusterings for project with no clustering

### DIFF
--- a/platform/components/clusters/clusters.tsx
+++ b/platform/components/clusters/clusters.tsx
@@ -281,8 +281,9 @@ const Clusters: React.FC = () => {
                 <Plus className="w-4 h-4 mr-1" /> New clustering
               </Button>
             </SheetTrigger>
-
-            <ExportClusteringsButton />
+            {clusterings && clusterings.length > 0 && (
+              <ExportClusteringsButton />
+            )}
           </div>
           {selectedClustering && (
             <div className="space-x-2 my-2">


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
