### PR TITLE
Fix: edit more docs links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@
 - [ ] typing, linting, docstrings (cicd will fail)
 - [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
 - [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
-- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `docs.phospho.ai`
+- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `phospho-app.github.io/docs/`

--- a/examples/lab/parallel-calls.ipynb
+++ b/examples/lab/parallel-calls.ipynb
@@ -1,1161 +1,1161 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Run parallel calls to OpenAI on a dataset, with rate limit\n",
-    "\n",
-    "In this notebook, you'll learn how to run multiple parallel calls to OpenAI on a dataset with a rate limit. \n",
-    "\n",
-    "As an example, we'll take a bunch of Amazon reviews as a dataset. Our goal is to **extract keywords** from the reviews. The way we extract keywords is by making a call to OpenAI GPT-4 and asking to list the keywords. \n",
-    "\n",
-    "To do that, here is what we will do:\n",
-    "\n",
-    "1. Load the dataset\n",
-    "2. Make API calls to OpenAI\n",
-    "3. Parallelize the calls while respecting the OpenAI rate limits\n",
-    "4. Displaying results\n",
-    "\n",
-    "Let's go!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install \"phospho[lab]\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd\n",
-    "import re\n",
-    "import os\n",
-    "import openai \n",
-    "\n",
-    "from phospho import lab\n",
-    "from dotenv import load_dotenv\n",
-    "\n",
-    "load_dotenv()\n",
-    "\n",
-    "assert os.environ.get(\"OPENAI_API_KEY\"), \"Please set the OPENAI_API_KEY environment variable.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Load dataset\n",
-    "\n",
-    "For demonstration purposes, we'll use a subset of the [Amazon Reviews dataset, collected in 2023 by McAuley Lab](https://amazon-reviews-2023.github.io)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "messages_df = pd.read_csv('data/Magazine_Subscriptions_5.csv')\n",
-    "# Create a new column to store the message id\n",
-    "messages_df[\"id\"] = messages_df.index.astype(str)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>overall</th>\n",
-       "      <th>verified</th>\n",
-       "      <th>reviewTime</th>\n",
-       "      <th>reviewerID</th>\n",
-       "      <th>asin</th>\n",
-       "      <th>reviewerName</th>\n",
-       "      <th>reviewText</th>\n",
-       "      <th>summary</th>\n",
-       "      <th>unixReviewTime</th>\n",
-       "      <th>vote</th>\n",
-       "      <th>style</th>\n",
-       "      <th>image</th>\n",
-       "      <th>id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>4</td>\n",
-       "      <td>True</td>\n",
-       "      <td>02 26, 2014</td>\n",
-       "      <td>A5QQOOZJOVPSF</td>\n",
-       "      <td>B00005N7P0</td>\n",
-       "      <td>John L. Mehlmauer</td>\n",
-       "      <td>I'm old, and so is my computer.  Any advice th...</td>\n",
-       "      <td>Cheapskates guide</td>\n",
-       "      <td>1393372800</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Run parallel calls to OpenAI on a dataset, with rate limit\n",
+        "\n",
+        "In this notebook, you'll learn how to run multiple parallel calls to OpenAI on a dataset with a rate limit. \n",
+        "\n",
+        "As an example, we'll take a bunch of Amazon reviews as a dataset. Our goal is to **extract keywords** from the reviews. The way we extract keywords is by making a call to OpenAI GPT-4 and asking to list the keywords. \n",
+        "\n",
+        "To do that, here is what we will do:\n",
+        "\n",
+        "1. Load the dataset\n",
+        "2. Make API calls to OpenAI\n",
+        "3. Parallelize the calls while respecting the OpenAI rate limits\n",
+        "4. Displaying results\n",
+        "\n",
+        "Let's go!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install \"phospho[lab]\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import re\n",
+        "import os\n",
+        "import openai \n",
+        "\n",
+        "from phospho import lab\n",
+        "from dotenv import load_dotenv\n",
+        "\n",
+        "load_dotenv()\n",
+        "\n",
+        "assert os.environ.get(\"OPENAI_API_KEY\"), \"Please set the OPENAI_API_KEY environment variable.\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Load dataset\n",
+        "\n",
+        "For demonstration purposes, we'll use a subset of the [Amazon Reviews dataset, collected in 2023 by McAuley Lab](https://amazon-reviews-2023.github.io)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "messages_df = pd.read_csv('data/Magazine_Subscriptions_5.csv')\n",
+        "# Create a new column to store the message id\n",
+        "messages_df[\"id\"] = messages_df.index.astype(str)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>overall</th>\n",
+              "      <th>verified</th>\n",
+              "      <th>reviewTime</th>\n",
+              "      <th>reviewerID</th>\n",
+              "      <th>asin</th>\n",
+              "      <th>reviewerName</th>\n",
+              "      <th>reviewText</th>\n",
+              "      <th>summary</th>\n",
+              "      <th>unixReviewTime</th>\n",
+              "      <th>vote</th>\n",
+              "      <th>style</th>\n",
+              "      <th>image</th>\n",
+              "      <th>id</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>4</td>\n",
+              "      <td>True</td>\n",
+              "      <td>02 26, 2014</td>\n",
+              "      <td>A5QQOOZJOVPSF</td>\n",
+              "      <td>B00005N7P0</td>\n",
+              "      <td>John L. Mehlmauer</td>\n",
+              "      <td>I'm old, and so is my computer.  Any advice th...</td>\n",
+              "      <td>Cheapskates guide</td>\n",
+              "      <td>1393372800</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   overall  verified   reviewTime     reviewerID        asin  \\\n",
+              "0        4      True  02 26, 2014  A5QQOOZJOVPSF  B00005N7P0   \n",
+              "\n",
+              "        reviewerName                                         reviewText  \\\n",
+              "0  John L. Mehlmauer  I'm old, and so is my computer.  Any advice th...   \n",
+              "\n",
+              "             summary  unixReviewTime  vote style image id  \n",
+              "0  Cheapskates guide      1393372800   NaN   NaN   NaN  0  "
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "   overall  verified   reviewTime     reviewerID        asin  \\\n",
-       "0        4      True  02 26, 2014  A5QQOOZJOVPSF  B00005N7P0   \n",
-       "\n",
-       "        reviewerName                                         reviewText  \\\n",
-       "0  John L. Mehlmauer  I'm old, and so is my computer.  Any advice th...   \n",
-       "\n",
-       "             summary  unixReviewTime  vote style image id  \n",
-       "0  Cheapskates guide      1393372800   NaN   NaN   NaN  0  "
+      "source": [
+        "messages_df.head(1)"
       ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "messages_df.head(1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The first thing we need to do is to transform this dataset in a list of phospho `lab.Message`, which is a data format more adapted for what we need to do. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Message(id='0', created_at=1393372800, role=None, content=\"I'm old, and so is my computer.  Any advice that can help me maximize my computer perfomance is very welcome.  MaximumPC has some good tips on computer parts, vendors, and usefull tests\", previous_messages=[], metadata={})]"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Convert every valid row of the df into a lab.Message\n",
-    "messages = lab.Message.from_df(messages_df, content=\"reviewText\", created_at=\"unixReviewTime\", id=\"id\")\n",
-    "messages[:1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Make API calls to OpenAI\n",
-    "\n",
-    "Let's create a function that takes a message content as an input, and then make a call to OpenAI to get a list of keywords. \n",
-    "\n",
-    "### Step by step\n",
-    "\n",
-    "First, we'll take a message. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Message(id='0', created_at=1393372800, role=None, content=\"I'm old, and so is my computer.  Any advice that can help me maximize my computer perfomance is very welcome.  MaximumPC has some good tips on computer parts, vendors, and usefull tests\", previous_messages=[], metadata={})"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "message = messages[0]\n",
-    "message"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then, we embed it into a prompt that we make to OpenAI."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'- Old computer\\n- Computer performance\\n- Advice\\n- MaximumPC\\n- Computer parts\\n- Vendors\\n- Useful tests'"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "openai_client = openai.AsyncClient(api_key=os.environ[\"OPENAI_API_KEY\"])\n",
-    "\n",
-    "# Label every message with keywords it contains\n",
-    "prompt = f\"\"\"You are an annotator reading Amazon product reviews. Your job is to label\n",
-    "each review with keywords that describe the main topics covered in the review.\n",
-    "The review is: \n",
-    "{message.content}\n",
-    "\n",
-    "Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
-    "Keywords:\"\"\"\n",
-    "\n",
-    "response = await openai_client.chat.completions.create(\n",
-    "    model=\"gpt-3.5-turbo\",\n",
-    "    messages=[\n",
-    "        {\n",
-    "            \"role\": \"system\",\n",
-    "            \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
-    "        },\n",
-    "        {\"role\": \"user\", \"content\": prompt},\n",
-    "    ],\n",
-    ")\n",
-    "response.choices[0].message.content"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally, we use regex to read the response. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['Old computer',\n",
-       " 'Computer performance',\n",
-       " 'Advice',\n",
-       " 'MaximumPC',\n",
-       " 'Computer parts',\n",
-       " 'Vendors',\n",
-       " 'Useful tests']"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response = response.choices[0].message.content\n",
-    "# Parse the response to extract the keywords with regex\n",
-    "keywords = re.findall(r\"- (.*)\", response)\n",
-    "keywords"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Turn this into a phospho job\n",
-    "\n",
-    "Okay, let's muscle up and turn this proof of concept into a function.\n",
-    "\n",
-    "However, let's respect the phospho job convention. To respect the convention, we need the function to take a lab.Message as an input, and return a lab.JobResult as an output.\n",
-    "\n",
-    "Respecting this format helps us parallelize the calls later on. \n",
-    "\n",
-    "Here's what the function looks like:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def get_keywords(\n",
-    "    message: lab.Message,\n",
-    "    model: str=\"openai:gpt-3.5-turbo\",\n",
-    ") -> lab.JobResult:\n",
-    "    \"\"\"\n",
-    "    This function uses OpenAI GPT to extract keywords from a given message.\n",
-    "    \"\"\"\n",
-    "    provider, model_name = lab.get_provider_and_model(model)\n",
-    "    openai_client = lab.get_async_client(provider)\n",
-    "\n",
-    "    # Label every message with keywords it contains\n",
-    "    prompt = f\"\"\"You are an annotator reading Amazon product reviews. Your job is to label\n",
-    "    each review with topics that describe important topics covered in the review, relevant\n",
-    "    to the e-commerce domain. Do not include generic topics such as \"good\", \"bad\", \"interesting\", etc.\n",
-    "    \n",
-    "    The review is: \n",
-    "    {message.content}\n",
-    "\n",
-    "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
-    "    Keywords:\"\"\"\n",
-    "\n",
-    "    response = await openai_client.chat.completions.create(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
-    "        messages=[\n",
-    "            {\n",
-    "                \"role\": \"system\",\n",
-    "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
-    "            },\n",
-    "            {\"role\": \"user\", \"content\": prompt},\n",
-    "        ],\n",
-    "    )\n",
-    "\n",
-    "    response = response.choices[0].message.content\n",
-    "    # Parse the response to extract the keywords with regex\n",
-    "    keywords = re.findall(r\"- (.*)\", response)\n",
-    "    # Let's trim and lowercase the keywords\n",
-    "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
-    "    return lab.JobResult(\n",
-    "        value=keywords,\n",
-    "        result_type=lab.ResultType.list,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Easy, right ? Let's try the function on a single keyword:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'maximumpc', 'advice', 'maximize', 'old computer', 'performance tweaks'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887291, job_id=None)"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Try the function one a single message\n",
-    "await get_keywords(messages[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Run the job on multiple messages\n",
-    "\n",
-    "Now, let's run the jobs on the dataset. \n",
-    "\n",
-    "### Without phospho\n",
-    "\n",
-    "With a simple for loop, you have to wait for a full API call to complete before running the next one. This takes a long time.  \n",
-    "\n",
-    "With **parallelism**, you can make multiple calls at the same time, but debugging becomes much harder.\n",
-    "\n",
-    "Moreover, OpenAI and model providers have set up **rate limits.** If you parallelize without care, you will reach rate limits of OpenAI, and your requests will fail.\n",
-    "\n",
-    "### With phospho\n",
-    "\n",
-    "phospho introduces the abstraction of a Workload. A workload is a set of jobs to run. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No job_config provided. Running with empty config\n"
-     ]
-    }
-   ],
-   "source": [
-    "workload = lab.Workload(jobs=[lab.Job(job_function=get_keywords)])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A workload offers quick configuration for the problem presented before:\n",
-    "- `executor_mode`: switch between `sequential` to debug and `parallel` to parallelize API cals\n",
-    "- `max_parallelism`: slow down purposefuly the number of requests per second to avoid being rate limited.\n",
-    "\n",
-    "Here is how to run a workload."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 100/100 [00:10<00:00,  9.25it/s]\n"
-     ]
     },
     {
-     "data": {
-      "text/plain": [
-       "{'get_keywords': JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'optimization', 'maximumpc', 'advice', 'maximize', 'old computer'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887295, job_id='get_keywords')}"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The first thing we need to do is to transform this dataset in a list of phospho `lab.Message`, which is a data format more adapted for what we need to do. "
       ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Run the workload on the messages\n",
-    "results = await workload.async_run(\n",
-    "    messages[:100], # Replace by messages to run on the whole dataset\n",
-    "    executor_type=\"parallel\", # Run the job on every messages in parallel\n",
-    "    max_parallelism=10, # Start at most 10 jobs per second to avoid rate limiting\n",
-    ")\n",
-    "results.get(\"0\") # Get the result for the first message"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Results are stored in the workload, in a dictionary: `message_id -> job_id -> JobResult`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "{'get_keywords': JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'optimization', 'maximumpc', 'advice', 'maximize', 'old computer'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887295, job_id='get_keywords')}"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "workload.results[\"0\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Display results\n",
-    "\n",
-    "Now that we ran the keyword detection on our dataset, let's get the results in a format more adapted for analytics."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>get_keywords</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>[computer performance, tips, computer parts, v...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>[men's magazine, articles, stories, know &amp; tel...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>[glamour magazine, articles, clothes, fashion,...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[Message(id='0', created_at=1393372800, role=None, content=\"I'm old, and so is my computer.  Any advice that can help me maximize my computer perfomance is very welcome.  MaximumPC has some good tips on computer parts, vendors, and usefull tests\", previous_messages=[], metadata={})]"
+            ]
+          },
+          "execution_count": 24,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "                                         get_keywords\n",
-       "0   [computer performance, tips, computer parts, v...\n",
-       "1   [men's magazine, articles, stories, know & tel...\n",
-       "10  [glamour magazine, articles, clothes, fashion,..."
+      "source": [
+        "# Convert every valid row of the df into a lab.Message\n",
+        "messages = lab.Message.from_df(messages_df, content=\"reviewText\", created_at=\"unixReviewTime\", id=\"id\")\n",
+        "messages[:1]"
       ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# In this df, the index is the message_id, and the column is the job_id\n",
-    "results_df = workload.results_df()\n",
-    "results_df.head(3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And join back the outputs with the original dataframe. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>get_keywords</th>\n",
-       "      <th>overall</th>\n",
-       "      <th>verified</th>\n",
-       "      <th>reviewTime</th>\n",
-       "      <th>reviewerID</th>\n",
-       "      <th>asin</th>\n",
-       "      <th>reviewerName</th>\n",
-       "      <th>reviewText</th>\n",
-       "      <th>summary</th>\n",
-       "      <th>unixReviewTime</th>\n",
-       "      <th>vote</th>\n",
-       "      <th>style</th>\n",
-       "      <th>image</th>\n",
-       "      <th>id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>[computer performance, tips, computer parts, v...</td>\n",
-       "      <td>4</td>\n",
-       "      <td>True</td>\n",
-       "      <td>02 26, 2014</td>\n",
-       "      <td>A5QQOOZJOVPSF</td>\n",
-       "      <td>B00005N7P0</td>\n",
-       "      <td>John L. Mehlmauer</td>\n",
-       "      <td>I'm old, and so is my computer.  Any advice th...</td>\n",
-       "      <td>Cheapskates guide</td>\n",
-       "      <td>1393372800</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>[men's magazine, articles, stories, know &amp; tel...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>False</td>\n",
-       "      <td>03 6, 2004</td>\n",
-       "      <td>A5RHZE7B8SV5Q</td>\n",
-       "      <td>B00005N7PS</td>\n",
-       "      <td>gorillazfan249</td>\n",
-       "      <td>There's nothing to say, but if you want a REAL...</td>\n",
-       "      <td>The best mature Men's magazine.</td>\n",
-       "      <td>1078531200</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>[glamour magazine, articles, clothes, fashion,...</td>\n",
-       "      <td>5</td>\n",
-       "      <td>True</td>\n",
-       "      <td>06 12, 2017</td>\n",
-       "      <td>A2VRQ8RNTKY1XT</td>\n",
-       "      <td>B00005N7QC</td>\n",
-       "      <td>Barbara M. Fox</td>\n",
-       "      <td>I love glamour mag. I have read it for over 25...</td>\n",
-       "      <td>Great magazine</td>\n",
-       "      <td>1497225600</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>{'Format:': ' Kindle Edition'}</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>10</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Make API calls to OpenAI\n",
+        "\n",
+        "Let's create a function that takes a message content as an input, and then make a call to OpenAI to get a list of keywords. \n",
+        "\n",
+        "### Step by step\n",
+        "\n",
+        "First, we'll take a message. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Message(id='0', created_at=1393372800, role=None, content=\"I'm old, and so is my computer.  Any advice that can help me maximize my computer perfomance is very welcome.  MaximumPC has some good tips on computer parts, vendors, and usefull tests\", previous_messages=[], metadata={})"
+            ]
+          },
+          "execution_count": 25,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "                                         get_keywords  overall  verified  \\\n",
-       "0   [computer performance, tips, computer parts, v...        4      True   \n",
-       "1   [men's magazine, articles, stories, know & tel...        5     False   \n",
-       "10  [glamour magazine, articles, clothes, fashion,...        5      True   \n",
-       "\n",
-       "     reviewTime      reviewerID        asin       reviewerName  \\\n",
-       "0   02 26, 2014   A5QQOOZJOVPSF  B00005N7P0  John L. Mehlmauer   \n",
-       "1    03 6, 2004   A5RHZE7B8SV5Q  B00005N7PS     gorillazfan249   \n",
-       "10  06 12, 2017  A2VRQ8RNTKY1XT  B00005N7QC     Barbara M. Fox   \n",
-       "\n",
-       "                                           reviewText  \\\n",
-       "0   I'm old, and so is my computer.  Any advice th...   \n",
-       "1   There's nothing to say, but if you want a REAL...   \n",
-       "10  I love glamour mag. I have read it for over 25...   \n",
-       "\n",
-       "                            summary  unixReviewTime  vote  \\\n",
-       "0                 Cheapskates guide      1393372800   NaN   \n",
-       "1   The best mature Men's magazine.      1078531200   3.0   \n",
-       "10                   Great magazine      1497225600   NaN   \n",
-       "\n",
-       "                             style image  id  \n",
-       "0                              NaN   NaN   0  \n",
-       "1                              NaN   NaN   1  \n",
-       "10  {'Format:': ' Kindle Edition'}   NaN  10  "
+      "source": [
+        "message = messages[0]\n",
+        "message"
       ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
-    "augmented_messages_df.head(3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of different keywords extracted: 398\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords\"].explode().nunique())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now have tons of fun with the extracted keywords and do all kind of data analytics. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: title={'center': 'Most common keywords in the dataset'}, xlabel='get_keywords'>"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJlCAYAAAAIImesAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACmRUlEQVR4nOzddVhU6f8+8HvoLglFkbQRuxXFFrsb29VVsddYC921dm1dY22/dreg2NgFtoAidi4iqCjw/P7gx/kwDubinDns/bquuS44czhzM8Mw532eUgkhBIiIiIiIiBRMT+4ARERERERE/xYLGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIgIAuLm5oUGDBnLHkNXhw4ehUqlw+PDhf32szp07w83N7V8f52vI/dq5ubmhc+fOsj0+ERHAwoaIvmD58uVQqVRQqVQ4fvy4xv1CCLi4uEClUv2wE6uHDx9i3LhxuHTp0g85PpESXLt2DePGjUNMTIzcUbKMrr239+zZg3Hjxskdg4i+EwsbIvoqJiYmWLNmjcb2I0eO4P79+zA2Nv5hj/3w4UMEBQXpzMkP0df4+++/cfPmzSw73rVr1xAUFJTtChtdem/v2bMHQUFBcscgou/EwoaIvoq/vz82btyI5ORkte1r1qxBqVKlkDNnTpmSEX09IQTevn2rlccyNDT8oQU/ERGpY2FDRF+lbdu2ePHiBfbv3y9te//+PTZt2oR27dpl+jOJiYkYPHgwXFxcYGxsjAIFCuDPP/+EEEJtv/3796Ny5cqwsbGBhYUFChQogJEjRwJIG/NQpkwZAECXLl2kbnHLly//bN4HDx6gW7ducHZ2hrGxMdzd3dG7d2+8f/9e2uf27dto2bIl7OzsYGZmhvLly2P37t1qx0kfc7FhwwYEBQUhd+7csLS0RIsWLfDq1SskJSVhwIABcHR0hIWFBbp06YKkpCS1Y6hUKvTt2xcbN25E4cKFYWpqigoVKuDy5csAgIULF8LLywsmJiaoVq1aplfkN27ciFKlSsHU1BT29vbo0KEDHjx4oLZP586dYWFhgQcPHqBJkyawsLCAg4MDhgwZgpSUlM8+X5+yYsUKGBgYYOjQodK206dPo27durC2toaZmRmqVq2KsLAw6f5Dhw5BpVJh69atGsdbs2YNVCoVTp48iR07dkClUiEiIkK6f/PmzVCpVGjWrJnazxUqVAitW7eWvk9OTsaECRPg6ekJY2NjuLm5YeTIkRrPffrYk+DgYJQuXRqmpqZYuHAhAOD+/fto0qQJzM3N4ejoiIEDB2r8PABERkaiefPmyJkzJ0xMTJAnTx60adMGr169+uxz9/EYm5iYGKhUKvz5559YtGiRlL1MmTI4e/bsZ4+1fPlytGzZEgDg5+cnvQ8+Hgt0/PhxlC1bFiYmJvDw8MDKlSs1jhUXF4cBAwZI70svLy9MmTIFqampn80ApBWGv/32G/LkyQMzMzP4+fnh6tWrGvu9fPkSQ4YMQdGiRWFhYQErKyvUq1cP4eHh0j5fem8fO3YMLVu2RN68eWFsbAwXFxcMHDhQozB9/PgxunTpgjx58sDY2Bi5cuVC48aNNd5He/fuRZUqVWBubg5LS0vUr19fLXvnzp0xb948AJCyqFSqLz4nRKRDBBHRZyxbtkwAEGfPnhUVK1YUHTt2lO7btm2b0NPTEw8ePBCurq6ifv360n2pqamievXqQqVSie7du4u5c+eKhg0bCgBiwIAB0n5XrlwRRkZGonTp0mLWrFliwYIFYsiQIcLX11cIIcTjx4/F+PHjBQDRs2dPsWrVKrFq1SoRHR39ycwPHjwQzs7OwszMTAwYMEAsWLBAjB49WhQqVEj8888/0nGdnJyEpaWl+PXXX8X06dNFsWLFhJ6entiyZYt0rEOHDgkAonjx4qJChQpi9uzZIjAwUKhUKtGmTRvRrl07Ua9ePTFv3jzRsWNHAUAEBQWp5QEgfHx8hIuLi5g8ebKYPHmysLa2Fnnz5hVz584VhQsXFtOmTROjRo0SRkZGws/PL9PXoEyZMmLGjBli+PDhwtTUVLi5uUm/jxBCdOrUSZiYmIgiRYqIrl27ivnz54vmzZsLAOKvv/764mv98Wu4cOFCoVKpxK+//iptCw0NFUZGRqJChQpi2rRpYsaMGcLHx0cYGRmJ06dPS6+9i4uLaN68ucZj+Pv7C09PTyGEEC9evBAqlUrMmTNHur9///5CT09PODg4SNuePn0qAIi5c+eq/a4ARIsWLcS8efNEQECAACCaNGmi8Tt5eXkJW1tbMXz4cLFgwQJx6NAh8ebNG5E/f35hYmIifvnlFzFz5kxRqlQp4ePjIwCIQ4cOCSGESEpKEu7u7sLZ2Vn89ttvYvHixSIoKEiUKVNGxMTEfPb57NSpk3B1dZW+v3PnjgAgSpQoIby8vMSUKVPE1KlThb29vciTJ494//79J48VHR0tAgMDBQAxcuRI6X3w+PFj6fcsUKCAcHJyEiNHjhRz584VJUuWFCqVSly5ckU6TmJiovDx8RE5cuQQI0eOFAsWLBABAQFCpVKJ/v37f/b3EUKIUaNGCQDC399fzJ07V3Tt2lU4OzsLe3t70alTJ2m/s2fPCk9PTzF8+HCxcOFCMX78eJE7d25hbW0tHjx4IIT48nu7X79+wt/fX0ycOFEsXLhQdOvWTejr64sWLVqoZapYsaKwtrYWo0aNEosXLxYTJ04Ufn5+4siRI9I+K1euFCqVStStW1fMmTNHTJkyRbi5uQkbGxtx584dIYQQJ06cELVq1RIApCyrVq364nNCRLqDhQ0RfVbGwmbu3LnC0tJSvHnzRgghRMuWLaWT8I9Pirdt2yYAiN9++03teC1atBAqlUpERUUJIYSYMWOGACCePXv2yQxnz54VAMSyZcu+KnNAQIDQ09MTZ8+e1bgvNTVVCCHEgAEDBABx7Ngx6b7Xr18Ld3d34ebmJlJSUoQQ/ytsvL291U4827ZtK1QqlahXr57a8StUqKB2MitEWmFjbGwsnUAJkVY0ABA5c+YU8fHx0vYRI0YIANK+79+/F46OjsLb21u8fftW2m/Xrl0CgBgzZoy0Lf1kf/z48WqPX6JECVGqVKnPPWVCCPXXcNasWUKlUokJEyaoPXf58uUTderUkZ5HIYR48+aNcHd3F7Vq1VL7PYyNjUVcXJy07enTp8LAwECMHTtW2lakSBHRqlUr6fuSJUuKli1bCgDi+vXrQgghtmzZIgCI8PBwIYQQly5dEgBE9+7d1fIPGTJEABAHDx5U+50AiH379qntO3PmTAFAbNiwQdqWmJgovLy81AqbixcvCgBi48aNX3z+PvapwiZHjhzi5cuX0vbt27cLAGLnzp2fPd7GjRvVsmWU/nsePXpU2vb06VNhbGwsBg8eLG2bMGGCMDc3F7du3VL7+eHDhwt9fX0RGxv7ycd/+vSpMDIyEvXr11d7/UeOHCkAqBU27969k95DGX9/Y2Njtb/Pz7230//PZDRp0iShUqnE3bt3hRBC/PPPPwKA+OOPPz6Z+/Xr18LGxkb06NFDbfvjx4+FtbW12vY+ffoIXvMlUi52RSOir9aqVSu8ffsWu3btwuvXr7Fr165PdkPbs2cP9PX1ERgYqLZ98ODBEEJg7969AAAbGxsAwPbt27+qK8yXpKamYtu2bWjYsCFKly6tcX9615I9e/agbNmyqFy5snSfhYUFevbsiZiYGFy7dk3t5wICAmBoaCh9X65cOQgh0LVrV7X9ypUrh3v37mmMRapRo4Zat6Ry5coBAJo3bw5LS0uN7bdv3wYAnDt3Dk+fPsXPP/8MExMTab/69eujYMGCGl3nAKBXr15q31epUkU63teYOnUq+vfvjylTpmDUqFHS9kuXLiEyMhLt2rXDixcv8Pz5czx//hyJiYmoUaMGjh49Kr2GAQEBSEpKwqZNm6SfX79+PZKTk9GhQwe1bMeOHQMAvH79GuHh4ejZsyfs7e2l7ceOHYONjQ28vb0BpL12ADBo0CC13IMHDwYAjefE3d0dderUUdu2Z88e5MqVCy1atJC2mZmZoWfPnmr7WVtbAwCCg4Px5s2br3r+vqR169awtbWVvq9SpQoAfNNrlJnChQtLxwIABwcHFChQQO24GzduRJUqVWBrayu9fs+fP0fNmjWRkpKCo0ePfvL4Bw4cwPv379GvXz+1LloDBgzQ2NfY2Bh6emmnGCkpKXjx4oXUzfTChQtf9fuYmppKXycmJuL58+eoWLEihBC4ePGitI+RkREOHz6Mf/75J9Pj7N+/H3FxcWjbtq3a76yvr49y5crh0KFDX5WHiHQfCxsi+moODg6oWbMm1qxZgy1btiAlJUXtxDCju3fvwtnZWe2kHUgbK5F+P5B2klepUiV0794dTk5OaNOmDTZs2PDdRc6zZ88QHx8vnQR/yt27d1GgQAGN7R/nS5c3b16179NPeF1cXDS2p6amaoy/+JafByCdpKXnyCxrwYIFNXKamJjAwcFBbZutre0nT/o+duTIEQwbNgzDhg1TG1cDpI01AYBOnTrBwcFB7bZ48WIkJSVJv3fBggVRpkwZrF69Wvr51atXo3z58vDy8pK2ValSBY8ePUJUVBROnDgBlUqFChUqqBU8x44dQ6VKlaQT5bt370JPT0/tOACQM2dO2NjYaDwn7u7uGr/n3bt34eXlpTGG4uPn2d3dHYMGDcLixYthb2+POnXqYN68eV8cX/M5H/8tpBc5X/safe1x04+d8biRkZHYt2+fxutXs2ZNAMDTp08/efz05zVfvnxq2x0cHNQKNSDtAsOMGTOQL18+GBsbw97eHg4ODoiIiPjq5y42NhadO3eGnZ2dNF6satWqACAdw9jYGFOmTMHevXvh5OQEX19fTJ06FY8fP1b7nQGgevXqGr93SEjIZ39nIlIWA7kDEJGytGvXDj169MDjx49Rr149qcXle5mamuLo0aM4dOgQdu/ejX379mH9+vWoXr06QkJCoK+vnzXB/6VP5fjUdvHRBAn/9ue/1r99vooUKYK4uDisWrUKP/30k1pRkF5s/vHHHyhevHimP29hYSF9HRAQgP79++P+/ftISkrCqVOnMHfuXLX901vMjh49itu3b6NkyZIwNzdHlSpVMHv2bCQkJODixYv4/fffNR7rawd2Z7zy/z2mTZuGzp07Y/v27QgJCUFgYCAmTZqEU6dOIU+ePN98vKx+zb/luKmpqahVqxZ++eWXTPfNnz//v8qQbuLEiRg9ejS6du2KCRMmwM7ODnp6ehgwYMBXXbRISUlBrVq18PLlSwwbNgwFCxaEubk5Hjx4gM6dO6sdY8CAAWjYsCG2bduG4OBgjB49GpMmTcLBgwdRokQJad9Vq1ZlOnujgQFPhYiyC76bieibNG3aFD/99BNOnTqF9evXf3I/V1dXHDhwAK9fv1Zrtblx44Z0fzo9PT3UqFEDNWrUwPTp0zFx4kT8+uuvOHToEGrWrPlNMxM5ODjAysoKV65c+ex+rq6uma4xklk+OaXnuHnzJqpXr652382bN7M8p729PTZt2oTKlSujRo0aOH78OJydnQEAnp6eAAArKyvpCv/ntGnTBoMGDcLatWvx9u1bGBoaqs1sBqS1MuTNmxfHjh3D7du3pa5Uvr6+GDRoEDZu3IiUlBT4+vpKP+Pq6orU1FRERkZKLWwA8OTJE8TFxX3Vc+Lq6oorV65ACKH29/WpdWeKFi2KokWLYtSoUThx4gQqVaqEBQsW4LfffvviY2WVrJihy9PTEwkJCV/1+n0s/XmNjIyEh4eHtP3Zs2carU2bNm2Cn58flixZorY9Li4O9vb20vef+p0uX76MW7duYcWKFQgICJC2Z5yVMSNPT08MHjwYgwcPRmRkJIoXL45p06bh//7v/6S/W0dHxy/+3pwFjUjZ2BWNiL6JhYUF5s+fj3HjxqFhw4af3M/f3x8pKSkaV+hnzJgBlUqFevXqAUibFvZj6a0B6VPvmpubA0g7KfoSPT09NGnSBDt37sS5c+c07k+/eu3v748zZ87g5MmT0n2JiYlYtGgR3NzcULhw4S8+ljaULl0ajo6OWLBggdpUxHv37sX169dRv379LH/MPHny4MCBA3j79i1q1aqFFy9eAABKlSoFT09P/Pnnn0hISND4uWfPnql9b29vj3r16uH//u//sHr1atStW1ftpDZdlSpVcPDgQZw5c0YqbIoXLw5LS0tMnjwZpqamKFWqlLS/v78/AGDmzJlqx5k+fToAfNVz4u/vj4cPH6qNAXrz5g0WLVqktl98fLzGeKmiRYtCT08v06mhf6RveR98SqtWrXDy5EkEBwdr3BcXF6fxu2ZUs2ZNGBoaYs6cOWqtQB+/DkBa69HHLVAbN27UmKL8U79TeutTxmMIITBr1iy1/d68eYN3796pbfP09ISlpaX0+tSpUwdWVlaYOHEiPnz4oJE1499tVjzHRCQfttgQ0Tfr1KnTF/dp2LAh/Pz88OuvvyImJgbFihVDSEgItm/fjgEDBkhXUcePH4+jR4+ifv36cHV1xdOnT/HXX38hT548UjclT09P2NjYYMGCBbC0tIS5uTnKlSuX6dgJIK0bTEhICKpWrYqePXuiUKFCePToETZu3Ijjx4/DxsYGw4cPx9q1a1GvXj0EBgbCzs4OK1aswJ07d7B582ZpPIfcDA0NMWXKFHTp0gVVq1ZF27Zt8eTJE8yaNQtubm4YOHDgD3lcLy8vhISEoFq1aqhTpw4OHjwIKysrLF68GPXq1UORIkXQpUsX5M6dGw8ePMChQ4dgZWWFnTt3qh0nICBAGoc1YcKETB+rSpUqWL16NVQqlfSa6+vro2LFiggODka1atVgZGQk7V+sWDF06tQJixYtQlxcHKpWrYozZ85gxYoVaNKkCfz8/L74+/Xo0QNz585FQEAAzp8/j1y5cmHVqlUwMzNT2+/gwYPo27cvWrZsifz58yM5ORmrVq2Cvr4+mjdv/k3P6b9VvHhx6OvrY8qUKXj16hWMjY1RvXp1ODo6fvUxhg4dih07dqBBgwbo3LkzSpUqhcTERFy+fBmbNm1CTExMpsUnAGlNpEmTJqFBgwbw9/fHxYsXsXfvXo2fadCgAcaPH48uXbqgYsWKuHz5MlavXq3W0gN8+r1dsGBBeHp6YsiQIXjw4AGsrKywefNmjZahW7duoUaNGmjVqhUKFy4MAwMDbN26FU+ePEGbNm0ApLUwzp8/Hx07dkTJkiXRpk0bODg4IDY2Frt370alSpWkCzDpBXRgYCDq1KkDfX196ThEpACyzMVGRIqRcbrnz/l4umch0qZZHThwoHB2dhaGhoYiX7584o8//lCbKjY0NFQ0btxYODs7CyMjI+Hs7Czatm2rMR3t9u3bReHChYWBgcFXTf189+5dERAQIBwcHISxsbHw8PAQffr0EUlJSdI+0dHRokWLFsLGxkaYmJiIsmXLil27dqkdJ32654+n+/3U8zJ27FiN6asBiD59+qjtlz7178fT1H7q8davXy9KlCghjI2NhZ2dnWjfvr24f/++2j6dOnUS5ubmGs9FeqYvyew1PH36tLC0tBS+vr7S9LsXL14UzZo1Ezly5BDGxsbC1dVVtGrVSoSGhmocMykpSdja2gpra2u16aozunr1qgAgChUqpLb9t99+EwDE6NGjNX7mw4cPIigoSLi7uwtDQ0Ph4uIiRowYId69e/fF3ynd3bt3RaNGjYSZmZmwt7cX/fv3F/v27VObUvn27duia9euwtPTU5iYmAg7Ozvh5+cnDhw4kPmTmMGnpnvObGpiAGrTYH/K33//LTw8PIS+vr5azk/9nlWrVhVVq1ZV2/b69WsxYsQI4eXlJYyMjIS9vb2oWLGi+PPPPz+7lo4QQqSkpIigoCCRK1cuYWpqKqpVqyauXLkiXF1dNaZ7Hjx4sLRfpUqVxMmTJzPN86n39rVr10TNmjWFhYWFsLe3Fz169BDh4eFq+zx//lz06dNHFCxYUJibmwtra2tRrlw5tWm80x06dEjUqVNHWFtbCxMTE+Hp6Sk6d+4szp07J+2TnJws+vXrJxwcHIRKpeLUz0QKoxLiX45WJCIi+oTk5GQ4OzujYcOGGuMtiIiIspJu9LUgIqJsadu2bXj27JnaAHAiIqIfgS02RESU5U6fPo2IiAhMmDAB9vb2X70oIxER0fdiiw0REWW5+fPno3fv3nB0dMTKlSvljkNERP8BbLEhIiIiIiLFY4sNEREREREpns6tY5OamoqHDx/C0tKSKwATEREREf2HCSHw+vVrODs7f3mNuW+ZG3rixImidOnSwsLCQjg4OIjGjRuLGzduqO1TtWpVAUDt9tNPP331Y9y7d0/j53njjTfeeOONN9544423/+7t3r17X6wjvqnF5siRI+jTpw/KlCmD5ORkjBw5ErVr18a1a9dgbm4u7dejRw+MHz9e+v7jlZw/x9LSEgBw7949WFlZfUs8IiIiIiLKRuLj4+Hi4iLVCJ/zTYXNvn371L5fvnw5HB0dcf78efj6+krbzczMkDNnzm85tCS9+5mVlRULGyIiIiIi+qohKv9q8oBXr14BAOzs7NS2r169Gvb29vD29saIESPw5s2bTx4jKSkJ8fHxajciIiIiIqJv8d2TB6SmpmLAgAGoVKkSvL29pe3t2rWDq6srnJ2dERERgWHDhuHmzZvYsmVLpseZNGkSgoKCvjcGERERERHR969j07t3b+zduxfHjx9Hnjx5PrnfwYMHUaNGDURFRcHT01Pj/qSkJCQlJUnfp/eje/XqFbuiERERERH9h8XHx8Pa2vqraoPvarHp27cvdu3ahaNHj362qAGAcuXKAcAnCxtjY2MYGxt/TwwiIiIiIiIA31jYCCHQr18/bN26FYcPH4a7u/sXf+bSpUsAgFy5cn1XQCIiIiIioi/5psKmT58+WLNmDbZv3w5LS0s8fvwYAGBtbQ1TU1NER0djzZo18Pf3R44cORAREYGBAwfC19cXPj4+P+QXICIiIiIi+qYxNp+aZm3ZsmXo3Lkz7t27hw4dOuDKlStITEyEi4sLmjZtilGjRn31eJlv6UdHRERERETZ1w8bY/OlGsjFxQVHjhz5lkMSERERERH9a/9qHRsiIiIiIiJdwMKGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixfumBTp1jdvw3Vl2rJjJ9bPsWEREREREpF1ssSEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHifVNhM2nSJJQpUwaWlpZwdHREkyZNcPPmTbV93r17hz59+iBHjhywsLBA8+bN8eTJkywNTURERERElNE3FTZHjhxBnz59cOrUKezfvx8fPnxA7dq1kZiYKO0zcOBA7Ny5Exs3bsSRI0fw8OFDNGvWLMuDExERERERpTP4lp337dun9v3y5cvh6OiI8+fPw9fXF69evcKSJUuwZs0aVK9eHQCwbNkyFCpUCKdOnUL58uWzLjkREREREdH/96/G2Lx69QoAYGdnBwA4f/48Pnz4gJo1a0r7FCxYEHnz5sXJkyczPUZSUhLi4+PVbkRERERERN/iuwub1NRUDBgwAJUqVYK3tzcA4PHjxzAyMoKNjY3avk5OTnj8+HGmx5k0aRKsra2lm4uLy/dGIiIiIiKi/6jvLmz69OmDK1euYN26df8qwIgRI/Dq1Svpdu/evX91PCIiIiIi+u/5pjE26fr27Ytdu3bh6NGjyJMnj7Q9Z86ceP/+PeLi4tRabZ48eYKcOXNmeixjY2MYGxt/TwwiIiIiIiIA39hiI4RA3759sXXrVhw8eBDu7u5q95cqVQqGhoYIDQ2Vtt28eROxsbGoUKFC1iQmIiIiIiL6yDe12PTp0wdr1qzB9u3bYWlpKY2bsba2hqmpKaytrdGtWzcMGjQIdnZ2sLKyQr9+/VChQgXOiEZERERERD/MNxU28+fPBwBUq1ZNbfuyZcvQuXNnAMCMGTOgp6eH5s2bIykpCXXq1MFff/2VJWGJiIiIiIgy802FjRDii/uYmJhg3rx5mDdv3neHIiIiIiIi+hb/ah0bIiIiIiIiXcDChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgU75sLm6NHj6Jhw4ZwdnaGSqXCtm3b1O7v3LkzVCqV2q1u3bpZlZeIiIiIiEjDNxc2iYmJKFasGObNm/fJferWrYtHjx5Jt7Vr1/6rkERERERERJ9j8K0/UK9ePdSrV++z+xgbGyNnzpxfdbykpCQkJSVJ38fHx39rJCIiIiIi+o/7IWNsDh8+DEdHRxQoUAC9e/fGixcvPrnvpEmTYG1tLd1cXFx+RCQiIiIiIsrGsrywqVu3LlauXInQ0FBMmTIFR44cQb169ZCSkpLp/iNGjMCrV6+k271797I6EhERERERZXPf3BXtS9q0aSN9XbRoUfj4+MDT0xOHDx9GjRo1NPY3NjaGsbFxVscgIiIiIqL/kB8+3bOHhwfs7e0RFRX1ox+KiIiIiIj+o354YXP//n28ePECuXLl+tEPRURERERE/1Hf3BUtISFBrfXlzp07uHTpEuzs7GBnZ4egoCA0b94cOXPmRHR0NH755Rd4eXmhTp06WRqciIiIiIgo3TcXNufOnYOfn5/0/aBBgwAAnTp1wvz58xEREYEVK1YgLi4Ozs7OqF27NiZMmMBxNERERERE9MN8c2FTrVo1CCE+eX9wcPC/CkRERERERPStfvgYGyIiIiIioh+NhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFO+bC5ujR4+iYcOGcHZ2hkqlwrZt29TuF0JgzJgxyJUrF0xNTVGzZk1ERkZmVV4iIiIiIiIN31zYJCYmolixYpg3b16m90+dOhWzZ8/GggULcPr0aZibm6NOnTp49+7dvw5LRERERESUGYNv/YF69eqhXr16md4nhMDMmTMxatQoNG7cGACwcuVKODk5Ydu2bWjTps2/S0tERERERJSJLB1jc+fOHTx+/Bg1a9aUtllbW6NcuXI4efJkpj+TlJSE+Ph4tRsREREREdG3yNLC5vHjxwAAJycnte1OTk7SfR+bNGkSrK2tpZuLi0tWRiIiIiIiov8A2WdFGzFiBF69eiXd7t27J3ckIiIiIiJSmCwtbHLmzAkAePLkidr2J0+eSPd9zNjYGFZWVmo3IiIiIiKib5GlhY27uzty5syJ0NBQaVt8fDxOnz6NChUqZOVDERERERERSb55VrSEhARERUVJ39+5cweXLl2CnZ0d8ubNiwEDBuC3335Dvnz54O7ujtGjR8PZ2RlNmjTJytxERERERESSby5szp07Bz8/P+n7QYMGAQA6deqE5cuX45dffkFiYiJ69uyJuLg4VK5cGfv27YOJiUnWpSYiIiIiIspAJYQQcofIKD4+HtbW1nj16tUXx9u4Dd+dZY8bM7l+lh2LiIiIiIj+vW+pDWSfFY2IiIiIiOjfYmFDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4hnIHSC74uKhRERERETawxYbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIpnIHcA0j634buz7Fgxk+tn2bGIiIiIiL4XW2yIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpnoHcAYjSuQ3fnaXHi5lcP8uOlZXZsjIXoNvZiIiIiLSFLTZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8bK8sBk3bhxUKpXarWDBgln9MERERERERBKDH3HQIkWK4MCBA/97EIMf8jBEREREREQAflBhY2BggJw5c/6IQxMREREREWn4IWNsIiMj4ezsDA8PD7Rv3x6xsbGf3DcpKQnx8fFqNyIiIiIiom+R5S025cqVw/Lly1GgQAE8evQIQUFBqFKlCq5cuQJLS0uN/SdNmoSgoKCsjkFEOsBt+O4sO1bM5PpZdqyszAXobraszAUwGxER6bYsb7GpV68eWrZsCR8fH9SpUwd79uxBXFwcNmzYkOn+I0aMwKtXr6TbvXv3sjoSERERERFlcz98VL+NjQ3y58+PqKioTO83NjaGsbHxj45BRERERETZ2A9fxyYhIQHR0dHIlSvXj34oIiIiIiL6j8rywmbIkCE4cuQIYmJicOLECTRt2hT6+vpo27ZtVj8UERERERERgB/QFe3+/fto27YtXrx4AQcHB1SuXBmnTp2Cg4NDVj8UERERERERgB9Q2Kxbty6rD0lERERERPRZP3yMDRERERER0Y/GwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFy/IFOomIiCiN2/DdWXq8mMn1s+xYWZktK3MBzPY9dPlvjUhb2GJDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeIZyB2AiIiIiLIvt+G7s+xYMZPrZ9mxAGb7HlmZC8jabGyxISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLF+2GFzbx58+Dm5gYTExOUK1cOZ86c+VEPRURERERE/3E/pLBZv349Bg0ahLFjx+LChQsoVqwY6tSpg6dPn/6IhyMiIiIiov84gx9x0OnTp6NHjx7o0qULAGDBggXYvXs3li5diuHDh6vtm5SUhKSkJOn7V69eAQDi4+O/+DipSW+yLPPXPN63YLZvl5W5AN3N9l95PQHdzca/te/DbN+Of2vfh9m+Hf/Wvg+zfTtt/62l3y+E+OKxVOJr9voG79+/h5mZGTZt2oQmTZpI2zt16oS4uDhs375dbf9x48YhKCgoKyMQEREREVE2cu/ePeTJk+ez+2R5i83z58+RkpICJycnte1OTk64ceOGxv4jRozAoEGDpO9TU1Px8uVL5MiRAyqV6l/niY+Ph4uLC+7duwcrK6t/fbysoqu5AGb7XrqaTVdzAcz2vXQ1m67mApjte+lqNl3NBTDb99LVbLqaC/jvZBNC4PXr13B2dv7ivj+kK9q3MDY2hrGxsdo2GxubLH8cKysrnXvRAd3NBTDb99LVbLqaC2C276Wr2XQ1F8Bs30tXs+lqLoDZvpeuZtPVXMB/I5u1tfVX7ZflkwfY29tDX18fT548Udv+5MkT5MyZM6sfjoiIiIiIKOsLGyMjI5QqVQqhoaHSttTUVISGhqJChQpZ/XBEREREREQ/pivaoEGD0KlTJ5QuXRply5bFzJkzkZiYKM2Spk3GxsYYO3asRnc3uelqLoDZvpeuZtPVXACzfS9dzaaruQBm+166mk1XcwHM9r10NZuu5gKYLTNZPitaurlz5+KPP/7A48ePUbx4ccyePRvlypX7EQ9FRERERET/cT+ssCEiIiIiItKWLB9jQ0REREREpG0sbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNE9P/FxcVh8eLFGDFiBF6+fAkAuHDhAh48eCBrrqNHjyI5OVlje3JyMo4ePSpDIuDDhw/w9PTE9evXZXl8Il0SHR2NUaNGoW3btnj69CkAYO/evbh69arMyYj+W1jYyCglJQWXLl3CP//8I3cUov+8iIgI5M+fH1OmTMGff/6JuLg4AMCWLVswYsQIWbP5+flJhVZGr169gp+fnwyJAENDQ7x7906Wx/5aFy5cwOXLl6Xvt2/fjiZNmmDkyJF4//69bLmePHmCjh07wtnZGQYGBtDX11e7yUlXnzNdduTIERQtWhSnT5/Gli1bkJCQAAAIDw/H2LFjZU5H2U316tWlz6eM4uPjUb16de0H+khUVBSCg4Px9u1bAIC2J1/OttM9Jycn4/Dhw4iOjka7du1gaWmJhw8fwsrKChYWFrJkGjBgAIoWLYpu3bohJSUFVatWxYkTJ2BmZoZdu3ahWrVqsuRKFxkZiUOHDuHp06dITU1Vu2/MmDEypUo7CRgyZAhCQ0Px9OlTjTdJSkqKTMk0xcfH4+DBgyhQoAAKFSokdxxF0JXnrGbNmihZsiSmTp0KS0tLhIeHw8PDAydOnEC7du0QExMjWzY9PT08efIEDg4Oattv3bqF0qVLIz4+XpZcEydOxK1bt7B48WIYGPyQ9Z7/lTJlymD48OFo3rw5bt++jSJFiqBp06Y4e/Ys6tevj5kzZ8qSq169eoiNjUXfvn2RK1cuqFQqtfsbN24sSy5Ad5+zjHTt871ChQpo2bIlBg0apPa/48yZM2jWrBnu37+v9UxfEhcXBxsbG7lj6LzU1FRERUVlel7k6+srSyY9PT08fvwYjo6OatufPn2K3Llz48OHD7LkevHiBVq3bo2DBw9CpVIhMjISHh4e6Nq1K2xtbTFt2jSt5NC9T6IscPfuXdStWxexsbFISkpCrVq1YGlpiSlTpiApKQkLFiyQJdemTZvQoUMHAMDOnTtx584d3LhxA6tWrcKvv/6KsLAwWXIBwN9//43evXvD3t4eOXPmVPugValUshY2nTt3RmxsLEaPHp3pSYCcWrVqBV9fX/Tt2xdv375F6dKlERMTAyEE1q1bh+bNm8uab9WqVViwYAHu3LmDkydPwtXVFTNnzoS7u7tsJ0+6+pydPXsWCxcu1NieO3duPH78WIZEQLNmzQCkvQc7d+6stoJzSkoKIiIiULFiRVmyAWnPWWhoKEJCQlC0aFGYm5ur3b9lyxaZkqW5desWihcvDgDYuHEjfH19sWbNGoSFhaFNmzaynaQfP34cx44dk7LpEl19ztLp4uf75cuXsWbNGo3tjo6OeP78udbzfGzKlClwc3ND69atAaT9D968eTNy5syJPXv2oFixYrJla9q0aaaf6SqVCiYmJvDy8kK7du1QoEABrWc7deoU2rVrh7t372pcUFWpVFq/qBoRESF9fe3aNbXPpZSUFOzbtw+5c+fWaqaMBg4cCAMDA8TGxqpdpGzdujUGDRrEwubf6N+/P0qXLo3w8HDkyJFD2t60aVP06NFDtlzPnz9Hzpw5AQB79uxBy5YtkT9/fnTt2hWzZs2SLRcA/Pbbb/j9998xbNgwWXNkRpdPAo4ePYpff/0VALB161YIIRAXF4cVK1bgt99+k7WwmT9/PsaMGYMBAwbg999/l/4J29jYYObMmbIVNrr6nBkbG2fa8nHr1i2NlhJtsba2BpDWlG9paQlTU1PpPiMjI5QvX17W/2k2NjayF++fI4SQrrIeOHAADRo0AAC4uLjIesLp4uKi9e4ZX0tXn7N0uvj5bmNjg0ePHsHd3V1t+8WLF2U90Uy3YMECrF69GgCwf/9+7N+/H3v37sWGDRswdOhQhISEyJbN2toa27Ztg42NDUqVKgUgrTtkXFwcateujfXr12PKlCkIDQ1FpUqVtJqtV69eKF26NHbv3q0TF1WLFy8OlUoFlUqVaZczU1NTzJkzR4ZkaUJCQhAcHIw8efKobc+XLx/u3r2rvSAiG7KzsxM3btwQQghhYWEhoqOjhRBC3LlzR5iamsqWK2/evCI4OFgkJycLFxcXsWvXLiGEEFeuXBE2Njay5RJCCEtLS+l50jWFChUSFy5ckDtGpkxMTERsbKwQQoiOHTuKYcOGCSGEuHv3rjA3N5czmihUqJDYunWrEEL9fXD58mWRI0cO2XLp6nPWrVs30aRJE/H+/XthYWEhbt++Le7evStKlCgh+vfvL1suIYQYN26cSEhIkDWDEvn5+YmAgACxcuVKYWhoKCIjI4UQQhw+fFi4urrKlis4OFjUrl1b3LlzR7YMn6Krz1k6Xfx8Hzx4sKhcubJ49OiRsLS0FJGRkeL48ePCw8NDjBs3TpZMGWX8nxsYGCh69uwphBDi5s2bsp97DBs2TPTu3VukpKRI21JSUkTfvn3FiBEjRGpqqujZs6eoVKmS1rOZmZlJf/+6ICYmRty5c0eoVCpx9uxZERMTI90ePnwokpOTZc1nYWEhbt26JX2d/t48e/assLOz01qObFnY2NjYiKtXrwoh1J/cY8eOCUdHR9lyjR07VlhbW4uCBQuKvHnzinfv3gkhhFiyZIkoX768bLmEEKJr165i/vz5smb4FF0+CciXL59Yv369SEhIEA4ODiI0NFQIIcSlS5dkLR6ESPswi4mJEUKovw9u3bolTExMZMulq89ZXFycqFmzprCxsRH6+vrCxcVFGBoaCl9fXxYVX/D06VNx7NgxcezYMfH06VO540guXbokvL29hZWVldoJZt++fUXbtm1ly2VjYyOMjIyEnp6esLCwELa2tmo3OYWHh+vkc5ZOFz/fk5KSRPfu3YWBgYFQqVTC0NBQ6OnpiQ4dOsh+simEELly5RJhYWFCCCHy588vNmzYIIQQ4saNG8LS0lLOaMLe3l7cvHlTY/vNmzelz4OIiAhhbW2t5WRpRf7evXu1/rhKVa9ePTFq1CghhJAuDqakpIiWLVuK5s2bay1HtuyKVrt2bcycOROLFi0CkNYXMiEhAWPHjoW/v79sucaNGwdvb2/cu3cPLVu2lPrL6+vrY/jw4bLlAgAvLy+MHj0ap06dQtGiRWFoaKh2f2BgoEzJ0vpnvnnzBp6enjAzM9PIltlsUdoyYMAAtG/fHhYWFsibN680AcTRo0dRtGhR2XIBgLu7Oy5dugRXV1e17fv27ZN1kH7G58zV1VVnnjNra2vs378fYWFhCA8PR0JCAkqWLImaNWvKlimdrk6gkZiYiH79+mHlypVS9yV9fX0EBARgzpw5MDMzkyVXumLFiqnN8JXujz/+kHWyA7nHqXyOj4/PJ58zuWdsA3Tz893IyAh///03Ro8ejStXriAhIQElSpRAvnz5ZMnzsWbNmqFdu3bIly8fXrx4gXr16gFI6yrn5eUla7bk5GTcuHED+fPnV9t+48YN6f+aiYmJLN3A+vXrh8GDB+Px48eZnhf5+PhoPVM6XZzsaerUqahRowbOnTuH9+/f45dffsHVq1fx8uVLrY4hz5azot2/fx916tSBEAKRkZEoXbo0IiMjYW9vj6NHj2rMJCGHd+/ewcTERO4Yko/7BmekUqlw+/ZtLaZRt2LFis/e36lTJy0lydy5c+dw79491KpVS5qRZ/fu3bCxsdF6n+CMFi9ejHHjxmHatGno1q0bFi9ejOjoaEyaNAmLFy9GmzZtZMt2/vx5xMbG6txzpqt0dRatn376CQcOHMDcuXOl1+348eMIDAxErVq1MH/+fFlypfPw8MDZs2fVxmIAaTNClSxZUtb/a7ru3Llz0hpFhQoVQunSpWVOlEYJn++65sOHD5g1axbu3buHzp07o0SJEgCAGTNmwNLSEt27d5ctW2BgINauXYuRI0eiTJkyANImJZk4cSLatWuHWbNmYfHixVi+fDmOHz+u1Wx6eporoqhUKgghZJk8IN2XJnu6cOGCLLmAtCUI5s6dq3ZxsE+fPsiVK5fWMmTLwgZIuwqwbt06RERESE9u+/bt1QbfaltKSgomTpyIBQsW4MmTJ7h16xY8PDwwevRouLm5oVu3brJlo3/n/fv3uHPnDjw9PXVq2tvVq1dj3LhxiI6OBgA4OzsjKCiIf2uZCAwMhJeXl0br5Ny5cxEVFSXrVXZLS0udnEDD3t4emzZt0piq/tChQ2jVqhWePXsmT7D/71PToj558gQuLi6yrsuSkpKCbdu2ScVDkSJF0KhRI9lbRe7fv4+2bdsiLCxMmg44Li4OFStWxLp16zQGBstB1z7fU1JSsHz5cqlF9eMr6AcPHpQllxKkpKRg8uTJmDt3Lp48eQIAcHJyQr9+/TBs2DDo6+sjNjYWenp6Wv/b+9KA9497Q2iLq6srfv75Z52b7Ck2NhYuLi6Ztq7FxsYib968WsmRbQsbXTR+/HisWLEC48ePR48ePXDlyhV4eHhg/fr1mDlzJk6ePCl3RAD/W0xJ7hlAMtLVk4A3b96gX79+UqtSerHar18/5M6dW/YuhunevHmDhIQEnbmaef/+fezYsQOxsbEaJ5fTp0+XJVPu3LmxY8cOaWaedBcuXECjRo1kXYuicOHCWL16tXSlVVeYmZnh/PnzGl0br169irJlyyIxMVGWXDt27AAANGnSBCtWrJBmlwPS/peEhoZi//79uHnzpiz5oqKi4O/vjwcPHkjT2N68eRMuLi7YvXs3PD09ZckFAHXr1pVmKcyYrUuXLrCyssK+fftkywboXm8HAOjbty+WL1+O+vXrZ9qiOmPGDJmS/c+qVauwcOFC3L59W2em/v9Y+qyUVlZWMifRbVZWVrh06RI8PDzkjqJGX18fjx490jjPePHiBRwdHbXXwqW10TxaduvWLbFw4UIxYcIEERQUpHaTi6enpzhw4IAQQn3Q4/Xr12WfmUQIIVasWCG8vb2FsbGxMDY2FkWLFhUrV66UO5aIjIwU+fLlE2ZmZqJEiRKiRIkSwszMTBQoUEBERUXJmi0wMFCUKlVKHDt2TJibm0uv6bZt20Tx4sVlzXb79m1phpKMbt26JetEDAcOHBBmZmbC29tbGBgYiOLFiwsbGxthbW0t/Pz8ZMtlbGyc6Qw4kZGRwtjYWIZE/6OrE2hUr15dtGzZUrx9+1ba9ubNG9GyZUtRo0YN2XKpVCqhUqmEnp6e9HX6zcjISOTPn1/s3LlTtnz16tUTdevWFS9evJC2PX/+XNStW1f4+/vLlkuItElHMpuF8ty5c7LOKprO0tJSBAQEiJCQELWZtOSUI0cOsXv3brljfNJff/0l7O3txW+//SZMTU2lz6lly5aJatWqyZxOt0VFRYm+ffuKGjVqiBo1aoh+/frJft6hq5M9qVSqTCePiYmJEWZmZlrLoTt9ZrKQri42+eDBg0wH6qWmpsq2Umy66dOnY/To0ejbt69aX/levXrh+fPnGDhwoGzZAgMD4enpiVOnTsHOzg5A2hWADh06IDAwELt375Yt27Zt27B+/XqUL19e7e+sSJEiUvcvuXTu3Bldu3bVGMB6+vRpLF68GIcPH5Yl14gRIzBkyBAEBQXB0tISmzdvhqOjI9q3b4+6devKkglIm0Bj37596Nu3r9r2vXv3yn5lTFcn0Jg1axbq1KmDPHnySIv8hYeHw8TEBMHBwbJkAiB1BXJ3d8fZs2dhb28vW5bMHDlyRO3/GQDkyJEDkydPln2MmYuLS6afRykpKXB2dpYhkboVK1ZgzZo1aNy4MaytrdG6dWt06NBB1jFARkZGsg/C/5w5c+bg77//RpMmTTB58mRpe+nSpTFkyBAZk+nuxCgAEBwcjEaNGqF48eLS+zIsLAxFihTBzp07UatWLVly6dpkT4MGDQKQdn49evRotUljUlJScPr0aa12o86WhY2uLjZZuHBhHDt2TKNf5qZNm2TvYjJnzhzMnz8fAQEB0rZGjRqhSJEiGDdunKyFjS6fBDx79izT7l2JiYmyd+W7ePFips9P+fLlNU7eten69etYu3YtAMDAwABv376FhYUFxo8fj8aNG6N3796y5Bo0aBD69u2LZ8+eSYufhYaGYtq0abLPYiX343+Kt7c3IiMjsXr1aty4cQMA0LZtW9nHM6a7c+eO3BEyZWxsjNevX2tsT0hIgJGRkQyJ/uePP/5Av379MG/ePKlYOHfuHPr3748///xT1mxA2kKcTZs2xevXr7Fp0yasXbsW5cuXh4eHBzp06CDLhcvBgwdj1qxZmDt3ruz/9zNz586dTM8xjI2NZesumq5z586IjY3F6NGjdWIRzIyGDx+OgQMHqhWD6duHDRsmW2GzaNEiWFhY4MiRIzhy5IjafSqVSuuFzcWLFwGkDWO4fPmy2v8wIyMjFCtWTLsFtNbahrRIVxeb3LZtm7C2thaTJ08WZmZm4o8//hDdu3cXRkZGIiQkRNZsn+qGc+vWLdm74dja2kpz8Gd0/Phx2dd8qFKlipg9e7YQ4n/ztguRtuZDnTp15IwmrKysPtmlxMLCQoZEaZycnMS1a9eEEGmLiG7fvl0IkbbmiNyLmv71118id+7cUrcld3d3sWLFClkz0b9z4MABMWLECNGtWzfRpUsXtZtcOnbsKIoUKSJOnTolUlNTRWpqqjh58qTw9vYWnTp1ki2XEOpr7BgZGal9rUvr7WR09epVUbx4caGnpyfL4zdp0kRYW1sLd3d30aBBA9G0aVO1m9wKFSoktm3bJoRQ7wY/e/ZsUaJECTmjCQsLC3Hx4kVZM3yKsbFxpt25b968Kft5kS7q3LmzePXqldwxsmdXtJYtWyIkJAS9evWSO4qaxo0bY+fOnRg/fjzMzc0xZswYlCxZUtYmzXReXl7YsGEDRo4cqbZ9/fr1ss/F36BBA/Ts2RNLlixB2bJlAaR1p+rVqxcaNWoka7aJEyeiXr16uHbtGpKTkzFr1ixcu3YNJ06c0LiSom2+vr6YNGkS1q5dK02ykJKSgkmTJqFy5cqy5SpfvjyOHz+OQoUKwd/fH4MHD8bly5exZcsWlC9fXrZcANC7d2/07t0bz549g6mpqTQVtS6Ijo7GsmXLEB0djVmzZsHR0RF79+5F3rx5UaRIEVkyTZo0CU5OTujatava9qVLl+LZs2eyt5oHBQVh/PjxKF26tE5dDZ49ezY6deqEChUqSN1IkpOT0ahRI8yaNUvWbLraOvixd+/eYceOHVizZg327dsHJycnDB06VJYsNjY2aNq0qSyP/TUGDRqEPn364N27dxBC4MyZM1i7dq009b+cXFxcNLqf6QoHBwdcunRJ4xzo0qVLOjERj67Nxrps2TK5IwDIprOiTZo0CdOnT0f9+vV1ov+hEmzevBmtW7dGzZo11fqShoaGYsOGDbL+046Li0OnTp2wc+dOjZOA5cuXq814JIfo6GhMnjxZbd72YcOGyb5A57Vr1+Dr6wsbGxtUqVIFAHDs2DHEx8fj4MGD8Pb2liXX7du3kZCQAB8fHyQmJmLw4ME4ceIE8uXLh+nTp8s2haYuO3LkCOrVq4dKlSrh6NGjuH79Ojw8PDB58mScO3cOmzZtkiWXm5sb1qxZg4oVK6ptP336NNq0aSN7V7BcuXJh6tSp6Nixo6w5PiUyMlLqwleoUCGdHqehK4KDg7FmzRps27YNBgYGaNGiBdq3bw9fX1+5o+k0XZ36PyQkBNOmTcPChQvh5uYma5aPjR8/HjNmzMDw4cOl/3FhYWGYMmUKBg0ahNGjR8uSS5dmY23WrBmWL18OKysrNGvW7LP7btmyRSuZsmVho8uLTeqy8+fPY8aMGWqLsg0ePFj28T/peBLw7R4+fCgtlmVqagofHx/07dtXbbzSf1nJkiURGhoKW1tblChR4rNX9OVc9KxChQpo2bIlBg0aBEtLS4SHh8PDwwNnzpxBs2bNZJuK2sTEBNevX9f4n3v79m0ULlwY7969kyVXuhw5cuDMmTOyTp+sBPHx8dIUu+lT7n6K3FPxmpmZoUGDBmjfvj38/f01LlySuuTkZKxZswZ16tSBk5OTzk39b2trizdv3iA5OVmnJkYB0saMzJw5E9OmTcPDhw8BpBWEQ4cORWBgoGwtwP3790dYWBhmzpyJunXrIiIiAh4eHti+fTvGjRsnjXnRhi5dumD27NmwtLREly5dPruvtlp0smVho0tsbW2/+o9fzjcwfb+UlBRs3bpVKggLFy6Mxo0b60TTsK6Ki4vDpk2bEB0djaFDh8LOzg4XLlyAk5MTcufOrbUcQUFBGDp0KMzMzDBu3LjPvlfHjh2rtVwfs7CwwOXLl+Hu7q5W2MTExKBgwYKyFRD58uXD2LFj0aFDB7Xtq1atwtixY2W/iDRs2DBYWFjIdmU1o0GDBmHChAkwNzeXZhH6FG2v5ZRx/Qk9Pb1M3wdC5tXW071+/RqWlpayZgCUc1EESCsGr1+/rpOt4emtDp/SqVMnLSX5vPTJPnThb8/V1VWajTXj50FUVBRKliz5xYsTP4IQAvfu3YODg4PsE8fwzOsH0+X+yrp8lU6XTwIyunr1Kho1aoTHjx9Li9lNmTIFDg4O2Llzp9a7e0VERMDb2xt6enqIiIj47L4+Pj5aSqUuIiICNWvWhLW1NWJiYtCjRw/Y2dlhy5YtiI2NxcqVK7WWJWOxMm7cOK097reysbHBo0ePNFpGLl68qNVC8GM9evTAgAED8OHDB7WZ5H755RcMHjxYtlzp3r17h0WLFuHAgQPw8fHRuBqszf8dFy9elKZR1uYV1a9x8OBBqRV32bJlcHFx0Vj8ODU1FbGxsXLEU2NpaamxYHP6xSRtLtjcuHFjGBsbS1/ryvitzJQtWxYXL17UycJGVwqXL9GFgiadLs7GKoSAl5cXrl69Kvu47GzTYqOUE2FdostX6fz8/LB161bY2NjAz8/vs/seOnRIS6k0VahQAQ4ODlixYgVsbW0BAP/88w86d+6MZ8+e4cSJE1rNo6enh8ePH6u9ppm9xeW88lqzZk2ULFkSU6dOVbvadOLECbRr1w4xMTGy5OrevTs6dOiAatWqyfL4nzNkyBCcPn0aGzduRP78+XHhwgU8efIEAQEBCAgIkK01SQiB4cOHY/bs2Xj//j2AtO5pw4YNk229sIw+979DpVLh4MGDWkyjDDqzevgnREVFwd/fHw8ePJAuJt28eRMuLi7YvXs3ux1mYsOGDRgxYgQGDhyIUqVKwdzcXO1+bV/k0uWLqkpoifP19UXLli3Rr18/WFpaIiIiAu7u7ujXrx8iIyOxb98+WXIVKVIES5YskX0SoGxT2CjhRHjPnj3Q19dHnTp11LaHhIQgJSUF9erV02qeI0eOoFKlSjAwMPjiDF5Vq1bVUiplMTU1xblz5zRmpbpy5QrKlCmDt2/fajXP3bt3kTdvXqhUKty9e/ez+8p19c7a2hoXLlyAp6enWmFz9+5dFChQQLZuVY0bN0ZwcDAcHBzQpk0bdOjQQVp0Um7v379Hnz59sHz5cqSkpMDAwAApKSlo164dli9frtUr1ZlJSEjA9evXYWpqinz58klXsilzXbt2xaxZszSuAicmJqJfv35YunSpTMnSLo48efIEDg4Oatvv3r2LwoULy77uib+/P4QQWL16tcaCzXp6erIs2Ny1a1dUrVpVo/UhPj4eAwYMkPX1BNJe04+lX/SS4yKXLl9UVUL35OPHj6NevXro0KEDli9fjp9++kltNtZSpUrJkmvnzp2YOnUq5s+fL9vkREA2KmyUwMfHB5MnT4a/v7/a9n379mHYsGEIDw+XKRkQGxsLFxcXjTdxer/JvHnzypRMt08CihUrhhkzZkjdcNIdPHgQ/fv3x+XLl2XJ9eHDB/z0008YPXr0ZyfTkIOjoyOCg4NRokQJtcJm//796Nq1K+7duydbtn/++QcbN27EmjVrcOzYMRQsWBDt27dHu3btdGLGnnv37uHy5ctISEhAiRIlZG/yTxcVFYXo6Gj4+vrC1NRUOinRFbqW71OtIs+fP0fOnDmRnJys9UzpPR1mzZqFHj16ZLp6uL6+PsLCwrSeLSNzc3NpxfWMwsPDUalSJSQkJGg9k56eHkxNTdGtWzfMnDlTKiSePHkCZ2dn2Vu5dO0iFy+q/nu6OBtrxokgjIyMNMbaaGscebYsbFauXIkyZcqgUKFCatvfvXuHDRs2ICAgQJZcpqamuH79usYJUkxMDIoUKSLrlTBd7n6giycB6fbs2YNffvkF48aNk5pfT506hfHjx2Py5Mlq68Vou0nd2toaly5d0rnCpnv37njx4gU2bNgAOzs7REREQF9fH02aNIGvr6/OjEu7f/8+1q5di6VLlyIyMlLWv7Px48djyJAhaiebAPD27Vv88ccfsnX7evHiBVq1aoVDhw5BpVIhMjISHh4e6Nq1K2xtbTFt2jRZculqvvj4eAghYGtri8jISLVWkZSUFOzcuRPDhw+XZmDSpvSeDkeOHEGFChU0Vg93c3PDkCFDZC+m7ezssGvXLo0pxsPCwtCwYUNZJuHR09PDwYMH0b17d7i7u2PDhg2wtbXVmcKGvo+HhwfOnj2LHDlyqG2Pi4tDyZIlZZ8cRdfoykQQ2bKw0dPTg7m5OZYvX47mzZtL2+X+J5MzZ06sWbNG4+r+gQMH0K5dOzx9+lSWXIBudj/Q5ZOAdBmb+NOvAKe/pTJ+L0eTeqdOnVC8eHEMHDhQq4/7Ja9evUKLFi1w7tw5vH79Gs7Oznj8+DEqVKiAPXv2aPT/lsOHDx+we/du/N///R92794NOzs7PHjwQLY8unrhISAgAE+fPsXixYtRqFAhqfUtODgYgwYNwtWrV2XJpav5PtXtJp1KpUJQUBB+/fVXLaZS16VLF8yaNUv2aZ0/JSAgABcuXNBYsLlHjx4oVaoUli9frvVM6WMb9fX10bx5czx48AA7duyAnZ2dThQ2X5qQRdsXe780sU1Gck1yA6iPWc3oyZMncHFxkcYVapuufh7oimw7K1pQUBA6duyIy5cv68xsR40bN8aAAQOwdetWaYBjVFQUBg8ejEaNGsmSKb37gUqlwujRozPtflC8eHFZstnY2EClUkGlUiF//vwa96efBMhJzokLviRfvnwYP348wsLCMh0wKtdCtdbW1ti/fz+OHz+OiIgIqRm9Zs2asuTJ6NChQ1izZg02b96M1NRUNGvWDLt27dK4GKFtn+o6FR4eLuuaRCEhIQgODkaePHnUtufLl++L3V+0QdfyHTp0CEIIVK9eHZs3b1Z77YyMjODq6gpnZ2et58pIV1YP/5TZs2ejU6dOqFChgjTL3YcPH9C4cWPZWnvT35s5cuTAgQMH0KtXL1SoUAF//PGHLHk+1r9/f7XvP3z4gDdv3sDIyAhmZmZaL2yKFy+uNsbnc+Q4Sd+xY4f0dXBwsNoi4CkpKQgNDZW1J8Sn2iOSkpLUWlrl8PGMhUWKFEGjRo20Og402xY2HTp0QMWKFdG0aVNcuXIFq1atkjsSpk6dirp166JgwYLSB+39+/dRpUoV/Pnnn7JkSp92VAiBy5cva3Q/KFasGIYMGSJLNiWcBOhy/98lS5bAxsYG58+fx/nz59XuU6lUshU26SpXrqzWVU9uuXPnxsuXL1G3bl0sWrQIDRs2lH0QfPo6WOnFfcaTgJSUFCQkJKBXr16y5UtMTNToHgek9aWW+7kDdC9f+v+LO3fuwMXFJdNB3fR5NjY22L59O6KiotQWk5ZzweaMJ5oGBgZYvHgxChcujJ9//lm2TBn9888/GtsiIyPRu3dvDB06VOt57ty5I3198eJFDBkyBEOHDkWFChUAACdPnsS0adMwdepUrWcDgCZNmgBI+5z8uPuUoaEh3NzcZOlmO3v2bCnX4sWLYWFhId2XkpKCo0ePomDBglrPlS6zGQsnTZqk9RkLs2VXtIzNdLGxsWjUqBFUKhUWLFiAihUrytpMJ4TA/v371VaC9/X1lS1POl3ufpBxpi9doIS1Yj72cfc4bUv/h/w15Cq4/v77b7Rs2RI2NjayPH5mVqxYASEEunbtipkzZ6pdOUwf95B+MiAHf39/lCpVChMmTJCmHXV1dUWbNm2QmpqKTZs2yZZN1/P9888/WLJkidpaLF26dJG1BU5XfWkJh4zkWM4h42D4jA4cOICwsDBZF/f9nHPnzqFDhw64ceOGbBnKli2LcePGaUyqtGfPHowePVrjopw2ubu74+zZs7C3t5ctQ0bprUR3795Fnjx51FpB0j8Pxo8fj3LlysmST1dmLMyWhc3H/SLfvHmD9u3bIzQ0FImJif/5/odfkj4rlYuLi8xJ0ixbtgwWFhZo2bKl2vaNGzfizZs3Wl/gSwlrxaRbsmQJZsyYgcjISABpXXAGDBiA7t27azXHx832z549w5s3b6QiIi4uDmZmZnB0dJRlQOaHDx9gamqKS5cuyTpN5accOXIEFStW1FhgUm5XrlxBjRo1ULJkSRw8eBCNGjXC1atX8fLlS4SFhcm+poiu5jt69CgaNmwIa2trlC5dGgBw/vx5xMXFYefOnTpxsUuXfGkJh3Rcm+jbXLp0Cb6+vrKsVJ/O1NQUFy5c0Jjs6fr16yhZsqTWl0xQAj8/P2zZskVaO09X6MqMhdmyK9rYsWPVmujMzMywdetWjB07FkePHtVqltmzZ6Nnz54wMTH54lVrObsGJScnIygoCLNnz5b++CwsLNCvXz+MHTtW1hOqSZMmYeHChRrbHR0d0bNnT60XNnfu3JEmMsjYpK5rxowZg+nTp6Nfv35qTfwDBw5EbGwsxo8fr7UsGZ+nNWvW4K+//sKSJUvUFtjr0aMHfvrpJ61lysjQ0BB58+aVvRD9lKpVqyI1NRW3bt3C06dPkZqaqna/XCfC3t7euHXrFubOnQtLS0skJCSgWbNm6NOnD3LlyiVLJiXk69OnD1q3bo358+dLV11TUlLw888/o0+fPrJNE6+rdHksY7r79+9jx44diI2N1RhULvei4BnHjABpLfiPHj3C3LlzUalSJZlSpSlUqBAmTZqExYsXS13h379/j0mTJmkUO3JITEzEkSNHMn1d5Tpn09X3g7GxMV6/fq2xPSEhQbtjfwT9UG5ubuL58+fS15+6ubu7y5qzV69ewtHRUSxYsECEh4eL8PBwsWDBApEzZ07Rq1cvWbMZGxuLO3fuaGy/c+eOMDEx0X4ghbC3txdr1qzR2L5mzRqRI0cOGRKl8fDwEBcuXNDYfu7cOeHm5iZDojSLFy8W/v7+4sWLF7Jl+JSTJ08Kd3d3oaenJ1QqldpNT09P7nj0jUxMTMSNGzc0tt+4cYP/0xTowIEDwszMTHh7ewsDAwNRvHhxYWNjI6ytrYWfn5/c8TL9n+Hk5CTatm0rHj58KGu206dPC0dHR+Hg4CBq1KghatSoIRwcHISjo6M4ffq0rNkuXLggcubMKaysrIS+vr5wcHAQKpVKmJuby3rOlpycLBYvXizatm0ratSoIfz8/NRucunYsaMoUqSIOHXqlEhNTRWpqani5MmTwtvbW3Tq1ElrObJli026a9euaVTZKpUKDRs21FqGjFeqdfnq/po1a7Bu3TrUq1dP2ubj4wMXFxe0bdsW8+fPly2bo6MjIiIiNNb/CQ8P15hfXtsmTZoEJycndO3aVW370qVL8ezZMwwbNkymZGndq9K7uWRUqlQpWddkefToUaaPn5KSgidPnsiQKM3cuXMRFRUFZ2dnuLq6aswid+HCBZmSAb169ULp0qWxe/du5MqVS9bxZkqZqjXdu3fvEBERkWlLl1yzUZYsWRLXr1+XWizTXb9+HcWKFZMlE32/ESNGYMiQIQgKCoKlpSU2b94MR0dHtG/fHnXr1pU7nsbfvS4pW7Ysbt++jdWrV0tjfVq3bo127drJPvX/wIED0bBhQyxYsADW1tY4deoUDA0N0aFDB42Z5rSpf//+WL58OerXrw9vb2+dGX+c2YyFycnJaNSoEWbNmqW9IForobQoOjpa+Pj4SFcmMl6lkPPqZlBQkEhMTNTY/ubNGxEUFCRDov9xcHAQ165d09h+7do1YW9vL0Oi//nll1+Eq6urOHjwoEhOThbJyckiNDRUuLq6isGDB8uazdXVVYSFhWlsP3XqlKytD0II0bdvXzFw4ECN7YMHDxY///yzDInSNGjQQJQoUUKcP39e2nbu3DlRsmRJ0bBhQ9lyjRs37rM3OZmZmYnIyEhZM6TL+H81/X9qZv9ndaElae/evdJVVl1q6Vq3bp3Imzev+OOPP8SxY8fEsWPHxB9//CHc3NzEunXrpFbz8PBw2TLS17OwsBBRUVFCCCFsbGzElStXhBBCXLp0Sbi6usqYLI0un3voMmtra6ll1draWjpHOnXqlChQoIBsuXLkyCF2794t2+N/ya1bt8SOHTvEjh07ZPncypaFTYMGDUTjxo3Fs2fPhIWFhbh27Zo4duyYKFu2rDh69KhsufT09MSTJ080tj9//lz2k4CgoCDRtm1b8e7dO2nbu3fvRPv27WU/qUtKShKtWrUSKpVKGBoaCkNDQ6Gvry+6dOkikpKSZM1mbGwsbt++rbE9OjpaGBsby5Dof/r27SusrKxEkSJFRLdu3US3bt2Et7e3sLKykoqe9Js2PX36VNSrV0+oVCphZGQkjIyMhEqlEvXq1ROPHz/Wahal8PPzE3v37pU7hhBCiJiYGOm2detW4enpqdGFNV++fGLr1q1yRxVeXl7i559/1rm/q8wKrY+LLrmLL/p6Tk5O0klvoUKFxPbt24UQaYWNubm5nNGEELp97pHu6tWrYu/evWL79u1qNznZ29uLW7duCSGEyJcvn9i3b58QQojr168LMzMz2XLlypVL3Lx5U7bH/5Rjx47JHUEIkU27op08eRIHDx6Evb099PT0oKenh8qVK2PSpEkIDAyU1m7RNqGji+wBaXPJh4aGIk+ePFJXiPDwcLx//x41atRAs2bNpH23bNmi1WxGRkZYv349JkyYIE2TXbRoUbi6umo1R2ZcXFwQFhamMetXWFiY7GvsXLlyBSVLlgQAREdHAwDs7e1hb2+PK1euSPtpuxnbwcEBe/bsQWRkpDTVbcGCBTNdhFXb4uLisGnTJkRHR2Po0KGws7PDhQsX4OTkhNy5c8uWq1+/fhg8eDAeP36MokWLakzmoc0uXxnfdy1btsTs2bPVpmpN78I6evRoaT0IuTx58gSDBg2Ck5OTrDk+psvdkunblS9fHsePH0ehQoXg7++PwYMH4/Lly9iyZQvKly8vdzydPve4ffs2mjZtisuXL6vNMJqeV84JXUqUKIGzZ88iX758qFq1KsaMGYPnz59j1apVss6eOXjwYMyaNQtz587VmW5oAFC9enXkzp0bbdu2RYcOHVC4cGFZcmTLwiYlJQWWlpYA0k7kHj58iAIFCsDV1RU3b97Ueh5dX2QPSFv0rHnz5mrbdGW653T58+fXiZPfjHr06IEBAwbgw4cP0ur0oaGh+OWXXzB48GBZs+nSzCmDBg3ChAkTYG5unumaFIcPH5a+lmsGoYiICNSsWRPW1taIiYlBjx49YGdnhy1btiA2NhYrV66UJRcA6b2ZcSxXxpW75frwv3z5cqYrcLu7u+PatWsyJFLXokULHD58WPZppz+mCxdlKOtMnz5dmk00KCgICQkJWL9+PfLlyyfrjGhKOPfo378/3N3dERoaCnd3d5w5cwYvXrzA4MGDZVu4PN3EiROlWb5+//13BAQEoHfv3siXLx+WLl0qW67jx4/j0KFD2Lt3L4oUKaJxoUvbF5/TPXz4EOvWrcPatWsxefJk+Pj4oH379mjbtq20KL02ZMt1bKpUqYLBgwejSZMmaNeuHf755x+MGjUKixYtwvnz59WuVmuDri+ypwS6OpWmEALDhw/H7NmzpVwmJiYYNmwYxowZI1suXePn54etW7fCxsbms2tSyLkORc2aNVGyZElMnToVlpaWCA8Ph4eHB06cOIF27dohJiZGllxA2oJsnyPXiXLJkiXh7e2tMVVr9+7dceXKFVknXADS1jBr2bIlHBwcMm3p0uZ0rTt27EC9evVgaGioMf3ux+Sa1ICyFyWce9jb2+PgwYPw8fGBtbU1zpw5gwIFCuDgwYMYPHiwbD1sdFmXLl0+e/+yZcu0lOTT7ty5gzVr1mDt2rW4ceMGfH19tfbZni0Lm+DgYCQmJqJZs2aIiopCgwYNcOvWLeTIkQPr16+XrqxrU3JyMlavXo3q1avrXEuIrgsNDUWjRo3g4eGBGzduwNvbGzExMRBCSAvvyS0hIQHXr1+Hqakp8uXLB2NjY7kj0TeytrbGhQsX4OnpqVbY3L17FwUKFMC7d+/kjqhzzpw5g4YNG0IIIXWHi4iIgEqlws6dO1G2bFlZ8y1ZsgS9evWCiYkJcuTIoXbFWqVSaXUx2I8X9v0UXVjYl7KXI0eOoFKlSjAw0L1OOra2trhw4QLc3d3h6emJxYsXw8/PD9HR0ShatCjevHkjd0T6TikpKdi7dy9Gjx6NiIgIrf1f072/8ixQp04d6WsvLy/cuHEDL1++lJpl5WBgYIDevXtLYwp0QcmSJREaGgpbW1uUKFHis8+NnFdedX0qTQB4/PgxXr58CV9fXxgbG3+yTzPpLmNj40xX4L5165a0IKucoqOjMXPmTOl/SOHChdG/f39Zu1np8lStAPDrr78iKCgIw4cP/2wxoQ0Zp9zV5el36dt96txCpVLBxMQEXl5e6Ny58xevtP8oiYmJCA0NVTs3AtIuAqempqot86Bt3t7eCA8Ph7u7O8qVK4epU6fCyMgIixYtgoeHh2y5AODFixcYM2YMDh06lOl08S9fvpQpWZpnz55JwysKFCigE59TQNoY49WrV2PTpk149+4dGjdujEmTJmnt8bNlYZMZuQfIAWknARcvXtSZ/tWNGzeWWhbkHuT7OdevX8fatWsBpBWIb9++hYWFBcaPH4/GjRujd+/esmV78eIFWrVqhUOHDkGlUiEyMhIeHh7o1q0bbG1tMW3aNNmy0bdp1KgRxo8fjw0bNgBIOymJjY3FsGHDNMafaVtwcDAaNWqE4sWLSyuFh4WFoUiRIti5cydq1aolWzZzc3P07NlTtsf/nPfv36N169ayFzUZffjwAXXr1sWCBQuQL18+ueNQFhgzZgx+//131KtXT2qlPHPmDPbt24c+ffrgzp076N27N5KTk9GjRw+t5xs+fDgmT56ssT29K7Wchc2oUaOQmJgIABg/fjwaNGiAKlWqSD1s5NSxY0dERUWhW7ducHJy0pmLlYmJiejXrx9WrlwpFVv6+voICAjAnDlzYGZmJkuuESNGYN26dXj48CFq1aqFWbNmoXHjxlrPky27ojVt2vSLV0/atWunsTjaj7ZhwwaMGDECAwcORKlSpTSuaMq1mF1KSgrCwsLg4+MDGxsbWTJ8Ts6cOXHo0CEUKlQIhQsXxuTJk9GoUSOEh4ejUqVK0qBNOQQEBODp06dYvHgxChUqJHVfCg4OxqBBg3D16lXZstG3efXqFVq0aIFz587h9evXcHZ2xuPHj1GhQgXs2bNH1haIEiVKoE6dOhonJ8OHD0dISIjsY1l01cCBA+Hg4ICRI0fKHUWNg4MDTpw4wcImm2jevDlq1aqlMRB/4cKFCAkJwebNmzFnzhwsWrQIly9f1no+U1NTXL9+XWOR65iYGBQpUkQqLHSF3D1s0llaWuL48eM6t2juTz/9hAMHDmDu3LnSha7jx48jMDAQtWrVkm1B9UqVKqF9+/Zo1aoV7O3tZckAZNPCpnPnzti2bRtsbGxQqlQpAGldqeLi4lC7dm2Eh4cjJiYGoaGh0h+FNuhyv2oTExNcv3490xmO5NakSRPUr18fPXr0wJAhQ7B9+3Z07twZW7Zsga2tLQ4cOCBbtpw5cyI4OBjFihVTG5dx+/Zt+Pj4yFp00fcJCwtDeHg4EhISULJkSdSsWVPuSDAxMcHly5c1ToRv3boFHx8fjv/5hMDAQKxcuRLFihWDj4+PxuQBck08MnDgQBgbG2d6FZ2Ux8LCApcuXYKXl5fa9qioKBQvXhwJCQmIjo6Gj4+PLEVEzpw5sWbNGo3xxQcOHEC7du3w9OlTrWf6WFRUFKKjo+Hr6wtTU1Od6M5dpkwZzJkzRyem7M7I3t4emzZtQrVq1dS2Hzp0CK1atcKzZ8/kCaYjsmVXtJw5c6Jdu3aYO3euVEykpqaif//+sLS0xLp169CrVy8MGzYMx48f11ouXV67wNvbG7dv39bJwkZXp9IE0pqEM2tmffnyJScQUKhKlSpJFzzi4uLkDfP/OTg44NKlSxqFzaVLl+Do6ChTKt13+fJllChRAgA0ZsOU86QpOTkZS5cuxYEDBzJtvZf7/xp9Gzs7O+zcuRMDBw5U275z506pG3xiYqK0DIW2NW7cGAMGDMDWrVulMXlRUVEYPHiw7DPw6XJ37r/++gvDhw/HmDFj4O3trXFhxMrKSpZcb968yXRtLkdHR52YbOHatWuZzmCrrb+1bNli4+DggLCwMI01T27duoWKFSvi+fPnuHz5MqpUqSLLiUtmL7pKpULDhg21niXdvn37MGLECEyYMCHTD1ptv4Fnz56Nnj17wsTEBLGxsXBxcZH96k1m/P39UapUKUyYMAGWlpaIiIiAq6sr2rRpg9TUVGzatEnuiPSVpkyZAjc3N7Ru3RoA0KpVK2zevBk5c+bEnj17ZO2OMH78eMyYMQPDhw9HxYoVAaS1LE2ZMgWDBg3C6NGjZctG305Xpzyn7/P333+jd+/e8Pf3l8bYnD17Fnv27MGCBQvQrVs3TJs2DWfOnJFl3MirV69Qt25dnDt3TlpP5P79+6hSpQq2bNkiaxd0Xe7OHRkZiXbt2ml09ZV7/bAaNWogR44cWLlyJUxMTAAAb9++RadOnfDy5UvZerHoymKr2bKwsbW1xYoVKzSqwx07dqBTp074559/EBkZibJly+Kff/7RWi5dedEzk7GbXMYCQq43sIGBAR4+fAhHR0fo6+vj0aNHOnll+urVq6hevbo07XSjRo1w9epVvHz5EmFhYTq3MCB9mru7O1avXo2KFSti//79aNWqFdavX48NGzYgNjYWISEhsmUTQmDmzJmYNm0aHj58CABwdnbG0KFDERgYKGvRHxcXh02bNiE6OhpDhw6FnZ0dLly4ACcnJ+TOnVu2XBnpYjcXyl7CwsIwd+5ctVmq+vXrJ12IkJsQAvv370d4eDhMTU3h4+MDX19fuWPpdHfusmXLwsDAAP3798908oCqVavKkuvy5cuoW7cukpKSpAtu4eHhMDY2RkhICIoUKSJLroYNG0JfXx+LFy/OdLHVKlWqaCVHtuyK1rFjR3Tr1g0jR45EmTJlAKRdPZk4cSICAgIApM3rru0X/+MVdk+fPo2XL1/qxAq7urRKPZB20rZ582b4+/tDCIH79+9/chxB3rx5tZwuzYcPHxAYGIidO3di//79sLS0REJCApo1a4Y+ffogV65csuSi7/P48WNpjaldu3ahVatWqF27Ntzc3FCuXDlZs6lUKgwcOBADBw6UVsKWq1tLRhEREahZsyasra0RExODHj16wM7ODlu2bEFsbCxWrlwpaz5d7eby6tUrpKSkaMzW+fLlSxgYGMjWxYW+X8YurLpIpVKhdu3aqF27ttxR1Ohyd+4rV67g4sWLWp9o6kuKFi2KyMhItWn227Zti/bt28PU1FS2XCdPnsTBgwdhb28PPT096OnpoXLlypg0aRICAwO1tthqtixsZsyYAScnJ0ydOhVPnjwBADg5OWHgwIEYNmwYAKB27dpaXwPl4xddX19flhc9M3JdefiUUaNGoV+/fujbty9UKpVUoGYkd3OwoaEhIiIiYGtri19//VWWDJR1bG1tce/ePbi4uGDfvn347bffAKT9ncm9YOKdO3eQnJyMfPnyqRU0kZGRMDQ01JjtSFsGDRqEzp07Y+rUqWq5/P390a5dO1kyZTRw4EAYGhoiNjYWhQoVkra3bt0agwYNkq2wadOmDRo2bIiff/5ZbfuGDRuwY8cO7NmzR5Zc9O+9e/dOY2yBHIVqxu7cs2fP/uy+gYGBWkqlqUqVKli5ciUmTJgAIK0AS01NxdSpUz/bZVMbSpcujXv37ulcYTNp0iQ4OTlpTB2+dOlSPHv2TDrP1baUlBTpc8De3h4PHz5EgQIF4OrqKrVkaoXI5l69eiVevXoldwwhhBA2Njbi9u3bQgghPDw8xMGDB4UQQkRFRQlTU1M5o4mlS5eKDRs2aGzfsGGDWL58uQyJhIiPjxeXL18WKpVKhIaGikuXLmV6k9OAAQPEsGHDZM1AWaNPnz7C1dVV1KxZU+TIkUO8fv1aCCHE2rVrRYkSJWTN5uvrm+n7cNWqVaJq1araD/T/WVlZiaioKCGEEBYWFiI6OloIIURMTIwwNjaWLVc6Jycn6X9ExnzR0dHC3Nxctly2trbi2rVrGtuvX78u7OzsZEhE/0ZiYqLo06ePcHBwEHp6eho3Obi5uYnnz59LX3/q5u7uLku+dFeuXBGOjo6ibt26wsjISLRo0UIUKlRIODk5Sf9b5LJhwwZRuHBhsWzZMnHu3DkRHh6udpOLq6urCAsL09h+6tQp4ebmJkOiNJUrVxZbt24VQgjRtm1bUbduXXH8+HEREBAgihQporUc2bLFJiNdatLX5RV2J02ahIULF2psd3R0RM+ePdGpUyetZ7K0tIS3tzeWLVuGSpUqyd4snRnObpR9zJgxA25ubrh37x6mTp0KCwsLAMCjR480rqxr28WLFzPt5lK+fHn07dtXhkRpjI2NER8fr7H91q1bOrEKtq52c0lKSkJycrLG9g8fPuDt27cyJKJ/Y+jQoTh06BDmz5+Pjh07Yt68eXjw4AEWLlwo25TeGWdhzfi1+Ghsr5x0vTt3+kQyXbt2lbalj4+Ws7fI48ePM31uHBwc8OjRI61miYiIgLe3N/T09DBq1ChpVjY5F1vNtoXNpk2bpEG/HzcLy7WYnS6vsBsbG5vpVM+urq6IjY2VIdH/VK9eHc+ePZNmczlz5gzWrFmDwoULy77i+ZUrV1CyZEkAaSdzGenCBwd9PUNDQwwZMkRj+8dTuMpBpVJJY2sySh+rIZdGjRph/Pjx2LBhA4C0nLGxsRg2bBiaN28uW650utrNpWzZsli0aBHmzJmjtn3BggXS2mukHDt37sTKlStRrVo1dOnSBVWqVIGXlxdcXV2xevVqtG/fXu6IWLJkCWbMmIHIyEgAQL58+TBgwAB0795dtky63p1bV5focHFxQVhYmMY5W1hYGJydnbWapUSJEtLkTr1798bZs2cBAF5eXrhx44Y8i61qrW1Ii2bNmiUsLCxE3759hZGRkfjpp59EzZo1hbW1tRg5cqTc8dS8ePFCpKamyh1DuLi4iO3bt2ts37Ztm8idO7cMif6ncuXKYuXKlUIIIR49eiQsLS1FhQoVhL29vQgKCpI1G5E2NGjQQLRs2VIkJydL25KTk0Xz5s1F3bp1ZcsVFxcnatasKWxsbIS+vr5wcXERhoaGwtfXVyQkJMiWK93ly5d1spvL8ePHhYmJiahSpYoYN26cGDdunKhSpYowMTERR48elS0XfR9zc3Nx9+5dIYQQuXPnFqdPnxZCCHH79m1ZuzymGz16tDA3NxfDhw8X27dvF9u3bxfDhw8XFhYWYvTo0bJm09Xu3O/fvxceHh6ZdhmV25QpU0SOHDnE0qVLRUxMjIiJiRFLliwROXLkEBMnTtRqFjs7O3Hq1CkhhBAqlUo8ffpUq4+fmWzZYvPXX39h0aJFaNu2LZYvX45ffvkFHh4eGDNmDF6+fCl3PDUfz4ojl7Zt2yIwMBCWlpbSFJBHjhxB//790aZNG1mzXblyRVobYMOGDShatCjCwsIQEhKCXr16YcyYMbLmI/rRpkyZAl9fXxQoUECaMvPYsWOIj4+Xdc0Ta2tr7N+/H8ePH0dERAQSEhJQsmRJ1KxZU7ZMGXl7e+PWrVuYO3euTnVzqVSpEk6ePIk//vgDGzZskKbfXbJkicYirKT7PDw8cOfOHeTNmxcFCxbEhg0bULZsWezcuVPWNWLSzZ8/H3///Tfatm0rbWvUqBF8fHzQr18/jB8/XrZsutqd29DQ8JMzscpt6NChePHiBX7++WepR5KJiQmGDRuGESNGaDVL8+bNUbVqVeTKlQsqlQqlS5eGvr5+pvvevn1bK5my5To2ZmZmuH79OlxdXeHo6Ij9+/ejWLFiiIyMRPny5fHixQu5I+qc9+/fo2PHjti4cSMMDNLq3dTUVAQEBGDBggUwMjKSLZuFhQWuXLkCNzc3NGrUCJUqVcKwYcMQGxuLAgUKsE86/Sc8fPgQc+fOVVuHom/fvjpzcYTov2rGjBnQ19dHYGAgDhw4gIYNG0IIgQ8fPmD69Ono37+/rPlsbGxw9uxZjaL51q1bKFu2rCwLlafT5cVqJ06ciFu3bmHx4sXSeZEuSUhIwPXr12Fqaop8+fLJNm5w3759iIqKQmBgIMaPH//JpQi09T7IloWNh4cHNm/ejBIlSqB06dLo0aMHfvrpJ4SEhKBNmzY612qjSyIjI3Hp0iWYmpqiaNGicHV1lTsSypUrBz8/P9SvXx+1a9fGqVOnUKxYMZw6dQotWrTA/fv35Y5ICpeSkoKwsDD4+PjoxBVWJTl79iwOHTqEp0+fIjU1Ve0+uSfP2LdvHywsLFC5cmUAwLx58/D333+jcOHCmDdvHmxtbWXJdeHCBRgaGqJo0aIAgO3bt2PZsmUoXLgwxo0bJ+uFJPr37t69i/Pnz8PLyws+Pj5yx0G/fv1gaGio8X4cMmQI3r59i3nz5smUTLc1bdoUoaGhsLCwQNGiRTVak7Zs2SJTMt3UpUsXzJ49W/Y11rJlYdO9e3e4uLhg7NixmDdvHoYOHYpKlSrh3LlzaNasGZYsWSJ3RJ2XkpKCy5cvw9XVVbYP/3SHDx9G06ZNER8fj06dOmHp0qUAgJEjR+LGjRv850JZwsTEBNevX890Eg3K3MSJEzFq1CgUKFBAY2Vuua+2AmkL2U2ZMgX+/v64fPkySpcujcGDB+PQoUMoWLAgli1bJkuuMmXKYPjw4WjevDlu376NwoULo1mzZjh79izq16+PmTNnypKLsqd+/fph5cqVcHFxQfny5QEAp0+fRmxsLAICAmBoaCjtK/fFCF3SpUuXz94v1/8P+rxsWdikpqYiNTVVajpcv349wsLCkC9fPvTq1UvtTUxpBgwYgKJFi6Jbt25ISUlB1apVceLECZiZmWHXrl2oVq2arPlSUlIQHx+vVmTFxMTAzMwMjo6OMiaj7KJ06dKYMmUKatSoIXcUxXBycsKUKVPQuXNnuaNkKmM31nHjxuHKlSvYtGkTLly4AH9/fzx+/FiWXNbW1rhw4QI8PT0xZcoUHDx4EMHBwQgLC0ObNm1w7949WXLR99PllsuvnQFQFy5GEP1butdpMAvo6enh/fv3uHDhAp4+fQpTU1NpMOu+ffvQsGFDmRPqnk2bNqFDhw4A0qauvH37Nm7cuIFVq1bh119/RVhYmKz59PX1NVqO5FptnbKn3377DUOGDMGECRMyHcSqS2ti6Qo9Pb1M19fRFUZGRtK6CgcOHEBAQACAtElbMlt/R1uEENLJ74EDB9CgQQMAadO4Pn/+XLZc9H2+1HIpt0OHDskdQdGePXuGmzdvAgAKFCigE2t00adlyxabffv2oWPHjplOEiDnokq6zMTEBFFRUciTJw969uwJMzMzzJw5E3fu3EGxYsW0fhJQsmRJhIaGwtbWFiVKlPjsh4Nc6xJR9qKnpyd9nfHvTci8GJsumzp1Kh4+fKizXacaNWqE9+/fo1KlSpgwYQLu3LmD3LlzIyQkBH379tVYe0pbqlevDhcXF9SsWRPdunXDtWvX4OXlhSNHjqBTp06IiYmRJRd9H11vuaTvk5iYKHXjS78Qoa+vj4CAAMyZMyfTxX9JftmyxaZfv35o1aoVxowZAycnJ7njKIKTkxOuXbuGXLlyYd++fZg/fz4A4M2bN5+cuu9Haty4sTTDR+PGjXXiqhdlb7p+VTM5ORmHDx9GdHQ02rVrB0tLSzx8+BBWVlawsLCQJdOQIUNQv359eHp6onDhwhrdfOUe/zZ37lz8/PPP2LRpE+bPn4/cuXMDAPbu3Yu6devKlmvmzJlo3749tm3bhl9//RVeXl4A0lrOK1asKFsu+j663nJJ32fQoEE4cuQIdu7cKb2+x48fR2BgIAYPHiydJ5FuyZYtNlZWVrh48SI8PT3ljqIY48aNw8yZM5ErVy68efMGt27dgrGxMZYuXYq///4bJ0+elDsi0X/W3bt3UbduXcTGxiIpKQm3bt2Ch4cH+vfvj6SkJCxYsECWXH379sXixYvh5+en0QUH4ODab/Xu3Tvo6+tzHKjC6HrLJX0fe3t7bNq0SWOM8aFDh9CqVSs8e/ZMnmD0WdmyxaZFixY4fPgwC5tvMG7cOHh7e+PevXto2bKl1Fqir6+P4cOHy5rNw8MDZ8+eRY4cOdS2x8XFoWTJklpb9Imyv2PHjmHhwoW4ffs2Nm7ciNy5c2PVqlVwd3eXpgyWQ//+/VG6dGmEh4ervQ+aNm2KHj16yJZrxYoV2Lx5M+rXry9bho/Fx8dL46G+1IVW7nFT586dw/Xr1wEAhQoVQunSpWXNQ99H11su6fu8efMm014/jo6O0tg90j3ZsrCZO3cuWrZsiWPHjqFo0aIa/2QCAwNlSqbbWrRoobGtU6dOMiRRFxMTk+n4hqSkJK5hQ1lm8+bN6NixI9q3b48LFy4gKSkJAPDq1StMnDgRe/bskS3bsWPHcOLECY31Tdzc3PDgwQOZUqUNwte1C0i2trZ49OgRHB0dYWNjk2k3VrnHTd2/fx9t27ZFWFiYtG5SXFwcKlasiHXr1iFPnjyy5KLvExgYiEOHDsHPzw85cuRg1+lsokKFChg7dixWrlwJExMTAMDbt28RFBSEChUqyJyOPiVbFjZr165FSEgITExMcPjwYY0ZSljYZC40NBQzZsxQu4I4YMAAaUY5bduxY4f0dXBwMKytraXvU1JSEBoayjVHKMv89ttvWLBgAQICArBu3Tppe6VKlfDbb7/JmCxtCvvMTsLv378v62Jo48aNw9ixY7Fs2TKdGUh78OBB2NnZAdDdcVPdu3fHhw8fcP36dRQoUAAAcPPmTXTp0gXdu3fHvn37ZE5I30IXWy7p35s5cybq1q2LPHnyoFixYgCA8PBwmJiYIDg4WOZ09CnZcoxNzpw5ERgYiOHDh6vNdESf9tdff6F///5o0aKFdCXi1KlT2LRpE2bMmIE+ffpoPVP6a6dSqfDxn6mhoSHc3Nwwbdo0aapUon/DzMwM165dg5ubGywtLREeHg4PDw9pAcV3797Jlq1169awtrbGokWLYGlpiYiICDg4OKBx48bImzevbGNZSpQogejoaAgh4ObmptE6LveMhbGxsXBxcdG4gi6EwL1795A3b15ZcpmamuLEiRMoUaKE2vbz58+jSpUq7OaiMK6urggODkbBggXljkJZ7M2bN1i9ejVu3LgBIO2Cb/v27WFqaipzMvqUbNli8/79e7Ru3ZpFzTeYOHEiZsyYgb59+0rbAgMDUalSJUycOFGWwiZ9ekV3d3ecPXsW9vb2Ws9A/x05c+ZEVFSUxvpIx48fh4eHhzyh/r9p06ahTp06UoHVrl07REZGwt7eHmvXrpUtV5MmTWR77K/h7u4udUvL6OXLl3B3d5etK5qLiws+fPigsT0lJQXOzs4yJKJ/QxdbLun7ZFxqYvz48RgyZIis4xjp22XLFpuBAwfCwcEBI0eOlDuKYlhYWODSpUvStKPpIiMjUaJECSQkJMiUjEg7Jk2ahP/7v//D0qVLUatWLezZswd3797FwIEDMXr0aPTr10/WfMnJyVi3bh0iIiKQkJCAkiVL8srhF+jp6eHJkycaC+rdvXsXhQsXRmJioiy5tm/fjokTJ2LevHnShAHnzp1Dv379MGzYMJ0vGEmdrrdc0tczNTVFZGQk8uTJA319/UwvjJBuy5YtNikpKZg6dSqCg4Ph4+Oj8U9m+vTpMiXTXY0aNcLWrVsxdOhQte3bt2/Xia5eiYmJOHLkCGJjY/H+/Xu1+zhmirLC8OHDkZqaiho1auDNmzfw9fWFsbExhgwZIntRAwAGBgbo0KGD3DEydf78eWlsXpEiRTS6WGnboEGDAKR1Yx09erTaVfSUlBScPn0axYsX12omW1tbtS5xiYmJKFeuHAwM0j6Gk5OTYWBggK5du7KwURi+XtlH8eLF0aVLF1SuXBlCCPz555+fXCdszJgxWk5HXyNbttj4+fl98j6VSoWDBw9qMY3umj17tvR1fHw8/vzzT1SqVEltjE1YWBgGDx6MUaNGyRUTFy9ehL+/P968eYPExETY2dnh+fPnMDMzg6OjI6d7piz1/v17REVFISEhAYULF5Zt8cuPRUZG4tChQ3j69KnUTTOdXB+wT58+RZs2bXD48GG12b38/Pywbt06jZYSbUn/DDhy5AgqVKigNpuckZER3NzcMGTIEOTLl09rmVasWPHV++rCbJRE/0U3b97E2LFjER0djQsXLqBw4cLSxYeMVCoVW+J0VLYsbOjrfO2MYiqVStbioVq1asifPz8WLFgAa2trhIeHw9DQEB06dED//v3RrFkz2bIRacPff/+N3r17w97eHjlz5tSY6VGuD9jWrVvj9u3bWLlyJQoVKgQAuHbtGjp16gQvLy9Zx/8AQJcuXTB79mxZZ44jImXS09PD48eP2RVNYVjYkM6zsbHB6dOnUaBAAdjY2ODkyZMoVKgQTp8+jU6dOkmzlRD9G+/evcOcOXM+2Soi59U5V1dX/Pzzzxg2bJhsGTJjbW2NAwcOoEyZMmrbz5w5g9q1ayMuLk6eYAA+fPgAU1NTXLp0Cd7e3rLlyExsbOxn75drtjYiIqXLlmNsKHsxNDSUZrhzdHREbGwsChUqBGtra9y7d0/mdJRddOvWDSEhIWjRogXKli2rU4vs/fPPP2jZsqXcMTSkpqZqjGEE0t6zHxeG2mZoaIi8efPKNvPZ57i5uX3270sXMxP9F+liF2D6PLbYEACga9eun71/6dKlWkqiqXbt2ujcuTPatWuHHj16ICIiAoGBgVi1ahX++ecfnD59WrZslH1YW1tjz549qFSpktxRNHTr1g1lypRBr1695I6ipnHjxoiLi8PatWulaYofPHiA9u3bw9bWFlu3bpU135IlS7BlyxasWrVKWrRTF4SHh6t9/+HDB1y8eBHTp0/H77//zu61RDpAV7sA0+exsCEAQNOmTdW+//DhA65cuYK4uDhUr14dW7ZskSlZ2jSor1+/hp+fH54+fYqAgACcOHEC+fPnx+LFi7U+uxFlT4ULF8a6devg4+MjdxQNkyZNwvTp01G/fn0ULVpUo5VErpkB7927h0aNGuHq1atwcXGRtnl7e2PHjh3IkyePLLnSlShRAlFRUfjw4QNcXV1hbm6udr+unZjs3r0bf/zxBw4fPix3FPpKHz58QMGCBbFr1y5pnBllD7raBZg+j4UNfVJqaip69+4NT09P/PLLL7LlePv2LYQQ0pStMTEx2Lp1KwoXLow6derIlouyl71792L27NlYsGABXF1d5Y6j5nMTfcg9uYcQAgcOHFBbmbtmzZqy5ckoKCjos/ePHTtWS0m+TlRUFIoVKybb+jr0fXLnzo0DBw6wsMlmrKyscOnSJdkXaKZvw8KGPuvmzZuoVq0aHj16JFuG2rVro1mzZujVqxfi4uJQsGBBGBoa4vnz55g+fTp69+4tWzbKPp49e4ZWrVrh6NGjMDMz02gVefnypUzJKLuJj49X+14IgUePHmHcuHG4ceMGLl26JE8w+i4TJ07ErVu3sHjx4kynBiZl0tUuwPR5fAfSZ0VHRyM5OVnWDBcuXMCMGTMAAJs2bYKTkxMuXryIzZs3Y8yYMSxsKEu0bdsWDx48wMSJE+Hk5KRTkwfostDQUISGhmY6uFbOsXnp4uLisGnTJkRHR2Po0KGws7PDhQsX4OTkhNy5c8uSycbGRuPvSwgBFxcXrFu3TpZM9P3Onj2L0NBQhISEoGjRohpdHuXsyk3fz8vLC6NHj8apU6d0qgswfR4LGwLwv5W606VfQdy9e7fsi8W9efNGWociJCQEzZo1g56eHsqXL4+7d+/Kmo2yjxMnTuDkyZMoVqyY3FEApL0nJ0yYAHNzc43358emT5+upVTqgoKCMH78eJQuXRq5cuXSuWIwIiICNWvWhLW1NWJiYtCjRw/Y2dlhy5YtiI2NxcqVK2XJdejQIbXv9fT04ODgAC8vL17xVyAbGxs0b95c7hiUxRYtWgQLCwscOXIER44cUbtPpVKxsNFR/A9KAICLFy+qfZ/+QTtt2rQvzpj2o3l5eWHbtm1o2rQpgoODMXDgQABpq55bWVnJmo2yj4IFC+Lt27dyx5BcvHgRHz58kL7WRQsWLMDy5cvRsWNHuaNkatCgQejcuTOmTp2qtkinv78/2rVrJ1uuqlWryvbYlPWWLVsmdwT6Ae7cuSN3BPoOHGNDANJaRYQQUhN6TEwMtm3bhkKFCsk+QH/Tpk1o164dUlJSUKNGDYSEhABImynq6NGj2Lt3r6z5KHsICQlBUFAQfv/990y7HbCI1pQjRw6cOXMGnp6eckfJlLW1NS5cuABPT09YWloiPDwcHh4euHv3LgoUKIB3797JkmvFihWwt7dH/fr1AQC//PILFi1ahMKFC2Pt2rU6N3kF0X/F17aUq1QqTJs2TYvJ6GuxsCEAuj9A//Hjx3j06BGKFSsmLdZ55swZWFlZoWDBgrJmo+wh/e8qs7EPKpVK1kUTV65ciTJlymjMuvTu3Tts2LABAQEBsuQaNmwYLCwsMHr0aFke/0scHR0RHByMEiVKqBU2+/fvR9euXWVb4LdAgQKYP38+qlevjpMnT6JGjRqYOXMmdu3aBQMDA47JUBh3d/fPdsOUc9ZC+jZ+fn7YunUrbGxs4Ofn98n9VCoVDh48qMVk9LVY2BAAwN7eHkeOHEGRIkWwePFizJkzR22A/vXr1+WOSPRDfdyH+mNydh/S09ODubk5li9frtaX/8mTJ3B2dtZq0ZXxKmZqaipWrFgBHx8f+Pj4aLRyyTX2J1337t3x4sULbNiwAXZ2doiIiIC+vj6aNGkCX19fzJw5U5ZcZmZmuHHjBvLmzYthw4bh0aNHWLlyJa5evYpq1arh2bNnsuSi7zNr1iy179MXXN23bx+GDh2K4cOHy5SM6L+HY2wIAAfoE+n6uIegoCB07NgRly9fxrhx42TL8fF4n/QFcq9cuaK2XRcmEpg2bRpatGgBR0dHvH37FlWrVsXjx49RoUIF/P7777LlsrCwwIsXL5A3b16EhIRIxaKJiYlOjfOir9O/f/9Mt8+bNw/nzp3Tchqi/za22BAAwMfHB927d0fTpk3h7e2Nffv2oUKFCjh//jzq/7/27j2u5vvxA/jrnNRKpfsK001UrJIR3TZja5goNF+lUmGZuZVLs422fV3WNzHf2BbG2Chrl68JfX27uGQUnVWikqKvCAmp3Dp9fn/06Gx9w2+ZnU9Hr+fj0eNRn8+pz2tnj3Je5/O+vPkmqqqqxI5I9Je7efMmNm/erLhD2b9/f4SGhkJPT0/UXFKpFFVVVSgrK4Ovry/c3d2xfft21NbWKv2OjSo6cuQI8vPzUVdXh4EDB4q+gWhAQACKiorg7OyMnTt3oqKiAkZGRti9ezeWLFnSpiSSaiorK8OAAQPa7FtERH8dqdgBqGNYunQpFixYAEtLSwwZMgSurq4Amu/eODs7i5yO6K934sQJ9O7dG2vWrEFNTQ1qamoQFxeH3r17Izc3V9RsLXc/hg4diuPHj6O0tBRubm44f/68qLk6upY5NB4eHnjnnXewaNEi0UsN0PxOvqurK65du4bvv/8eRkZGAICTJ09i8uTJIqejpyU5ORmGhoZixyDqVHjHhhQ4QZ86M09PT9jY2GDjxo2KvUQaGxsxbdo0lJWV4dChQ6Jla7lj8/zzzwNoHjoaEBCAtLQ01NfX847NI6ipqcHDwwNTpkzBxIkTYWBgIHYkegY5Ozu3GnopCAKqqqpw7do1bNiwATNmzBAxHVHnwmJDRARAS0sLMpmsTYk/ffo0Bg0ahIaGBpGSNc+vWbhwIbp27drq+LJly3Do0KE2Gz5SM5lMhh07diAxMRHXrl3DyJEjMWXKFHh7e+O5554TOx49Iz766KNWX7fsAzds2DC+KUikZCw2REQATE1NsX37dnh5ebU6npqaiqCgIFy5ckWkZPRnCYKAzMxM7NixA99//z2ampowfvx4fPXVV2JHIyKip4jFhogIwJw5c/Djjz8iNjYWbm5uAICsrCwsXLgQEyZMEG1p4N87ffo0KioqcP/+fcUxiUQCb29vEVOpltzcXISFhSE/P59D+Oipkcvl+Omnn1otPDJ27FioqamJnIyoc+Fyz0REAGJjYyGRSBAUFITGxkYAgLq6OmbOnIlVq1aJmq1lNbSCggJIJBK0vB/VMq6fL9Af7+LFi9ixYwd27NiBU6dOwdXVFevXrxc7Fj0jSktLMXr0aFRWVsLW1hYAsHLlSvTq1QspKSno3bu3yAmJOg/esSEi+p2GhgacO3cOANC7d+8281rE4O3tDTU1NWzatAlWVlbIzs7G9evXERkZidjYWHh6eoodsUP68ssvsWPHDmRlZcHOzg4BAQHw9/eHhYWF2NHQ2NiIzMxMnDt3Dv7+/tDV1cWlS5fQrVs36OjoiB2P2mH06NEQBAHffvutYhW069evY8qUKZBKpUhJSRE5IVHnwWJDRAQgNDQUn332mWKj2hb19fWYPXu2qPMxjI2NkZ6eDkdHR+jp6SE7Oxu2trZIT09HZGRkm00zqVmvXr0wefJkBAQEwMnJSew4ChcuXMDIkSNRUVGBe/fuoaSkBNbW1pg7dy7u3buHL774QuyI1A7a2to4duwYHBwcWh3Py8uDu7s76urqREpG1PlwHxsiIgBff/31Q3d9v3PnDrZt2yZCot/I5XJF4TI2NsalS5cAABYWFiguLhYzWodWUVGBmJiYDlVqgOad6gcNGoQbN25AS0tLcdzX1xdpaWkiJqMn8dxzz+H27dttjtfV1UFDQ0OERESdF+fYEFGnVltbC0EQIAgCbt++DU1NTcU5uVyOvXv3KvaPEcuLL76IvLw8WFlZYciQIYiJiYGGhgYSEhJgbW0taraOJj8//w8/1tHR8S9M8miHDx/G0aNH27zotbS0RGVlpSiZ6MmNGTMGM2bMwObNm+Hi4gIAOH78OMLDwzF27FiR0xF1Liw2RNSp6evrQyKRQCKRoG/fvm3OSySSNvtUKNsHH3yA+vp6AMDHH3+MMWPGwNPTE0ZGRkhKShI1W0czYMCAhy6w8DBiLbrQ1NT00GtfvHixzVBI6vjWrVuH4OBguLq6Ql1dHUDzHKqxY8fis88+EzkdUefCOTZE1KkdPHgQgiBg+PDh+P777xWTfwFAQ0MDFhYW6NGjh4gJH66mpgYGBgaPfeHeGV24cEHxuUwmw4IFC7Bw4UK4uroCAH755ResXr0aMTEx8PHxESXjpEmToKenh4SEBOjq6iI/Px8mJiYYN24czM3NsWXLFlFy0Z9z9uxZFBUVAQDs7e1hY2MjciKizofFhogIzS+Izc3NWRSeIS4uLoiOjsbo0aNbHd+7dy8+/PBDnDx5UpRcFy9exBtvvAFBEHD27FkMGjQIZ8+ehbGxMQ4dOiT60EciIlXFYkNEBGD//v3Q0dGBh4cHAGD9+vXYuHEj+vXrh/Xr18PAwEC0bL6+vg8tXBKJBJqamrCxsYG/v79iDw1qpqWlhdzcXNjb27c6fubMGQwcOPChi0UoS2NjIxITE5Gfn4+6ujoMHDgQAQEBrRYTINUgCAKSk5ORkZGBq1evoqmpqdX5H374QaRkRJ0PV0UjIgKwcOFC1NbWAgAKCgoQERGB0aNHo7y8HBEREaJm09PTQ3p6OnJzcxXzgWQyGdLT09HY2IikpCQ4OTkhKytL1Jwdjb29PVauXIn79+8rjt2/fx8rV65sU3aUrUuXLpgyZQpiYmKwYcMGTJs2jaVGRc2bNw+BgYEoLy+Hjo4O9PT0Wn0QkfLwjg0REQAdHR2cOnUKlpaWiI6OxqlTp5CcnIzc3FyMHj0aVVVVomWLiopCbW0t4uPjIZU2vx/V1NSEuXPnQldXF8uXL0d4eDgKCwtx5MgR0XJ2NNnZ2fD29oYgCIoV0FpWTduzZ49iBSsxnD179pHv8C9dulSkVPQkDA0N8c0337QZ8khEysdiQ0SE5hcnR44cQb9+/eDh4YGgoCDMmDED58+fR79+/dDQ0CBaNhMTE2RlZbVZta2kpARubm6orq5GQUEBPD09cfPmTXFCdlD19fX49ttvW03q9vf3h7a2tmiZNm7ciJkzZ8LY2BhmZmathhlKJBLk5uaKlo3az8rKCvv27YOdnZ3YUYg6PS73TEQEwMPDAxEREXB3d0d2drZiGeWSkhK88MILomZrbGxEUVFRm2JTVFSkWDZYU1OTCx88hLa2Njw8PGBubq4YktayCaZYe4z8/e9/x/Lly7F48WJRrk9PV3R0ND766CN89dVXHE5IJDIWGyIiAPHx8XjnnXeQnJyMzz//HD179gQA7Nu3DyNHjhQ1W2BgIMLCwrBkyRIMHjwYAJCTk4MVK1YgKCgIQPOy1f379xczZodTVlYGX19fFBQUKPa2+X35E2sfmxs3bsDPz0+Ua9PT99Zbb2Hnzp14/vnnYWlpqdjLpgXvwBEpD4eiERF1cHK5HKtWrUJ8fDyuXLkCADA1NcXs2bOxePFiqKmpoaKiAlKpVPS7Sx2Jt7c31NTUsGnTJlhZWeH48eOoqalBZGQkYmNj4enpKUqusLAwDB48GOHh4aJcn56ut956CxkZGZg4cSJMTU3b3DldtmyZSMmIOh8WGyIiABUVFY89b25urqQkj9eyclu3bt1ETtLxGRsbIz09HY6OjtDT00N2djZsbW2Rnp6OyMhIyGQyUXKtXLkScXFxePPNN+Hg4NDmHf45c+aIkouejLa2NlJTUxVLxROReDgUjYgIgKWl5WPnqIg1bOl/sdD8cXK5HLq6ugCaS86lS5dga2sLCwsLFBcXi5YrISEBOjo6OHjwIA4ePNjqnEQiYbFRMb169eLvJVEHwWJDRAS0eff+wYMHkMlkiIuLw/Lly0VK9Zvk5GTs2rULFRUVrfZlATiG/1FefPFF5OXlwcrKCkOGDEFMTAw0NDSQkJAAa2tr0XKVl5eLdm16+lavXo1Fixbhiy++gKWlpdhxiDo1DkUjInqMlJQU/OMf/0BmZqZoGdatW4f3338fU6dORUJCAkJCQnDu3Dnk5ORg1qxZHaJ4dUSpqamor6/H+PHjUVpaijFjxqCkpARGRkZISkrC8OHDxY5IzwADAwM0NDSgsbERXbt2bTO0sKamRqRkRJ0Piw0R0WOUlpbCyckJ9fX1omWws7PDsmXLMHnyZOjq6iIvLw/W1tZYunQpampqEB8fL1o2VVNTUwMDAwOlL40dERGBTz75BNra2oiIiHjsY+Pi4pSUip6Gr7/++rHng4ODlZSEiDgUjYgIv03KbyEIAi5fvozo6Gj06dNHpFTNKioq4ObmBgDQ0tLC7du3ATQvAz106FAWm3YwNDQU5boymQwPHjxQfE7PDhYXoo6DxYaICIC+vn6bd/EFQUCvXr2QmJgoUqpmZmZmqKmpgYWFBczNzXHs2DE4OTmhvLwcvOmuGjIyMh76OT1b7t6922YOHBcWIFIeFhsiIgDp6emtio1UKoWJiQlsbGzQpYu4fyqHDx+O3bt3w9nZGSEhIZg/fz6Sk5Nx4sQJjB8/XtRs1H7btm3D4MGDYW9v3+r43bt3sWvXLsWmq6Qa6uvrsXjxYuzatQvXr19vc76jrKhI1Blwjg0RUQfX1NSEpqYmRcFKTEzE0aNH0adPH7z99tvQ0NAQOSG1h1Qqhba2NrZu3YoJEyYojl+5cgU9evTgC2EVM2vWLGRkZOCTTz5BYGAg1q9fj8rKSnz55ZdYtWoVAgICxI5I1Gmw2BARoXnTRFNTU4SGhrY6/tVXX+HatWtYvHixSMnoWSOVShEbG4sPPvgAixYtQnR0NAAWG1Vlbm6Obdu2YdiwYejWrRtyc3NhY2OD7du3Y+fOndi7d6/YEYk6DRYbIiI0b9C5Y8cOxST9FsePH8ff/vY30fceuXv3LvLz83H16lU0NTW1Ojd27FiRUtGTkEqlqKqqQllZGXx9feHu7o7t27ejtraWxUYF6ejo4PTp0zA3N8cLL7yAH374AS4uLigvL4eDgwPq6urEjkjUaXCODRERgKqqKnTv3r3NcRMTE1y+fFmERL/Zv38/goKCUF1d3eacRCLhC2EV0zKXa+jQoTh+/DjGjh0LNzc3fPHFFyInoydhbW2N8vJymJubw87ODrt27YKLiwt+/vln6Ovrix2PqFORih2AiKgj6NWrF7Kystocz8rKQo8ePURI9JvZs2fDz88Ply9fVsy3aflgqVE9vx8oYW5ujqNHj8LS0hKvv/66iKnoSYWEhCAvLw8AEBUVhfXr10NTUxPz58/HwoULRU5H1Lnwjg0REYDp06dj3rx5ePDggWJH+rS0NCxatAiRkZGiZrty5QoiIiJgamoqag56OpYtWwYdHR3F1127dsWPP/6IZcuW4dChQyImoycxf/58xeevvfYaioqKcPLkSdjY2MDR0VHEZESdD+fYEBGh+V30qKgorFu3TrEPhaamJhYvXoylS5eKmi00NBTu7u4ICwsTNQcREVFHxmJDRPQ7dXV1OHPmDLS0tNCnTx8899xzYkdCQ0MD/Pz8YGJiAgcHB6irq7c6P2fOHJGS0Z9x+vRpVFRUtNrQUSKRwNvbW8RU9EesW7fuDz+Wv59EysNiQ0TUwW3evBnh4eHQ1NSEkZFRq41EJRIJysrKRExH7dWyGlpBQQEkEolizk3L/1fOm+r4rKys/tDj+PtJpFwsNkREHZyZmRnmzJmDqKgoSKVc80XVeXt7Q01NDZs2bYKVlRWys7Nx/fp1REZGIjY2Fp6enmJHJCJSSSw2REQdnKGhIXJyctC7d2+xo9BTYGxsjPT0dDg6OkJPTw/Z2dmwtbVFeno6IiMjIZPJxI5IRKSSuCoaEVEHFxwcjKSkJCxZskTsKPQUyOVy6OrqAmguOZcuXYKtrS0sLCxQXFwscjpqr4iIiIcel0gk0NTUhI2NDcaNGwdDQ0MlJyPqfFhsiIg6OLlcjpiYGKSmpsLR0bHN4gFxcXEiJaMn8eKLLyIvLw9WVlYYMmQIYmJioKGhgYSEBFhbW4sdj9pJJpMhNzcXcrkctra2AICSkhKoqanBzs4OGzZsQGRkJI4cOYJ+/fqJnJbo2cahaEREHdyrr776yHMSiQTp6elKTEN/VmpqKurr6zF+/HiUlpZizJgxKCkpgZGREZKSkhT7KJFqWLt2LQ4fPowtW7agW7duAIBbt25h2rRp8PDwwPTp0+Hv7487d+4gNTVV5LREzzYWGyIiIpHV1NTAwMCg1Yp3pBp69uyJAwcOtLkbU1hYCC8vL1RWViI3NxdeXl6orq4WKSVR58DldYiIiERmaGjIUqOibt26hatXr7Y5fu3aNdTW1gIA9PX1W+1XRER/Dc6xISIiUiJfX9+HlpjfTzb39/dXzNegjm3cuHEIDQ3F6tWrMXjwYABATk4OFixYAB8fHwBAdnY2+vbtK2JKos6BQ9GIiIiUaOrUqfjpp5+gr6+Pl156CQCQm5uLmzdvwsvLC3l5eTh//jzS0tLg7u4uclr6/9TV1WH+/PnYtm0bGhsbAQBdunRBcHAw1qxZA21tbfz6668AgAEDBogXlKgTYLEhIiJSoqioKNTW1iI+Pl6x4WpTUxPmzp0LXV1dLF++HOHh4SgsLMSRI0dETkt/VF1dHcrKygAA1tbW0NHRETkRUefDYkNERKREJiYmyMrKajM0qaSkBG5ubqiurkZBQQE8PT1x8+ZNcUISEakgLh5ARESkRI2NjSgqKmpzvKioCHK5HACgqanJxQSIiNqJiwcQEREpUWBgIMLCwrBkyZJWk81XrFiBoKAgAMDBgwfRv39/MWMSEakcDkUjIiJSIrlcjlWrViE+Ph5XrlwBAJiammL27NlYvHgx1NTUUFFRAalUihdeeEHktEREqoPFhoiISCQt+5y07FhPRERPjsWGiIiIiIhUHufYEBERKVlycjJ27dqFioqKNjvS5+bmipSKiEi1cVU0IiIiJVq3bh1CQkJgamoKmUwGFxcXGBkZoaysDKNGjRI7HhGRyuJQNCIiIiWys7PDsmXLMHnyZOjq6iIvLw/W1tZYunQpampqEB8fL3ZEIiKVxDs2RERESlRRUQE3NzcAgJaWFm7fvg2geRnonTt3ihmNiEilsdgQEREpkZmZGWpqagAA5ubmOHbsGACgvLwcHERBRPTkWGyIiIiUaPjw4di9ezcAICQkBPPnz8frr7+OSZMmwdfXV+R0RESqi3NsiIiIlKipqQlNTU3o0qV5YdLExEQcPXoUffr0wdtvvw0NDQ2RExIRqSYWGyIiIiIiUnncx4aIiEjJ7t69i/z8fFy9ehVNTU2tzo0dO1akVEREqo3FhoiISIn279+PoKAgVFdXtzknkUggl8tFSEVEpPq4eAAREZESzZ49G35+frh8+bJivk3LB0sNEdGT4xwbIiIiJerWrRtkMhl69+4tdhQiomcK79gQEREp0cSJE5GZmSl2DCKiZw7v2BARESlRQ0MD/Pz8YGJiAgcHB6irq7c6P2fOHJGSERGpNhYbIiIiJdq8eTPCw8OhqakJIyMjSCQSxTmJRIKysjIR0xERqS4WGyIiIiUyMzPDnDlzEBUVBamUI8KJiJ4W/kUlIiJSovv372PSpEksNURETxn/qhIRESlRcHAwkpKSxI5BRPTM4QadRERESiSXyxETE4PU1FQ4Ojq2WTwgLi5OpGRERKqNc2yIiIiU6NVXX33kOYlEgvT0dCWmISJ6drDYEBERERGRyuMcGyIiIiIiUnksNkREREREpPJYbIiIiIiISOWx2BARERERkcpjsSEiIiIiIpXHYkNERH8JS0tLrF27VuwYT9358+chkUjw66+/ih2FiIh+h8WGiIj+X1u3boW+vr7YMYiIiB6JxYaIiOgh7t+/L3YEIiJqBxYbIqJO4Pbt2wgICIC2tja6d++ONWvWYNiwYZg3bx4A4N69e1iwYAF69uwJbW1tDBkyBJmZmQCAzMxMhISE4NatW5BIJJBIJIiOjm53hk2bNkFfXx9paWkAgFOnTmHUqFHQ0dGBqakpAgMDUV1dDQDYtm0bjIyMcO/evVY/w8fHB4GBgbh16xbU1NRw4sQJAEBTUxMMDQ0xdOhQxWO/+eYb9OrVS/F1QUEBhg8fDi0tLRgZGWHGjBmoq6tTnJ86dSp8fHywfPly9OjRA7a2tgCA7OxsODs7Q1NTE4MGDYJMJmuV6caNGwgICICJiQm0tLTQp08fbNmypd3PDxER/TksNkREnUBERASysrKwe/duHDhwAIcPH0Zubq7i/LvvvotffvkFiYmJyM/Ph5+fH0aOHImzZ8/Czc0Na9euRbdu3XD58mVcvnwZCxYsaNf1Y2JiEBUVhX//+98YMWIEbt68ieHDh8PZ2RknTpzA/v37ceXKFbz11lsAAD8/P8jlcuzevVvxM65evYqUlBSEhoZCT08PAwYMUJSvgoICSCQSyGQyRVk5ePAgXnnlFQBAfX093njjDRgYGCAnJwffffcd/vOf/+Ddd99tlTMtLQ3FxcU4cOAA9uzZg7q6OowZMwb9+vXDyZMnER0d3ea//cMPP8Tp06exb98+nDlzBp9//jmMjY3b9fwQEdFTIBAR0TOttrZWUFdXF7777jvFsZs3bwpdu3YV5s6dK1y4cEFQU1MTKisrW33fiBEjhPfee08QBEHYsmWLoKen167rWlhYCGvWrBEWLVokdO/eXTh16pTi3CeffCJ4eXm1evx///tfAYBQXFwsCIIgzJw5Uxg1apTi/OrVqwVra2uhqalJEARBiIiIEN58801BEARh7dq1wqRJkwQnJydh3759giAIgo2NjZCQkCAIgiAkJCQIBgYGQl1dneLnpaSkCFKpVKiqqhIEQRCCg4MFU1NT4d69e4rHfPnll4KRkZFw584dxbHPP/9cACDIZDJBEATB29tbCAkJaddzQ0RET18XsYsVERH9tcrKyvDgwQO4uLgojunp6SmGWhUUFEAul6Nv376tvu/evXswMjL6U9devXo16uvrceLECVhbWyuO5+XlISMjAzo6Om2+59y5c+jbty+mT5+OwYMHo7KyEj179sTWrVsxdepUSCQSAMArr7yCzZs3Qy6X4+DBg/Dy8oKZmRkyMzPh6OiI0tJSDBs2DABw5swZODk5QVtbW3Edd3d3NDU1obi4GKampgAABwcHaGhoKB5z5swZODo6QlNTU3HM1dW1Vd6ZM2diwoQJyM3NhZeXF3x8fODm5vannjciImo/Fhsiok6urq4OampqOHnyJNTU1Fqde1jxaA9PT0+kpKRg165diIqKanVNb29vfPrpp22+p3v37gAAZ2dnODk5Ydu2bfDy8kJhYSFSUlIUj3v55Zdx+/Zt5Obm4tChQ1ixYgXMzMywatUqODk5oUePHujTp0+78v6++PxRo0aNwoULF7B3714cOHAAI0aMwKxZsxAbG9vun0VERE+Oc2yIiJ5x1tbWUFdXR05OjuLYrVu3UFJSAqC5QMjlcly9ehU2NjatPszMzAAAGhoakMvl7b62i4sL9u3bhxUrVrR6oT9w4EAUFhbC0tKyzTV/Xy6mTZuGrVu3YsuWLXjttddaLQagr68PR0dHxMfHQ11dHXZ2dnj55Zchk8mwZ88exfwaALC3t0deXh7q6+sVx7KysiCVShV3rh7G3t4e+fn5uHv3ruLYsWPH2jzOxMQEwcHB+Oabb7B27VokJCS0+7kiIqI/h8WGiOgZp6uri+DgYCxcuBAZGRkoLCxEWFgYpFIpJBIJ+vbti4CAAAQFBeGHH35AeXk5srOzsXLlSsUdEktLS9TV1SEtLQ3V1dVoaGj4w9d3c3PD3r178dFHHyk27Jw1axZqamowefJk5OTk4Ny5c0hNTUVISEirAuXv74+LFy9i48aNCA0NbfOzhw0bhm+//VZRYgwNDWFvb4+kpKRWxSYgIACampoIDg7GqVOnkJGRgdmzZyMwMFAxDO1h/P39IZFIMH36dJw+fRp79+5tcydm6dKl+Ne//oXS0lIUFhZiz549sLe3/8PPDxERPR0sNkREnUBcXBxcXV0xZswYvPbaa3B3d4e9vb1i7siWLVsQFBSEyMhI2NrawsfHBzk5OTA3NwfQXE7Cw8MxadIkmJiYICYmpl3X9/DwQEpKCj744AP885//RI8ePZCVlQW5XA4vLy84ODhg3rx50NfXh1T62z9Nenp6mDBhAnR0dODj49Pm577yyiuQy+WKuTRAc9n532Ndu3ZFamoqampqMHjwYEycOBEjRoxAfHz8Y3Pr6Ojg559/RkFBAZydnfH++++3GT6noaGB9957D46Ojnj55ZehpqaGxMTEdj0/RET050kEQRDEDkFERMpVX1+Pnj17YvXq1QgLCxM7zmONGDEC/fv3x7p168SOQkREHRgXDyAi6gRkMhmKiorg4uKCW7du4eOPPwYAjBs3TuRkj3bjxg1kZmYiMzMTGzZsEDsOERF1cCw2RESdRGxsLIqLi6GhoYGXXnoJhw8ffuKNJA8fPoxRo0Y98nzLJpl/hrOzM27cuIFPP/30sRP8iYiIAA5FIyKiJ3Dnzh1UVlY+8ryNjY0S0xAREbHYEBERERHRM4CrohERERERkcpjsSEiIiIiIpXHYkNERERERCqPxYaIiIiIiFQeiw0REREREak8FhsiIiIiIlJ5LDZERERERKTy/g94YGoG1COYmwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x500 with 1 Axes>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Then, we embed it into a prompt that we make to OpenAI."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Eg: Count the number of messages that contain a specific keyword\n",
-    "\n",
-    "keywords_to_count = augmented_messages_df.explode(\"get_keywords\").groupby(\"get_keywords\").size().sort_values(ascending=False)\n",
-    "\n",
-    "keywords_to_count.head(20).plot(kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Bonus: Use the previous results of the job\n",
-    "\n",
-    "This PoC was cool, but all the Job execution are independent. \n",
-    "\n",
-    "Let's say that you want to **use the previous results of the job** as context for the current message. For example, to anchor the LLM with the current keywords found.\n",
-    "\n",
-    "There are multiple ways to do it. \n",
-    "\n",
-    "### With phospho\n",
-    "\n",
-    "With phospho, one cool way is to set a `job` argument to the job function. At runtime, `job` is then a reference to the current lab.Job and contains all results so far."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def get_keywords_previous_results(\n",
-    "    message: lab.Message,\n",
-    "    job: lab.Job = None, # Add the job as an argument\n",
-    "    model: str=\"openai:gpt-3.5-turbo\",\n",
-    ") -> lab.JobResult:\n",
-    "    \"\"\"\n",
-    "    This function uses OpenAI GPT to extract keywords from a given message.\n",
-    "\n",
-    "    It also uses the previous results of the job to provide context to the LLM.\n",
-    "    The job argument is used to access the previous results.\n",
-    "    \"\"\"\n",
-    "    provider, model_name = lab.get_provider_and_model(model)\n",
-    "    openai_client = lab.get_async_client(provider)\n",
-    "\n",
-    "    # Using the reference to the job, we can access the results of the other jobs\n",
-    "    # to use them as context for the current job\n",
-    "    previous_keywords = []\n",
-    "    if job:\n",
-    "        # Get the previous results\n",
-    "        previous_job_results = job.results.values()\n",
-    "        # Let's flatten the list of lists of keywords\n",
-    "        previous_keywords = [keyword for result in previous_job_results for keyword in result.value]\n",
-    "\n",
-    "    prompt = \"You are an annotator reading Amazon product reviews. Your job is to label \\\n",
-    "    each review with topics that describe important topics covered in the review, relevant \\\n",
-    "    to the e-commerce domain. Do not include generic topics such as 'good', 'bad', 'interesting', etc.\"\n",
-    "    \n",
-    "    # If there are previous results, we add them to the prompt\n",
-    "    if len(previous_keywords) > 0:\n",
-    "        prompt += f\"\"\"\n",
-    "        So far, you've reviewed {len(previous_job_results)} reviews, and the keywords you've found are:\n",
-    "        {\", \".join(previous_keywords)}\n",
-    "\n",
-    "        If possible, reuse the existing topics to label the current review. Do not add \n",
-    "        variations of the same topics.\"\"\"\n",
-    "\n",
-    "    prompt = f\"\"\"The review is: \n",
-    "    {message.content}\n",
-    "\n",
-    "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
-    "    Keywords:\"\"\"\n",
-    "\n",
-    "    response = await openai_client.chat.completions.create(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
-    "        messages=[\n",
-    "            {\n",
-    "                \"role\": \"system\",\n",
-    "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
-    "            },\n",
-    "            {\"role\": \"user\", \"content\": prompt},\n",
-    "        ],\n",
-    "    )\n",
-    "\n",
-    "    response = response.choices[0].message.content\n",
-    "    keywords = re.findall(r\"- (.*)\", response)\n",
-    "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
-    "    return lab.JobResult(\n",
-    "        value=keywords,\n",
-    "        result_type=lab.ResultType.list,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's run this job. \n",
-    "\n",
-    "Note that we are still running the jobs in parallel! This means that the existing results won't always be available at the start. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No job_config provided. Running with empty config\n",
-      "100%|██████████| 100/100 [00:10<00:00,  9.52it/s]\n"
-     ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of different keywords extracted: 552\n"
-     ]
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'- Old computer\\n- Computer performance\\n- Advice\\n- MaximumPC\\n- Computer parts\\n- Vendors\\n- Useful tests'"
+            ]
+          },
+          "execution_count": 26,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "openai_client = openai.AsyncClient(api_key=os.environ[\"OPENAI_API_KEY\"])\n",
+        "\n",
+        "# Label every message with keywords it contains\n",
+        "prompt = f\"\"\"You are an annotator reading Amazon product reviews. Your job is to label\n",
+        "each review with keywords that describe the main topics covered in the review.\n",
+        "The review is: \n",
+        "{message.content}\n",
+        "\n",
+        "Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
+        "Keywords:\"\"\"\n",
+        "\n",
+        "response = await openai_client.chat.completions.create(\n",
+        "    model=\"gpt-3.5-turbo\",\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"system\",\n",
+        "            \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
+        "        },\n",
+        "        {\"role\": \"user\", \"content\": prompt},\n",
+        "    ],\n",
+        ")\n",
+        "response.choices[0].message.content"
+      ]
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJLCAYAAAA1hAPqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACauklEQVR4nOzdeViN+f8/8Ocp2nctRNqsUfax7wZlzzKI7GYMIstgxhZGlrEzjLFmGIOxjGWEELKT7FT2JXuobNX790e/7m/HyTo59333eT6u61zqPrdznp1T97lf93vTCCEEiIiIiIiIVMxA7gBERERERET/FQsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiAgC4ubmhadOmcseQ1d69e6HRaLB3797//Fhdu3aFm5vbf36cjyH3e+fm5oauXbvK9vxERAALGyL6gGXLlkGj0UCj0eDAgQM69wsh4OLiAo1G88VOrO7cuYOxY8fi1KlTX+TxidTg/PnzGDt2LK5duyZ3lByjtL/tbdu2YezYsXLHIKLPxMKGiD6KiYkJVq1apbM9MjISt27dgrGx8Rd77jt37iAkJEQxJz9EH+P333/HpUuXcuzxzp8/j5CQkFxX2Cjpb3vbtm0ICQmROwYRfSYWNkT0Ufz8/LB27VqkpqZqbV+1ahUqVKiA/Pnzy5SM6OMJIfDixQu9PFfevHm/aMFPRETaWNgQ0Ufp0KEDHj16hJ07d0rbXr9+jXXr1qFjx47Z/p/k5GQMHjwYLi4uMDY2RvHixfHLL79ACKG1386dO1GjRg3Y2NjAwsICxYsXx48//gggY8xDpUqVAADdunWTusUtW7bsvXlv376NHj16wNnZGcbGxnB3d0efPn3w+vVraZ8rV66gbdu2sLOzg5mZGapUqYKtW7dqPU7mmIs1a9YgJCQEBQsWhKWlJdq0aYOnT5/i1atXGDhwIBwdHWFhYYFu3brh1atXWo+h0WjQr18/rF27Fl5eXjA1NUXVqlVx5swZAMBvv/2GIkWKwMTEBHXq1Mn2ivzatWtRoUIFmJqawt7eHp06dcLt27e19unatSssLCxw+/ZttGzZEhYWFnBwcMCQIUOQlpb23tfrXZYvX448efJg6NCh0rYjR46gcePGsLa2hpmZGWrXro2oqCjp/j179kCj0WDDhg06j7dq1SpoNBocOnQI//zzDzQaDU6fPi3d//fff0Oj0cDf31/r/5UsWRLffPON9H1qairGjx8PT09PGBsbw83NDT/++KPOa5859iQ8PBwVK1aEqakpfvvtNwDArVu30LJlS5ibm8PR0RHBwcE6/x8AYmNj0bp1a+TPnx8mJiYoVKgQ2rdvj6dPn773tXt7jM21a9eg0Wjwyy+/YOHChVL2SpUq4dixY+99rGXLlqFt27YAgLp160p/B2+PBTpw4AC++uormJiYwMPDA2FhYTqPlZiYiIEDB0p/l0WKFMHkyZORnp7+3gxARmE4YcIEFCpUCGZmZqhbty7OnTuns9/jx48xZMgQeHt7w8LCAlZWVvD19UVMTIy0z4f+tvfv34+2bduicOHCMDY2houLC4KDg3UK04SEBHTr1g2FChWCsbExChQogBYtWuj8Hf3777+oWbMmzM3NYWlpiSZNmmhl79q1K+bNmwcAUhaNRvPB14SIFEQQEb3H0qVLBQBx7NgxUa1aNdG5c2fpvo0bNwoDAwNx+/Zt4erqKpo0aSLdl56eLurVqyc0Go3o2bOnmDt3rmjWrJkAIAYOHCjtd/bsWWFkZCQqVqwoZs2aJRYsWCCGDBkiatWqJYQQIiEhQYwbN04AEL179xYrVqwQK1asEPHx8e/MfPv2beHs7CzMzMzEwIEDxYIFC8SoUaNEyZIlxZMnT6THdXJyEpaWluKnn34S06dPF2XKlBEGBgZi/fr10mPt2bNHABBly5YVVatWFbNnzxZBQUFCo9GI9u3bi44dOwpfX18xb9480blzZwFAhISEaOUBIHx8fISLi4uYNGmSmDRpkrC2thaFCxcWc+fOFV5eXmLatGli5MiRwsjISNStWzfb96BSpUpixowZYvjw4cLU1FS4ublJP48QQnTp0kWYmJiIUqVKie7du4v58+eL1q1bCwDi119//eB7/fZ7+NtvvwmNRiN++uknaVtERIQwMjISVatWFdOmTRMzZswQPj4+wsjISBw5ckR6711cXETr1q11nsPPz094enoKIYR49OiR0Gg0Ys6cOdL9AwYMEAYGBsLBwUHadv/+fQFAzJ07V+tnBSDatGkj5s2bJwIDAwUA0bJlS52fqUiRIsLW1lYMHz5cLFiwQOzZs0ekpKSIYsWKCRMTE/HDDz+ImTNnigoVKggfHx8BQOzZs0cIIcSrV6+Eu7u7cHZ2FhMmTBCLFi0SISEholKlSuLatWvvfT27dOkiXF1dpe+vXr0qAIhy5cqJIkWKiMmTJ4spU6YIe3t7UahQIfH69et3PlZ8fLwICgoSAMSPP/4o/R0kJCRIP2fx4sWFk5OT+PHHH8XcuXNF+fLlhUajEWfPnpUeJzk5Wfj4+Ih8+fKJH3/8USxYsEAEBgYKjUYjBgwY8N6fRwghRo4cKQAIPz8/MXfuXNG9e3fh7Ows7O3tRZcuXaT9jh07Jjw9PcXw4cPFb7/9JsaNGycKFiworK2txe3bt4UQH/7b7t+/v/Dz8xMTJ04Uv/32m+jRo4cwNDQUbdq00cpUrVo1YW1tLUaOHCkWLVokJk6cKOrWrSsiIyOlfcLCwoRGoxGNGzcWc+bMEZMnTxZubm7CxsZGXL16VQghxMGDB8XXX38tAEhZVqxY8cHXhIiUg4UNEb1X1sJm7ty5wtLSUqSkpAghhGjbtq10Ev72SfHGjRsFADFhwgStx2vTpo3QaDQiLi5OCCHEjBkzBADx4MGDd2Y4duyYACCWLl36UZkDAwOFgYGBOHbsmM596enpQgghBg4cKACI/fv3S/c9f/5cuLu7Czc3N5GWliaE+L/CpnTp0lonnh06dBAajUb4+vpqPX7VqlW1TmaFyChsjI2NpRMoITKKBgAif/784tmzZ9L2ESNGCADSvq9fvxaOjo6idOnS4sWLF9J+W7ZsEQDE6NGjpW2ZJ/vjxo3Tev5y5cqJChUqvO8lE0Jov4ezZs0SGo1GjB8/Xuu1K1q0qGjUqJH0OgohREpKinB3dxdff/211s9hbGwsEhMTpW33798XefLkEWPGjJG2lSpVSrRr1076vnz58qJt27YCgLhw4YIQQoj169cLACImJkYIIcSpU6cEANGzZ0+t/EOGDBEAxO7du7V+JgBi+/btWvvOnDlTABBr1qyRtiUnJ4siRYpoFTbR0dECgFi7du0HX7+3vauwyZcvn3j8+LG0fdOmTQKA2Lx583sfb+3atVrZssr8Offt2ydtu3//vjA2NhaDBw+Wto0fP16Ym5uLy5cva/3/4cOHC0NDQ3Hjxo13Pv/9+/eFkZGRaNKkidb7/+OPPwoAWoXNy5cvpb+hrD+/sbGx1u/n+/62M48zWYWGhgqNRiOuX78uhBDiyZMnAoCYOnXqO3M/f/5c2NjYiF69emltT0hIENbW1lrb+/btK3jNl0i92BWNiD5au3bt8OLFC2zZsgXPnz/Hli1b3tkNbdu2bTA0NERQUJDW9sGDB0MIgX///RcAYGNjAwDYtGnTR3WF+ZD09HRs3LgRzZo1Q8WKFXXuz+xasm3bNnz11VeoUaOGdJ+FhQV69+6Na9eu4fz581r/LzAwEHnz5pW+r1y5MoQQ6N69u9Z+lStXxs2bN3XGItWvX1+rW1LlypUBAK1bt4alpaXO9itXrgAAjh8/jvv37+P777+HiYmJtF+TJk1QokQJna5zAPDdd99pfV+zZk3p8T7GlClTMGDAAEyePBkjR46Utp86dQqxsbHo2LEjHj16hIcPH+Lhw4dITk5G/fr1sW/fPuk9DAwMxKtXr7Bu3Trp///1119ITU1Fp06dtLLt378fAPD8+XPExMSgd+/esLe3l7bv378fNjY2KF26NICM9w4ABg0apJV78ODBAKDzmri7u6NRo0Za27Zt24YCBQqgTZs20jYzMzP07t1baz9ra2sAQHh4OFJSUj7q9fuQb775Bra2ttL3NWvWBIBPeo+y4+XlJT0WADg4OKB48eJaj7t27VrUrFkTtra20vv38OFDNGjQAGlpadi3b987H3/Xrl14/fo1+vfvr9VFa+DAgTr7Ghsbw8Ag4xQjLS0Njx49krqZnjx58qN+HlNTU+nr5ORkPHz4ENWqVYMQAtHR0dI+RkZG2Lt3L548eZLt4+zcuROJiYno0KGD1s9saGiIypUrY8+ePR+Vh4iUj4UNEX00BwcHNGjQAKtWrcL69euRlpamdWKY1fXr1+Hs7Kx10g5kjJXIvB/IOMmrXr06evbsCScnJ7Rv3x5r1qz57CLnwYMHePbsmXQS/C7Xr19H8eLFdba/nS9T4cKFtb7PPOF1cXHR2Z6enq4z/uJT/j8A6SQtM0d2WUuUKKGT08TEBA4ODlrbbG1t33nS97bIyEgMGzYMw4YN0xpXA2SMNQGALl26wMHBQeu2aNEivHr1Svq5S5QogUqVKmHlypXS/1+5ciWqVKmCIkWKSNtq1qyJu3fvIi4uDgcPHoRGo0HVqlW1Cp79+/ejevXq0ony9evXYWBgoPU4AJA/f37Y2NjovCbu7u46P+f169dRpEgRnTEUb7/O7u7uGDRoEBYtWgR7e3s0atQI8+bN++D4mvd5+3chs8j52PfoYx8387GzPm5sbCy2b9+u8/41aNAAAHD//v13Pn7m61q0aFGt7Q4ODlqFGpBxgWHGjBkoWrQojI2NYW9vDwcHB5w+ffqjX7sbN26ga9eusLOzk8aL1a5dGwCkxzA2NsbkyZPx77//wsnJCbVq1cKUKVOQkJCg9TMDQL169XR+7h07drz3ZyYidckjdwAiUpeOHTuiV69eSEhIgK+vr9Ti8rlMTU2xb98+7NmzB1u3bsX27dvx119/oV69etixYwcMDQ1zJvh/9K4c79ou3pog4b/+/4/1X1+vUqVKITExEStWrMC3336rVRRkFptTp05F2bJls/3/FhYW0teBgYEYMGAAbt26hVevXuHw4cOYO3eu1v6ZLWb79u3DlStXUL58eZibm6NmzZqYPXs2kpKSEB0djZ9//lnnuT52YHfWK/+fY9q0aejatSs2bdqEHTt2ICgoCKGhoTh8+DAKFSr0yY+X0+/5pzxueno6vv76a/zwww/Z7lusWLH/lCHTxIkTMWrUKHTv3h3jx4+HnZ0dDAwMMHDgwI+6aJGWloavv/4ajx8/xrBhw1CiRAmYm5vj9u3b6Nq1q9ZjDBw4EM2aNcPGjRsRHh6OUaNGITQ0FLt370a5cuWkfVesWJHt7I158vBUiCi34F8zEX2SVq1a4dtvv8Xhw4fx119/vXM/V1dX7Nq1C8+fP9dqtbl48aJ0fyYDAwPUr18f9evXx/Tp0zFx4kT89NNP2LNnDxo0aPBJMxM5ODjAysoKZ8+efe9+rq6u2a4xkl0+OWXmuHTpEurVq6d136VLl3I8p729PdatW4caNWqgfv36OHDgAJydnQEAnp6eAAArKyvpCv/7tG/fHoMGDcKff/6JFy9eIG/evFozmwEZrQyFCxfG/v37ceXKFakrVa1atTBo0CCsXbsWaWlpqFWrlvR/XF1dkZ6ejtjYWKmFDQDu3buHxMTEj3pNXF1dcfbsWQghtH6/3rXujLe3N7y9vTFy5EgcPHgQ1atXx4IFCzBhwoQPPldOyYkZujw9PZGUlPRR79/bMl/X2NhYeHh4SNsfPHig09q0bt061K1bF4sXL9banpiYCHt7e+n7d/1MZ86cweXLl7F8+XIEBgZK27POypiVp6cnBg8ejMGDByM2NhZly5bFtGnT8Mcff0i/t46Ojh/8uTkLGpG6sSsaEX0SCwsLzJ8/H2PHjkWzZs3euZ+fnx/S0tJ0rtDPmDEDGo0Gvr6+ADKmhX1bZmtA5tS75ubmADJOij7EwMAALVu2xObNm3H8+HGd+zOvXvv5+eHo0aM4dOiQdF9ycjIWLlwINzc3eHl5ffC59KFixYpwdHTEggULtKYi/vfff3HhwgU0adIkx5+zUKFC2LVrF168eIGvv/4ajx49AgBUqFABnp6e+OWXX5CUlKTz/x48eKD1vb29PXx9ffHHH39g5cqVaNy4sdZJbaaaNWti9+7dOHr0qFTYlC1bFpaWlpg0aRJMTU1RoUIFaX8/Pz8AwMyZM7UeZ/r06QDwUa+Jn58f7ty5ozUGKCUlBQsXLtTa79mzZzrjpby9vWFgYJDt1NBf0qf8HbxLu3btcOjQIYSHh+vcl5iYqPOzZtWgQQPkzZsXc+bM0WoFevt9ADJaj95ugVq7dq3OFOXv+pkyW5+yPoYQArNmzdLaLyUlBS9fvtTa5unpCUtLS+n9adSoEaysrDBx4kS8efNGJ2vW39uceI2JSD5ssSGiT9alS5cP7tOsWTPUrVsXP/30E65du4YyZcpgx44d2LRpEwYOHChdRR03bhz27duHJk2awNXVFffv38evv/6KQoUKSd2UPD09YWNjgwULFsDS0hLm5uaoXLlytmMngIxuMDt27EDt2rXRu3dvlCxZEnfv3sXatWtx4MAB2NjYYPjw4fjzzz/h6+uLoKAg2NnZYfny5bh69Sr+/vtvaTyH3PLmzYvJkyejW7duqF27Njp06IB79+5h1qxZcHNzQ3Bw8Bd53iJFimDHjh2oU6cOGjVqhN27d8PKygqLFi2Cr68vSpUqhW7duqFgwYK4ffs29uzZAysrK2zevFnrcQIDA6VxWOPHj8/2uWrWrImVK1dCo9FI77mhoSGqVauG8PBw1KlTB0ZGRtL+ZcqUQZcuXbBw4UIkJiaidu3aOHr0KJYvX46WLVuibt26H/z5evXqhblz5yIwMBAnTpxAgQIFsGLFCpiZmWntt3v3bvTr1w9t27ZFsWLFkJqaihUrVsDQ0BCtW7f+pNf0vypbtiwMDQ0xefJkPH36FMbGxqhXrx4cHR0/+jGGDh2Kf/75B02bNkXXrl1RoUIFJCcn48yZM1i3bh2uXbuWbfEJQFoTKTQ0FE2bNoWfnx+io6Px77//6vyfpk2bYty4cejWrRuqVauGM2fOYOXKlVotPcC7/7ZLlCgBT09PDBkyBLdv34aVlRX+/vtvnZahy5cvo379+mjXrh28vLyQJ08ebNiwAffu3UP79u0BZLQwzp8/H507d0b58uXRvn17ODg44MaNG9i6dSuqV68uXYDJLKCDgoLQqFEjGBoaSo9DRCogy1xsRKQaWad7fp+3p3sWImOa1eDgYOHs7Czy5s0rihYtKqZOnao1VWxERIRo0aKFcHZ2FkZGRsLZ2Vl06NBBZzraTZs2CS8vL5EnT56Pmvr5+vXrIjAwUDg4OAhjY2Ph4eEh+vbtK169eiXtEx8fL9q0aSNsbGyEiYmJ+Oqrr8SWLVu0Hidzuue3p/t91+syZswYnemrAYi+fftq7Zc59e/b09S+6/n++usvUa5cOWFsbCzs7OxEQECAuHXrltY+Xbp0Eebm5jqvRWamD8nuPTxy5IiwtLQUtWrVkqbfjY6OFv7+/iJfvnzC2NhYuLq6inbt2omIiAidx3z16pWwtbUV1tbWWtNVZ3Xu3DkBQJQsWVJr+4QJEwQAMWrUKJ3/8+bNGxESEiLc3d1F3rx5hYuLixgxYoR4+fLlB3+mTNevXxfNmzcXZmZmwt7eXgwYMEBs375da0rlK1euiO7duwtPT09hYmIi7OzsRN26dcWuXbuyfxGzeNd0z9lNTQxAaxrsd/n999+Fh4eHMDQ01Mr5rp+zdu3aonbt2lrbnj9/LkaMGCGKFCkijIyMhL29vahWrZr45Zdf3ruWjhBCpKWliZCQEFGgQAFhamoq6tSpI86ePStcXV11pnsePHiwtF/16tXFoUOHss3zrr/t8+fPiwYNGggLCwthb28vevXqJWJiYrT2efjwoejbt68oUaKEMDc3F9bW1qJy5cpa03hn2rNnj2jUqJGwtrYWJiYmwtPTU3Tt2lUcP35c2ic1NVX0799fODg4CI1Gw6mfiVRGI8R/HK1IRET0DqmpqXB2dkazZs10xlsQERHlJGX0tSAiolxp48aNePDggdYAcCIioi+BLTZERJTjjhw5gtOnT2P8+PGwt7f/6EUZiYiIPhdbbIiIKMfNnz8fffr0gaOjI8LCwuSOQ0RE/wPYYkNERERERKrHFhsiIiIiIlI9FjZERERERKR6ilugMz09HXfu3IGlpSU0Go3ccYiIiIiISCZCCDx//hzOzs4fXDxbcYXNnTt34OLiIncMIiIiIiJSiJs3b6JQoULv3UdxhY2lpSWAjPBWVlYypyEiIiIiIrk8e/YMLi4uUo3wPoorbDK7n1lZWbGwISIiIiKijxqiwskDiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6eeQO8F+4Dd+aY491bVKTHHssIiIiIiLSL7bYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPU+qbAJDQ1FpUqVYGlpCUdHR7Rs2RKXLl3S2qdOnTrQaDRat++++y5HQxMREREREWX1SYVNZGQk+vbti8OHD2Pnzp148+YNGjZsiOTkZK39evXqhbt370q3KVOm5GhoIiIiIiKirPJ8ys7bt2/X+n7ZsmVwdHTEiRMnUKtWLWm7mZkZ8ufPnzMJiYiIiIiIPuA/jbF5+vQpAMDOzk5r+8qVK2Fvb4/SpUtjxIgRSElJ+S9PQ0RERERE9F6f1GKTVXp6OgYOHIjq1aujdOnS0vaOHTvC1dUVzs7OOH36NIYNG4ZLly5h/fr12T7Oq1ev8OrVK+n7Z8+efW4kIiIiIiL6H/XZhU3fvn1x9uxZHDhwQGt77969pa+9vb1RoEAB1K9fH/Hx8fD09NR5nNDQUISEhHxuDCIiIiIios/ritavXz9s2bIFe/bsQaFChd67b+XKlQEAcXFx2d4/YsQIPH36VLrdvHnzcyIREREREdH/sE9qsRFCoH///tiwYQP27t0Ld3f3D/6fU6dOAQAKFCiQ7f3GxsYwNjb+lBhERERERERaPqmw6du3L1atWoVNmzbB0tISCQkJAABra2uYmpoiPj4eq1atgp+fH/Lly4fTp08jODgYtWrVgo+Pzxf5AYiIiIiIiD6psJk/fz6AjEU4s1q6dCm6du0KIyMj7Nq1CzNnzkRycjJcXFzQunVrjBw5MscCExERERERve2Tu6K9j4uLCyIjI/9TICIiIiIiok/1n9axISIiIiIiUgIWNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqfVJhExoaikqVKsHS0hKOjo5o2bIlLl26pLXPy5cv0bdvX+TLlw8WFhZo3bo17t27l6OhiYiIiIiIsvqkwiYyMhJ9+/bF4cOHsXPnTrx58wYNGzZEcnKytE9wcDA2b96MtWvXIjIyEnfu3IG/v3+OByciIiIiIsqU51N23r59u9b3y5Ytg6OjI06cOIFatWrh6dOnWLx4MVatWoV69eoBAJYuXYqSJUvi8OHDqFKlSs4lJyIiIiIi+v/+0xibp0+fAgDs7OwAACdOnMCbN2/QoEEDaZ8SJUqgcOHCOHToULaP8erVKzx79kzrRkRERERE9Ck+u7BJT0/HwIEDUb16dZQuXRoAkJCQACMjI9jY2Gjt6+TkhISEhGwfJzQ0FNbW1tLNxcXlcyMREREREdH/qM8ubPr27YuzZ89i9erV/ynAiBEj8PTpU+l28+bN//R4RERERET0v+eTxthk6tevH7Zs2YJ9+/ahUKFC0vb8+fPj9evXSExM1Gq1uXfvHvLnz5/tYxkbG8PY2PhzYhAREREREQH4xBYbIQT69euHDRs2YPfu3XB3d9e6v0KFCsibNy8iIiKkbZcuXcKNGzdQtWrVnElMRERERET0lk9qsenbty9WrVqFTZs2wdLSUho3Y21tDVNTU1hbW6NHjx4YNGgQ7OzsYGVlhf79+6Nq1aqcEY2IiIiIiL6YTyps5s+fDwCoU6eO1valS5eia9euAIAZM2bAwMAArVu3xqtXr9CoUSP8+uuvORKWiIiIiIgoO59U2AghPriPiYkJ5s2bh3nz5n12KCIiIiIiok/xn9axISIiIiIiUgIWNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1Prmw2bdvH5o1awZnZ2doNBps3LhR6/6uXbtCo9Fo3Ro3bpxTeYmIiIiIiHR8cmGTnJyMMmXKYN68ee/cp3Hjxrh79650+/PPP/9TSCIiIiIiovfJ86n/wdfXF76+vu/dx9jYGPnz5//sUERERERERJ/ii4yx2bt3LxwdHVG8eHH06dMHjx49+hJPQ0REREREBOAzWmw+pHHjxvD394e7uzvi4+Px448/wtfXF4cOHYKhoaHO/q9evcKrV6+k7589e5bTkYiIiIiIKJfL8cKmffv20tfe3t7w8fGBp6cn9u7di/r16+vsHxoaipCQkJyOQURERERE/0O++HTPHh4esLe3R1xcXLb3jxgxAk+fPpVuN2/e/NKRiIiIiIgol8nxFpu33bp1C48ePUKBAgWyvd/Y2BjGxsZfOgYREREREeVin1zYJCUlabW+XL16FadOnYKdnR3s7OwQEhKC1q1bI3/+/IiPj8cPP/yAIkWKoFGjRjkanIiIiIiIKNMnFzbHjx9H3bp1pe8HDRoEAOjSpQvmz5+P06dPY/ny5UhMTISzszMaNmyI8ePHs1WGiIiIiIi+mE8ubOrUqQMhxDvvDw8P/0+BiIiIiIiIPtUXnzyAiIiIiIjoS2NhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkennkDpBbuQ3fmmOPdW1Skxx7LCIiIiKi3IgtNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESql0fuAKR/bsO35thjXZvUJMceKydzATmbjYiIiIiUjS02RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKqXR+4ARGrgNnxrjj3WtUlNcuyxAGVnIyIiItIXttgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6n1yYbNv3z40a9YMzs7O0Gg02Lhxo9b9QgiMHj0aBQoUgKmpKRo0aIDY2NicyktERERERKTjkwub5ORklClTBvPmzcv2/ilTpmD27NlYsGABjhw5AnNzczRq1AgvX778z2GJiIiIiIiyk+dT/4Ovry98fX2zvU8IgZkzZ2LkyJFo0aIFACAsLAxOTk7YuHEj2rdv/9/SEhERERERZSNHx9hcvXoVCQkJaNCggbTN2toalStXxqFDh7L9P69evcKzZ8+0bkRERERERJ/ik1ts3ichIQEA4OTkpLXdyclJuu9toaGhCAkJyckYRKQQbsO35thjXZvUJMcei4iIiHIf2WdFGzFiBJ4+fSrdbt68KXckIiIiIiJSmRwtbPLnzw8AuHfvntb2e/fuSfe9zdjYGFZWVlo3IiIiIiKiT5GjhY27uzvy58+PiIgIaduzZ89w5MgRVK1aNSefioiIiIiISPLJY2ySkpIQFxcnfX/16lWcOnUKdnZ2KFy4MAYOHIgJEyagaNGicHd3x6hRo+Ds7IyWLVvmZG4iIiIiIiLJJxc2x48fR926daXvBw0aBADo0qULli1bhh9++AHJycno3bs3EhMTUaNGDWzfvh0mJiY5l5qIiIiIiCiLTy5s6tSpAyHEO+/XaDQYN24cxo0b95+CERERERERfSzZZ0UjIiIiIiL6r1jYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUL4/cAYiI9M1t+NYcfbxrk5rk6OMRERHRp2OLDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPXyyB2AiIj+j9vwrTn2WNcmNcmxxwKUnY2IiIgtNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlK9HC9sxo4dC41Go3UrUaJETj8NERERERGRJM+XeNBSpUph165d//ckeb7I0xAREREREQH4QoVNnjx5kD9//i/x0ERERERERDq+yBib2NhYODs7w8PDAwEBAbhx48aXeBoiIiIiIiIAX6DFpnLlyli2bBmKFy+Ou3fvIiQkBDVr1sTZs2dhaWmps/+rV6/w6tUr6ftnz57ldCQiIiIiIsrlcryw8fX1lb728fFB5cqV4erqijVr1qBHjx46+4eGhiIkJCSnYxAR0f8Qt+Fbc+yxrk1qkmOPlZO5AOVmy8lcgLKzEZFyffHpnm1sbFCsWDHExcVle/+IESPw9OlT6Xbz5s0vHYmIiIiIiHKZL17YJCUlIT4+HgUKFMj2fmNjY1hZWWndiIiIiIiIPkWOFzZDhgxBZGQkrl27hoMHD6JVq1YwNDREhw4dcvqpiIiIiIiIAHyBMTa3bt1Chw4d8OjRIzg4OKBGjRo4fPgwHBwccvqpiIiIiIiIAHyBwmb16tU5/ZBERERERETv9cXH2BAREREREX1pLGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSvRxfoJOIiIgot3IbvjXHHuvapCY59lg5mQtQbraczAUw2+dQ8u8aW2yIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLV+2KFzbx58+Dm5gYTExNUrlwZR48e/VJPRURERERE/+O+SGHz119/YdCgQRgzZgxOnjyJMmXKoFGjRrh///6XeDoiIiIiIvof90UKm+nTp6NXr17o1q0bvLy8sGDBApiZmWHJkiVf4umIiIiIiOh/XJ6cfsDXr1/jxIkTGDFihLTNwMAADRo0wKFDh3T2f/XqFV69eiV9//TpUwDAs2fPPvhc6a9SciAxPvr5PgWzfbqczAUoN9v/yvsJKDcbf9c+D7N9Ov6ufR5m+3T8Xfs8zPbp9P27lnm/EOKDj6URH7PXJ7hz5w4KFiyIgwcPomrVqtL2H374AZGRkThy5IjW/mPHjkVISEhORiAiIiIiolzk5s2bKFSo0Hv3yfEWm081YsQIDBo0SPo+PT0djx8/Rr58+aDRaP7z4z979gwuLi64efMmrKys/vPj5RSl5gKY7XMpNZtScwHM9rmUmk2puQBm+1xKzabUXACzfS6lZlNqLuB/J5sQAs+fP4ezs/MH983xwsbe3h6Ghoa4d++e1vZ79+4hf/78OvsbGxvD2NhYa5uNjU1Ox4KVlZXi3nRAubkAZvtcSs2m1FwAs30upWZTai6A2T6XUrMpNRfAbJ9LqdmUmgv438hmbW39Ufvl+OQBRkZGqFChAiIiIqRt6enpiIiI0OqaRkRERERElFO+SFe0QYMGoUuXLqhYsSK++uorzJw5E8nJyejWrduXeDoiIiIiIvof90UKm2+++QYPHjzA6NGjkZCQgLJly2L79u1wcnL6Ek/3XsbGxhgzZoxOdze5KTUXwGyfS6nZlJoLYLbPpdRsSs0FMNvnUmo2peYCmO1zKTWbUnMBzJadHJ8VjYiIiIiISN++yAKdRERERERE+sTChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkRERERE9J/Ex8dj5MiR6NChA+7fvw8A+Pfff3Hu3Dm9ZWBhQ5SD0tLScOrUKTx58kTWHPXq1UNiYqLO9mfPnqFevXr6D0Qko9evX+PSpUtITU2VOwoA4OTJkzhz5oz0/aZNm9CyZUv8+OOPeP36tYzJKLd7+fKl3BEktra2sLOz07nly5cPBQsWRO3atbF06VK5Y9JHioyMhLe3N44cOYL169cjKSkJABATE4MxY8boLUeune45NTUVe/fuRXx8PDp27AhLS0vcuXMHVlZWsLCwkC1XbGws9uzZg/v37yM9PV3rvtGjR8uUCti9ezeqVasGExMT2TK8z4oVK7BgwQJcvXoVhw4dgqurK2bOnAl3d3e0aNFCtlwDBw6Et7c3evTogbS0NNSuXRsHDx6EmZkZtmzZgjp16siSy8DAAAkJCXB0dNTafv/+fRQsWBBv3ryRJRf9N0o9rr3t2bNn2L17N4oXL46SJUvKliMlJQX9+/fH8uXLAQCXL1+Gh4cH+vfvj4IFC2L48OGy5KpUqRKGDx+O1q1b48qVKyhVqhRatWqFY8eOoUmTJpg5c6YsubJKT09HXFxctp9VtWrVkikVfY709HT8/PPPWLBgAe7duyf9HYwaNQpubm7o0aOHLLlmzJiBn3/+Gb6+vvjqq68AAEePHsX27dsRHByMq1evYsWKFZgzZw569eql12z//PNPtts1Gg1MTExQpEgRuLu76zXTuyjleFu1alW0bdsWgwYNgqWlJWJiYuDh4YGjR4/C398ft27d0k8QkQtdu3ZNlChRQpiZmQlDQ0MRHx8vhBAiKChIfPvtt7LlWrhwoTA0NBROTk6iTJkyomzZstKtXLlysuUSQghzc3NhbGwsatSoIUaOHCl27twpUlJSZM2U6ddffxX29vZiwoQJwtTUVHo/ly5dKurUqSNrtoIFC4pjx44JIYTYsGGDcHZ2FpcuXRIjR44U1apV03uemJgYERMTIzQajdizZ4/0fUxMjDh58qSYOHGicHV11XuurFq2bClatWqlc/P39xcdO3YUo0ePFhcvXpQt3759+0RAQICoUqWKuHXrlhBCiLCwMLF//37ZMgmh3OOaEEK0bdtWzJkzRwghREpKiihatKjImzevyJMnj1i3bp1suYKCgkSFChXE/v37hbm5ufSabdy4UZQtW1a2XFZWViIuLk4IIcSkSZNEw4YNhRBCHDhwQBQqVEi2XJkOHTok3N3dhYGBgdBoNFo3AwMDueOJsLAwUa1aNVGgQAFx7do1IYQQM2bMEBs3bpQ115MnT0R4eLhYsWKFWL58udZNTiEhIcLDw0P88ccfWp+hq1evFlWqVJEtl7+/v5g/f77O9gULFgh/f38hhBCzZ88WpUuX1nc06Xc9u9//zH9r1aolHj9+rPdsSj3empubiytXrgghhLCwsJB+z65evSqMjY31liNXFjYtWrQQnTp1Eq9evdJ6cffs2SOKFCkiW67ChQuLSZMmyfb87/P69Wtx4MAB8fPPP4uGDRsKCwsLYWRkJKpVqyZ++uknWbOVLFlSbNiwQQih/cdy5swZkS9fPhmTCWFsbCxu3rwphBCiV69eYsCAAUIIIa5cuSIsLS31nifzgJvdAVmj0QgzMzOxePFivefKqkuXLsLa2lq4uroKf39/4e/vL9zc3ISNjY1o166dKF68uDA2NhYHDhzQe7Z169YJU1NT0bNnT2FsbCz9rs2ZM0f4+vrqPU9WSj2uCSGEk5OTOHXqlBBCiJUrV4oiRYqI5ORk8euvv8paQBQuXFgcOnRICKF97IiNjZXl7zOTpaWluHz5shBCiAYNGoiZM2cKIYS4fv26MDExkS1XpjJlyoi2bduK8+fPiydPnojExEStm5yUeqHrn3/+EZaWlkKj0Qhra2thY2Mj3WxtbWXLJYQQnp6eYteuXUII7b+DCxcuCBsbG9lymZubi9jYWJ3tsbGxwtzcXAghRFxcnDAzM9N3NLFr1y5RuXJlsWvXLvHs2TPx7NkzsWvXLlG1alWxdetWceDAAVGqVCnRvXt3vWdT6vG2YMGCIioqSgih/Xu2fv164eHhobccubKwsbOzk674vl01mpqaypbL0tJSyqJ0Z8+eFV26dBF58uSR/QqdiYmJdFUu6/t5+fJl2U8CChcuLMLDw0VqaqpwcXERW7ZsEUJkvH5yfGBcu3ZNXL16VWg0GnHs2DFx7do16Xbnzh2Rmpqq90xvGzZsmOjTp49IS0uTtqWlpYl+/fqJESNGiPT0dNG7d29RvXp1vWcrW7asdHU16+/ayZMnhZOTk97zZKXU45oQGX+jN27cEEII0blzZzFs2DAhRMaJeuYJihyynvhmfc1OnTolrKysZMtVt25dERgYKMLCwkTevHmlk7u9e/fK3qIqhBBmZmbZnnAqgVIvdBUtWlQMGDBAJCcny5bhXd71GXru3DlZ/z5dXFzE9OnTdbZPnz5duLi4CCEyeiHIcewtVaqUdJKe1YEDB4SXl5cQQoidO3dKOfVJqcfbwYMHixo1aoi7d+8KS0tLERsbKw4cOCA8PDzE2LFj9ZYjj346vOlXeno60tLSdLbfunULlpaWMiTK0LZtW+zYsQPfffedbBne5fLly9i7dy/27t2LyMhIvHr1CjVr1sQvv/wi2ziRTO7u7jh16hRcXV21tm/fvl3W/qQA0K1bN7Rr1w4FChSARqNBgwYNAABHjhxBiRIl9J4n8zV6u0+8kixevBhRUVEwMPi/uUsMDAzQv39/VKtWDRMnTkS/fv1Qs2ZNvWe7dOlStuMHrK2ts52MQZ+UelwDABcXFxw6dAh2dnbYvn07Vq9eDQB48uSJrOP2KlasiK1bt6J///4AMvrHA8CiRYtQtWpV2XLNnDkTAQEB2LhxI3766ScUKVIEALBu3TpUq1ZNtlyZKleujLi4OCmXkly9ehXlypXT2W5sbIzk5GQZEmW4ffs2goKCYGZmJluGd/Hy8sL+/ft1PkPXrVuX7WupL6NGjUKfPn2wZ88eaYzNsWPHsG3bNixYsAAAsHPnTtSuXVvv2eLj42FlZaWz3crKCleuXAEAFC1aFA8fPtR3NMUebydOnIi+ffvCxcUFaWlp8PLyQlpaGjp27IiRI0fqLUeuLGwaNmyImTNnYuHChQAyPsySkpIwZswY+Pn5yZarSJEiGDVqFA4fPgxvb2/kzZtX6/6goCCZkgElSpSAg4MDBgwYgOHDh8Pb21s6CZDboEGD0LdvX7x8+RJCCBw9ehR//vknQkNDsWjRIlmzjR07FqVLl8bNmzfRtm1bGBsbAwAMDQ1lG5icSakTVaSmpuLixYsoVqyY1vaLFy9KJ+4mJiay/P7lz58fcXFxcHNz09p+4MABeHh46D1PVko9rgEZk2gEBATAwsICrq6u0sWQffv2wdvbW7ZcEydOhK+vL86fP4/U1FTMmjUL58+fx8GDBxEZGSlbLh8fH61Z0TJNnToVhoaGMiTS1r9/fwwePBgJCQnZflb5+PjIlEy5F7oaNWqE48ePy36cyM7o0aPRpUsX3L59G+np6Vi/fj0uXbqEsLAwbNmyRbZcvXr1gpeXF+bOnYv169cDAIoXL47IyEipwB88eLAs2SpUqIChQ4ciLCwMDg4OAIAHDx7ghx9+QKVKlQBkfMa6uLjoPVvW423hwoUVc7w1MjLC77//jlGjRuHs2bNISkpCuXLlULRoUf0G0VvbkB7dvHlTeHl5iZIlS4o8efKIKlWqiHz58onixYuLe/fuyZbLzc3tnTd3d3fZcgkhxIABA0S5cuWEsbGxqFq1qhgxYoQIDw9XTLP6H3/8IYoUKSKNFSlYsKBYtGiR3LG0vHjxQu4IEiVPVNG/f39hb28vpk+fLvbv3y/2798vpk+fLuzt7UVQUJAQQojff/9dlq5oEydOFF5eXuLw4cPC0tJS7N+/X/zxxx/CwcFBzJ49W+95slLqcS3T8ePHxfr168Xz58+lbVu2bJFlrFRWcXFxomfPnqJSpUqiZMmSIiAgQJw+fVrWTJmOHTsmwsLCRFhYmDQJiRJkNz4v66BpOf3++++iYMGCYvXq1cLc3Fz8+eefYsKECdLXclm0aJEoXLiwGDNmjFi3bp3YtGmT1k1u+/btEw0aNBAODg7C1NRUVK9eXYSHh8sdS7EuXrwoihcvLoyMjISnp6fw9PQURkZGokSJEuLSpUtCiIwJg8LCwmTJd+zYMUUeb5UgV0/3vHr1apw+fRpJSUkoX748AgICYGpqKnc0RUtMTMT+/fsRGRmJyMhInDt3DuXKlUNUVJTc0QBkTN+alJSkM42xXNLS0jBx4kTFTaPp6uqK77//HsOGDZPl+d8nLS0NkyZNwty5c3Hv3j0AgJOTE/r3749hw4bB0NAQN27cgIGBAQoVKqTXbEIITJw4EaGhoUhJSQGQ0cVlyJAhGD9+vF6zZIfHtdzh1q1b6NChA6KiomBjYwMg49hbrVo1rF69Wu+/92+7fv36e+9/u7VE31auXImxY8ciPj4eAODs7IyQkBDZjrcAtLrWvk2j0WTbjZSUPa14eno6duzYgcuXLwPIaE36+uuv3/te69Pr169x9epVeHp6Ik8e+TtgpaWlYdmyZYiIiMj2/dy9e7decuTawkbpMl92pXT3yvTo0SNERkZiz5492Lt3L86fPw9bW1tZ+pFmunr1KlJTU3WaM2NjY5E3b16dbkP6NG7cOCxfvhzjxo1Dr169cPbsWXh4eOCvv/7CzJkzcejQIVlyWVlZ4dSpU4rsFpHVs2fPACDbvsxyev36NeLi4pCUlAQvLy9FrBHz8uVLxa4zBWScrP/zzz+4ceOGziKT06dP11uOzN+pjyHX713jxo2RmJiI5cuXo3jx4gAyxnd169YNVlZW2L59uyy51EZpF7qUysPDA8eOHUO+fPm0ticmJqJ8+fLSmBF9O3z4MDp27Ijr16/j7VNRFoPvptT1ufr164dly5ahSZMm0rjjrGbMmKGXHLm2sFHq+IKwsDBMnToVsbGxAIBixYph6NCh6Ny5s2yZgIzxPVkLmVq1aqF27dqoU6eO7ONtateuje7du6NLly5a2//44w8sWrQIe/fulScYMsZN/fbbb6hfv77WglQXL15E1apV8eTJE1ly9ejRA5UqVVLkRBX0eaysrNCqVSt06tQJ9evXV8xVQwCIiIhA8+bNpd/90qVL49q1axBCoHz58nq7UgdkXDn/0PFKCCHriZOpqSkOHjyoM3D7xIkTqFmzptRaKKf4+HjMnDkTFy5cAJAxAH3AgAHw9PSUNZeSL3Qp1bsWbL537x4KFy6MV69eyZKrbNmyKFasGEJCQrI9Eba2tpYlV6aIiIh3tj4sWbJEplTAgAEDEBUVhZkzZ6Jx48Y4ffo0PDw8sGnTJowdOxbR0dGy5LK3t0dYWJjsYz7lb7v6An7//Xf06dMH9vb2yJ8/v9Yfi0ajka2wmT59OkaNGoV+/fqhevXqADIGJX/33Xd4+PAhgoODZckFAHfv3kXv3r1Rp04dlC5dWrYc2YmOjpZer6yqVKmCfv36yZDo/9y+fTvbmYPS09Px5s0bGRJlUPJEFffu3cOQIUOkD4y3r63o+2TT39//o/fNHOAqh+XLl2PVqlVo0aIFrK2t8c0336BTp06oWLGibJkyjRgxAkOGDEFISAgsLS3x999/w9HREQEBAWjcuLFes+zZs0evz/c5XFxcsj0+pKWlwdnZWYZE2sLDw9G8eXOULVtWOvZGRUWhVKlS2Lx5M77++mvZsnXt2hXdu3fXKWyOHDki+4WuyMhI/PLLL1rF4NChQ2WZ4REA/vnnH+nr8PBwrUIhLS0NERERshaCsbGxWLdunSJn3wsJCcG4ceNQsWLFbIsuOW3cuBF//fUXqlSpopWrVKlSUvdMORgZGSnivcyVLTZKHV/g7u6OkJAQBAYGam1fvnw5xo4di6tXr8qUTNmsra2xd+/ebK9u1qlTB8+fP5cpWcbMKcHBwejUqZNWi824ceOwc+dO7N+/X5Zc7u7u77xPo9HI1vUAAHx9fXHjxg3069cv2w+MFi1a6DVPt27dPnrfpUuXfsEkH+f58+dYt24d/vzzT+zevRseHh7o1KmTrC3RlpaWOHXqFDw9PWFra4sDBw6gVKlSiImJQYsWLXDt2jXZsinRpk2bMHHiRMybN08qTI8fPy6NM2vZsqWs+cqVK4dGjRph0qRJWtuHDx+OHTt24OTJkzIly2i5PHnypM4JVFxcHCpWrCjbtOx//PEHunXrBn9/f61icMOGDVi2bBk6duyo90yZrboajUbnAlJm69a0adPQtGlTvWcDgHr16uGHH37Q+8WPj1GgQAFMmTJF9t402TEzM5O6vWc974iJiUGtWrXw9OlTWXJNmzYNV65cwdy5c+UtBGWYsOCLU+pCmMbGxtkuenb58mVhbGwsQyJtYWFholq1aqJAgQLSYl4zZswQGzdulDVX06ZNRdu2bbUWl0xNTRWtW7cWjRs3ljGZEBs3bhTW1tZi0qRJwszMTEydOlX07NlTGBkZiR07dsiaTaksLCxEdHS03DFyhXPnzomyZcvKPlOVk5OTOH/+vBAiYwHFzFmgTp06JeuCcUII8fjxYzF16lTRvXt30b17d/HLL7+IR48eyZrJxsZGGBkZCQMDA2FkZKT1ta2trdZNDsbGxuLy5cs62y9duiT7Z5WVlZU4efKkzvbjx48LCwsLGRJlKFGiRLaLTU6bNk2UKFFChkT/x83NTTx48EDWDNlZv3698PLyEkuXLhXHjx8XMTExWjc52dnZibi4OFkzvEvNmjWlWTotLCzElStXhBBC9OvXTzRq1Ei2XC1bthTW1tbC3d1dNG3aVLRq1Urrpi+5siuaUhfCLFKkCNasWYMff/xRa/tff/2l/3m+3zJ//nyMHj0aAwcOxM8//yx1B7KxscHMmTP1fhU9q0mTJqF27dooXry41KS/f/9+PHv2TK9997PTokULbN68GePGjYO5uTlGjx6N8uXLy95dI5PSZk0BMrrhCIU2FI8ZMwbdu3eXfdan93n58iX++ecfrFq1Ctu3b4eTkxOGDh0qa6YqVargwIEDKFmyJPz8/DB48GCcOXMG69evR5UqVWTLtW/fPjRr1gzW1tZSy8js2bMxbtw4bN68WbZZl2bOnCnL834sBwcHnDp1Sudz6dSpU7IP1K9VqxZCQ0Px559/Smv+pKWlITQ0FDVq1JAt15UrV9CsWTOd7c2bN9f5zNc3pfYGad26NQCge/fu0rbM1iW5Jw/o2bMnVq1ahVGjRsmW4V2Uuj6XjY0NWrVqJdvzZ8qVXdFCQ0Mxffp0NGnSRFHjC/7++2988803aNCggVZTdUREBNasWSPrL4SXlxcmTpyIli1bajVtnj17FnXq1JF1VjQAuHPnDubOnYuYmBiYmprCx8cH/fr1g52dnay5lEqps6YAwI4dOzBt2jT89ttvihvoW7ZsWZw9exa1a9dGjx490Lp1a2nRVbmFh4dj1apV2LhxI/LkyYM2bdogICBA9ilRgYyTuqSkJPj4+CA5ORmDBw/GwYMHUbRoUUyfPl22QtHb2xtVq1bF/PnztU6Cv//+exw8eDDbRTIpY7bHGTNmYPjw4dJCiVFRUZg8eTIGDRok68ne+fPnUatWLdjY2GR7oUuuMaJFihTB0KFD8e2332ptX7BgAaZNmyZNGKQvs2fPRu/evWFiYoLZs2e/d1+5zomUPK34gAEDEBYWBh8fH/j4+OicR+pzpsfsxMfHY9KkSYiJiZGm/h82bJisC3QqRa4sbJQ8vuDEiROYMWOGNLiwZMmSGDx4sM74EX0zNTXFxYsX4erqqlXYxMbGwsfHBy9evJAl15s3b9C4cWMsWLBA9lYtNVHqrCkAYGtri5SUFKSmpsLMzEznA+Px48cyJcsQHR2NpUuX4s8//0Rqairat2+P7t27S6tNy8XMzAxNmzZFQEAA/Pz8dF430mVqaopTp05JUypnunTpEsqWLavX49qzZ8+k6aU/NCW13NOfCyEwc+ZMTJs2DXfu3AGQsVbM0KFDERQUJPtAaiVe6Jo/fz4GDhyI7t27axWDy5Ytw6xZs3QKni/N3d0dx48fR758+RR9TqRUdevWfed9Go1G9t4i9G65srChT+fl5YXQ0FC0aNFCq7CZM2cOli5dKutgUQcHB+nqrxLY2tp+9Ae7XCfprq6u0qwpWd/PuLg4lC9f/pPW+shpma1I7/L2tN5yefPmDTZv3oylS5ciPDwcJUqUQI8ePdC1a1dZpiF9/vw5LC0t9f68HysxMRHr1q1DfHw8hg4dCjs7O5w8eRJOTk4oWLCgLJmqV6+OoUOH6gzG37hxIyZNmoTDhw/rLYuhoSHu3r0LR0fHd05JrYQuOG/LnJxFyb97SrFhwwZMmzZN68Ll0KFDZe3KrTT//PMPfH19kTdvXq1Z27LTvHlzPaVSn7S0NGzYsEFrBr4WLVrovct5+fLlERERAVtbW5QrV+6950b6Oo9URqf7XEwtV+kGDRqEvn374uXLlxBC4OjRo/jzzz8RGhqKRYsWyZYLADp16oTFixfrzNAjF6X3jweABw8eZNsXPjk5WfarrUopXD5ECIE3b97g9evXEELA1tYWc+fOxahRo/D777/jm2++0WseS0tLpKWlYePGjTofZpndrORy+vRpNGjQANbW1rh27Rp69eoFOzs7rF+/Hjdu3EBYWJhes2QKCgrCgAEDEBcXJ431OXz4MObNm6f348nu3bulFoWlS5fCxcVF531LT0/HjRs39JrrQ5RQ0Jw+fRqlS5eGgYGB1vubHR8fHz2l0tWqVStFjDH4kLS0NJw5cwaurq6wtbXV63O3bNlSWlPnfbP/Ka3AV5Jz586hefPmSEhIkFqjJ0+eDAcHB2zevFmv3TFbtGghdddu0aKF7OcXQC5qsRk0aBDGjx8Pc3NzDBo06L376rNvpJqu0q1cuRJjx46V5kF3dnZGSEgIevToIWuu/v37IywsDEWLFkWFChVgbm6udb/cfV2VqFatWmjbti369+8PS0tLnD59Gu7u7ujfvz9iY2P1vrK5Wgp8IKO7aGZXNGNjYwQGBqJnz57S9LJz5szBhAkTcO/ePb3miouLg5+fH27fvq21Wr2Liwu2bt0q68KJDRo0QPny5TFlyhStFsKDBw+iY8eOep3uOfM4+6GPNjmPuVk/F7J69OgRHB0dZcmlxCuvmbIuMPm+91cJn6NKNHDgQHh7e6NHjx5IS0tDrVq1cOjQIZiZmWHLli2oU6eO3BEVwd/fH8uWLYOVldUH1zeTc02zqlWrwsHBAcuXL5cK0ydPnqBr16548OABDh48KFs2Jcg1LTbR0dHSgmdyjh94W9ardEpfOC4gIAABAQFISUlBUlKS7LPfZDp79izKly8PIGMQfFZyXx3Ytm0bDA0N0ahRI63tO3bsQFpaGnx9fWXJpbRZU2xtbaUTORsbG8UW+N7e3rh48SIaNmyIxYsXo1mzZjpX1Tt06IABAwboPVtQUBA8PT1x+PBh6Zjy6NEjdOrUCUFBQdi6daveM2U6duwYfvvtN53tBQsWREJCgl6zKHUGqKwyf9fflpSUBBMTExkSKfPKa6arV6/CwcFB+lop7OzscPnyZdjb23+wi7KcYwfXrVuHTp06AQA2b96Ma9eu4eLFi1ixYgV++uknREVFyZZNSaytraX3UI7uxh/r1KlTOH78uFZrm62tLX7++WdZx4J2794dtWvX1umV8ezZMwwcOBBLlizRS45c02KjBjdu3ICLi4vOwU8IgZs3b6Jw4cIyJaPP5ePjg0mTJsHPz09r+/bt2zFs2DDExMTIlExZs6ZERkaievXqyJMnzwcLq9q1a+spla7x48eje/fuso0JeR9zc3McPnxY5/2LiYlB9erVkZSUJFMywNHREeHh4ShXrpxWi83OnTvRvXt33Lx5U7ZsSpLZm2DWrFno1asXzMzMpPvS0tJw5MgRGBoa8kTzHd68eYNvv/0Wo0aNeu+AeH1Zvnw52rdvD2NjYyxbtuy9hY2cXXBNTEwQFxeHQoUKoXfv3jAzM8PMmTNx9epVlClTRtYxlxEREToTKg0cOBANGjSQLZPSlSlTBjNmzEC9evW0tu/evRsDBgyQbbZHAwMDmJqaokePHpg5c6a0QOy9e/fg7Oyst4uWuabFJquwsDBUqlQJJUuW1Nr+8uVLrFmzBoGBgbLkcnd3z7b7wePHj+Hu7q73K9VK7nqQnbi4OMTHx6NWrVowNTV951VPfYqNjYWXl5fO9hIlSiAuLk6GRP/H09MTv//+u6wZMmUtVuQsXD4kcyzN2168eIGpU6di9OjRMqTKYGxsLA3kziopKQlGRkYyJPo/zZs3x7hx47BmzRoAGS2pN27cwLBhw6S1KuR0/vx53LhxA69fv9baru/ByZm9CYQQOHPmjNb7ZmRkhDJlymDIkCF6zZQdDw8PHDt2DPny5dPanpiYiPLly8s2i1bevHnx999/K2ZtkazFSteuXeUL8gFOTk44f/48ChQogO3bt2P+/PkAMpYFkHN83q+//ooBAwagTZs2Uiv44cOH4efnhxkzZqBv376yZVOy0NBQBAUFYezYsVpjB8eNG4fJkydrFar67tq9detW9OzZExcuXMCaNWv0PoYLyKUtNgYGBjA3N8eyZcu0PlT1XTVml+vevXtSk3qm69evw8vLC8nJyXrNExISgqFDh8LMzAxjx459b5EwZswYPSbT9ujRI7Rr1w579uyBRqNBbGwsPDw80L17d9ja2mLatGmyZcufPz9WrVqlc+Vk165d6NixI+7fvy9LLqX14f/QgN+s5Bz8q7TXLavAwECcPHkSixcvxldffQUAOHLkCHr16oUKFSpg2bJlsmV7+vQp2rRpg+PHj+P58+dwdnZGQkICqlatim3btumMi9OXK1euoFWrVjhz5ozWuIzMY51c72e3bt0wa9Ys2ceTvUvWMS1Z3bt3Dy4uLjoFoj516dIFZcuWRXBwsGwZsqPkY8fYsWMxc+ZMFChQACkpKbh8+TKMjY2xZMkS/P777zh06JAsuQoVKoThw4ejX79+WtvnzZuHiRMn4vbt27LkAjJ+14cMGYKIiAjcv39fZ0yXnO9nZksI8H/HsrePbXJ07c48bhgaGqJ169a4ffs2/vnnH9jZ2bHFJieEhISgc+fOOHPmDMaOHStrlszuBxqNBqNGjcq2+0HZsmX1nitrsSL3a/Q+wcHByJs3L27cuKHVCvfNN99g0KBBshY2LVq0wMCBA7FhwwZp8HZcXBwGDx4s61SV77pe8erVK1mu7pctW1ZrRen3kfMD4135YmJiZF8Mdvbs2ejSpQuqVq0qrWHz5s0btGjRQvaZ+qytrbFz504cOHAAp0+flro+yt2dZMCAAXB3d0dERATc3d1x9OhRPHr0CIMHD8Yvv/wiW66lS5fK9tzvk3X63fDwcK1xBmlpadLrKKeiRYti3LhxiIqKynYyGbkWm1TaMTersWPHonTp0rh58ybatm0rjaUyNDSUdbHmxMRENG7cWGd7w4YNMWzYMBkS/Z+uXbvixo0bGDVqFAoUKCB775CslDpeO/M1ypcvH3bt2oXvvvsOVatWxdSpU/WbI7e22CQkJEhX66pXr44VK1bg2bNnsrTYZC70FBkZiapVq+p0P3Bzc8OQIUNkXaelZ8+e6NSpkyJnR8mfPz/Cw8NRpkwZrf77V65cgY+Pj6xjC54+fYrGjRvj+PHjKFSoEADg1q1bqFmzJtavXw8bGxu95slcYTo4OBjjx4+HhYWFdF9aWhr27duHa9eu6X2CjawrTEdHR2PIkCEYOnQoqlatCgA4dOgQpk2bhilTprx3CtAvJXPg79OnT2FlZaX1IZaWloakpCR89913mDdvnt6zvS0uLk6rP3rmbG2ky97eHrt374aPjw+sra1x9OhRFC9eHLt378bgwYMVNdGMEmReCc5u1rG8efPCzc0N06ZNQ9OmTeWIB0B5C3Ar9ZirBh07dkS5cuUwdOhQre2//PILjh8/jtWrV8uULGOa8/3798ty0VmtsmvpnT59OoYNG4b09HS22PwXmSclVapUwZEjR9C8eXNUq1YNCxYskCVPZnWt5O4HDx48QOPGjeHg4ID27dujU6dOKFOmjNyxAGSsvZK1lSvT48ePpStPcrG2tsbBgwexc+dOrVWwa9WqJUueGTNmAMi4erhgwQKt/tOZRbQcfweurq7S123btsXs2bO1Jlzw8fGBi4sLRo0aJUthM3PmTAgh0L17d4SEhGhdqc583TKLMH360NT1Wa/c6Xva88wTuo8h11X0tLQ0aR0We3t73LlzB8WLF4erqysuXbokSyYlS09PB5BRPBw7dgz29vYyJ9KVdVa0t7vfyEGpx9y3KXGQvpeXF37++Wfs3btXOr4ePnwYUVFRGDx4sNYxRt/HEBcXlw9OGa9PaljLac+ePTo9GwYNGgQfHx+9ToiSq1tsMqvGlJQUBAQEICIiAsnJyYqY5z5zliAXFxeZk/yfJ0+eYO3atVi1ahX279+PEiVKICAgAB07doSbm5tsufz8/FChQgWMHz9eWpPF1dUV7du3R3p6OtatWydbNqWqW7cu1q9fL8vAvQ8xNTXFyZMndSb3uHDhAsqXL48XL17IlEx79jYlyGzt/RCNRoPdu3d/4TTa3r5y/uDBA6SkpEitlImJiTAzM4Ojo6Nsg81r1qyJwYMHo2XLlujYsSOePHmCkSNHYuHChThx4gTOnj0rSy76bxYvXowZM2YgNjYWQEb3tIEDB6Jnz56yZVLyMTfrIP2sBcS6detkHaT/sd0a5WiJ27FjB6ZNm4bffvtN1vOfTFzL6ePlysIm66D4rMaMGYN9+/bJ1j8xNTUVISEhmD17ttR9ysLCAv3798eYMWOkfvNKcOvWLfz5559YsmQJYmNjkZqaKluWs2fPon79+ihfvjx2796N5s2b49y5c3j8+DGioqL0vjDh7Nmz0bt3b5iYmHzwqrVcV6qVrHz58ihdujQWLVokdct8/fo1evbsibNnz8o6A9/JkyeRN29eaUrlTZs2YenSpfDy8sLYsWNl7yuvVKtWrcKvv/6KxYsXay0e2qtXL3z77bcICAiQJVd4eDiSk5Ph7++PuLg4NG3aFJcvX0a+fPnw119/6Uz6Qf8nOTkZkZGR2c4mJ+dxbfTo0Zg+fTr69++v1ZV17ty5CA4Oxrhx42TLplRKHqSvVLa2tkhJSUFqairMzMx0zs/0vS7R9evXUbhwYWg0Gq2u3dnJ2kNC327duoV//vkn2+OGvnoV5MrCRqn69OmD9evXY9y4cVoH5LFjx6Jly5bSFIxye/PmDbZu3Yo//vgDW7duhZ2dnewHvqdPn2Lu3Llaa7L07dsXBQoU0HsWd3d3HD9+HPny5VNcf+9MaWlpWLZsmTSjS2YXk0z6vrqf1dGjR9GsWTMIIaQm89OnT0Oj0WDz5s3SjF9yqFSpEoYPH47WrVvjypUr8PLygr+/P44dO4YmTZrIPkhfqTw9PbFu3TqUK1dOa/uJEyfQpk0bRS2q+Pjx4w8upvi/Ljo6Gn5+fkhJSUFycjLs7Ozw8OFD2VvgAMDBwQGzZ89Ghw4dtLb/+eef6N+/Px4+fChTMmWc1GXHwsICp06d0hmPFxsbi3Llysk6TjWTEroVZrV8+fL33i/nukRKFRERgebNm8PDwwMXL15E6dKlce3aNQghpAvT+pCrC5vs1i7QaDRo1qyZLHmsra2xevVqndXot23bhg4dOuDp06ey5Mq0Z88erFq1Cn///TfS09Ph7++PgIAA1KtXTzEHG/o4/fr1w7Jly9CkSZNsZ3TJ7Bcul+TkZKxcuRIXL14EkNHfu2PHjrJNC5zJ2toaJ0+ehKenJyZPnozdu3cjPDwcUVFRaN++PReafAczMzNERkbqrHp99OhR1KlTBykpKbLkWrp0Kdq3bw9TU1NZnl+t6tSpg2LFimHBggWwtrZGTEwM8ubNi06dOmHAgAHw9/eXLZuNjQ2OHTumM9nO5cuX8dVXXyExMVGWXEo5qcuOkgfpK7FbodKFhobCyckJ3bt319q+ZMkSPHjwQLYZ5b766iv4+voiJCREmujJ0dERAQEBaNy4Mfr06aOfICIXio+PFz4+PkKj0QgDAwOh0Wikrw0MDGTL5eDgIM6fP6+z/fz588Le3l6GRP/H2dlZmJiYiJYtW4q1a9eKly9fyprnbS9evBBHjhwRmzdvFps2bdK6ySkkJEQkJyfrbE9JSREhISEyJMqQL18+sXXrVtmeX60sLS3F5cuXhRBCNGjQQMycOVMIIcT169eFiYmJnNEUrWnTpqJcuXLixIkT0rbjx4+L8uXLi2bNmsmWy9HRUVhaWoru3buLqKgo2XKojbW1tbh48aL0debn1uHDh0Xx4sXljCb69esngoODdbYPHjxYfP/99zIkylCpUiUxevRoIYQQFhYWIj4+Xjx//lw0b95c/Prrr3rPM2vWLOk2fvx4YW1tLfz8/MT48ePF+PHjRZMmTYSNjY0YP3683rNlGjVqlDA3NxfDhw+XPs+HDx8uLCwsxKhRo2TLlSkuLk789NNPon379uLevXtCCCG2bdsmzp49K2suV1fXbI9nhw8fFm5ubjIkymBhYSHi4uKEEELY2NhIr9OpU6eEq6ur3nLkysKmadOmokWLFuLBgwfCwsJCnD9/Xuzfv1989dVXYt++fbLlCgkJER06dNAqGl6+fCkCAgLE2LFjZcslhBALFy4UT548kTXDu/z777/CwcFBKlCz3uQsVIUQwsDAQDrgZfXw4UNZsxUoUEBcunRJtuf/GOfOnRP//vuvogrVunXrisDAQBEWFiby5s0rYmNjhRBC7N27V68HZrW5f/++8PX1FRqNRhgZGQkjIyOh0WiEr6+vSEhIkC3XmzdvxPr160Xz5s1F3rx5RfHixcWkSZPE3bt3ZcukBvb29lKBX7RoUbF9+3YhhBAXLlwQZmZmckYT/fr1E1ZWVqJUqVKiR48eokePHqJ06dLCyspKKnoyb/qklJO6TG5ubh91c3d313u2TPb29mLVqlU621etWiXy5csnQ6L/s3fvXmFqaioaNGggjIyMRHx8vBBCiNDQUNG6dWtZsxkbG4srV67obI+PjxfGxsYyJMrg5OQkXQQpWbKk9Hl+6tQpYW5urrccypj6J4cdOnQIu3fvhr29PQwMDGBgYIAaNWogNDQUQUFBss0nHx0djYiICBQqVEiaSjkmJgavX79G/fr1tZr3169fr9dsvXr1ApCxRkZ8fDxq1aoFU1PTj1pQ8Uvr378/2rZti9GjR8PJyUnWLG971+sj94KOgwcPxqxZszB37lzZ37+3KXU1eCBj2ueAgABs3LgRP/30k9Qnfd26dahWrZpsuZTOwcEB27ZtQ2xsrDSdbIkSJVCsWDFZc+XJkwetWrVCq1atcO/ePfzxxx9Yvnw5Ro0ahcaNG6NHjx5o1qyZ1kreBJQrV07q7lW7dm2MHj0aDx8+xIoVK1C6dGlZs509exbly5cHAMTHxwPImMrb3t5ea5Y7fR/3zM3NpW7vBQoUQHx8PEqVKgUAsoz7UdK4tnd58+YNKlasqLO9QoUKsk5YBADDhw/HhAkTMGjQIGnKeACoV68e5s6dK2OyjNl0o6KidMb4RkVFwdnZWaZUGUusHDhwACVLloSfnx8GDx6MM2fOYP369ahSpYrecuTKwkapaxfY2NigdevWWtuUMt3zo0eP0K5dO+zZswcajQaxsbHw8PBAjx49YGtri2nTpsmW7d69exg0aJCiiprMwccajQbFihV754KOcjlw4AD27NmDf//9F6VKldKZ0UXfhXNWSl0NHsiY///MmTM626dOnaq1PgVlrE8wfvx4mJubZ7vezt69e6Wv5Rw4ncnJyQk1atTA5cuXcfnyZZw5cwZdunSBra0tli5dqsjFieUyceJEPH/+HADw888/IzAwEH369EHRokWxZMkSWbMpddV1pZzUvc/r169x9epVeHp6KmJK+86dO2P+/Pk6x4eFCxfKNpNipjNnzmDVqlU62x0dHWWdoALIuBA9cOBAvHnzRprZMSIiAj/88AMGDx4sW67p06dLE1GEhIQgKSkJf/31F4oWLarXzwD5f7O/gNKlSyMmJgbu7u6oXLkypkyZAiMjIyxcuBAeHh6y5Vq6dKlsz/0hwcHByJs3L27cuKG1vsg333yDQYMGyVrYtGnTBnv37tX7tM7vo9QFHTPZ2NigVatWsj3/+yi1RTVTYmIi1q1bh/j4eAwdOhR2dnY4f/48nJycULBgQVmzKUl0dDTevHkjff0ucrcY3rt3DytWrMDSpUtx5coVtGzZElu2bEGDBg2QnJyMcePGoUuXLh+cQvV/Sdar6I6Ojti+fbuMadRBKSd12UlJSUH//v2lmb4uX74MDw8P9O/fHwULFsTw4cNly7Z48WLs2LFDKv6OHDmCGzduIDAwUOuCib5fQxsbG9y9e1enVSQ6Olr2z4GhQ4fi0aNH+P7776VWQhMTEwwbNgwjRoyQLVfW82tzc3PZFqbNlbOice2CT5c/f36Eh4ejTJky0mwWHh4euHLlCnx8fGSdDjIlJQVt27aFg4MDvL29dVof5FpTITU1FStXrkS9evUU0/KmBra2tjh58iTc3d3h6emJRYsWoW7duoiPj4e3t7dsM2gBGdNO169fHzY2Nrh27RouXboEDw8PjBw5Ejdu3EBYWJhs2ejTNWvWDOHh4ShWrBh69uyJwMBAnS6i9+/fR/78+XWmRCf6WGlpaYiKioKPj4+0QK2SDBgwAFFRUZg5cyYaN26M06dPw8PDA5s2bcLYsWNlu5ik5AWIhwwZgiNHjmDt2rUoVqwYTp48iXv37iEwMBCBgYEYM2aMXvNkJykpCRcuXICpqSmKFi0KY2NjuSMpQq5ssWnUqJH0dZEiRXDx4kXZ1i4oX748IiIiYGtri3Llyr33+eVcmDA5OVlnQVMgY80Huf9Y/vzzT+zYsQMmJibYu3ev1muo0WhkK2zy5MmDPn36SGMKlOjBgwdS98vixYvDwcFB5kTKbVEFMrpXdevWDVOmTNHqV+3n54eOHTvKmIw+h6OjIyIjI9/beurg4KCK8Qj69OjRI4wePRp79uzJdh0sfS9OqHSGhoZo2LAhLly4oMjCZuPGjfjrr79QpUoVrc/PUqVKSeOU5KDUboVARnfMvn37wsXFBWlpafDy8kJaWho6duyIkSNHyh0PAJCQkIDHjx+jVq1aMDY2ln1M9LvOsTUaDUxMTFCkSBF07doV3bp1+6I5cmVhkx25BnK3aNFCKgxatmwpS4aPUbNmTYSFhWH8+PEAMn4R09PTMWXKlI++qvKl/PTTTwgJCcHw4cMVN8j3q6++QnR0tKwr/WYnOTkZ/fv3R1hYmHRSYmhoiMDAQMyZMyfbIlZfRo4cieTkZADAuHHj0LRpU9SsWVNqUZXTsWPH8Ntvv+lsL1iwIBISEmRIRP/F4sWLP7iPRqNR3N+v3Dp37oy4uDj06NEDTk5OsncnVIPSpUvjypUr7120WS4PHjyAo6Ojzvbk5GTFvLe3bt0CABQqVEjmJBmMjIzw+++/Y9SoUTh79iySkpJQrlw5nfWT5KDUMdGjR4/Gzz//DF9fX2mh7aNHj2L79u3o27cvrl69ij59+iA1NVWasOqL0Nv8a3rUsmVL0apVK52bv7+/6Nixoxg9erQ0R7++pKamisjISMVOqXz27Fnh6OgoGjduLIyMjESbNm1EyZIlhZOTkzSFpVxsbW1lz/Auf/31l/Dw8BBz5swRBw8eFDExMVo3ufTu3Vt4eHiIbdu2iadPn4qnT5+KrVu3Ck9PT/Hdd9/JlutdHj16JNLT0+WOIRwcHMTJkyeFEP+3FoUQQuzYsUMUKlRIzmj0mfbu3SuaNm0qPD09haenp2jWrJms0/6rgYWFhTh16pTcMVTl33//FWXLlhWbN28Wd+7ckY67mTc51axZU8yePVsIkfHeZk4V3K9fP9GoUSPZcqWlpYmQkBBhZWUlrTNobW0txo0bJ9LS0mTLpXSdO3cWjRo1Ejdv3tT6nNq+fbvw8vKSLZe/v7+YP3++zvYFCxYIf39/IYQQs2fPFqVLl/6iOXLlGJuuXbti48aNsLGxQYUKFQBkdPNKTExEw4YNERMTg2vXriEiIgLVq1fXWy4TExNcuHBBcVd03rx5g8aNGyM0NBQ7d+5ETEwMkpKSUL58efTt2xcFChSQNV9wcDAcHBzw448/ypojO+9rQdJoNLJNXWxvb49169bpzPS0Z88etGvXDg8ePJAlV1ZKnFq8Z8+eePToEdasWQM7OzucPn0ahoaGaNmyJWrVqoWZM2fKmo8+zR9//IFu3brB399fOtZHRUVhw4YNWLZsGbsXvkOlSpUwZ84cxczmpQZZPwuyHscyj2tyTmN/4MAB+Pr6olOnTli2bBm+/fZbnD9/HgcPHkRkZKR0nqRvI0aMwOLFixESEiL9fR44cABjx45Fr1698PPPP+s1T3azO76LnBNCKHVMtIWFBU6dOiUtk5ApLi4OZcuWRVJSEuLj4+Hj4yP12vgScmVXtPz586Njx46YO3eudLBJT0/HgAEDYGlpidWrV+O7777DsGHDcODAAb3lUmpTdd68eXH69GnY2trip59+kjuOjrS0NEyZMgXh4eHw8fHRmTxAzgOMUvvmp6SkZDs9tqOjo6yD8wHlNqMDwLRp09CmTRs4OjrixYsXqF27NhISElC1alW9f8jSf/fzzz9jypQpCA4OlrYFBQVh+vTpGD9+PAubd/j1118xfPhwjB49GqVLl9Y55lpZWcmUTLmUPF6kRo0aiImJQWhoKLy9vbFjxw6UL18ehw4dgre3t2y5li9fjkWLFqF58+bSNh8fHxQsWBDff/+93o+5b0+icPLkSaSmpqJ48eIAMmaTMzQ0lK0QzKTUMdF2dnbYvHmz1vEWADZv3iwNB0lOTtYav/ol5MoWGwcHB0RFReksDnf58mVUq1YNDx8+xJkzZ1CzZk0kJibqLdf27dsxYsQIjB8/HhUqVIC5ubnW/XJ+WAQHB8PY2BiTJk2SLcO7vG+MjxyzpWTn/PnzuHHjhjT1IpCRrVmzZrLkqV+/PvLly4ewsDCYmJgAAF68eIEuXbrg8ePH2LVrlyy5ACAwMBD379/HokWLULJkSelqU3h4OAYNGoRz587Jli1TVFSUVstlgwYN5I5En8HY2Bjnzp3L9gpi6dKl8fLlS5mSKVtsbCw6duyoM6GNElof6NMFBgaibt26qFWrlqKWTTAxMcHp06d1ztUuXbqEsmXL4sWLFzIly7hgunfvXixfvhy2trYAgCdPnqBbt26oWbOmrOvF+Pn5oUKFChg/fjwsLS1x+vRpuLq6on379khPT8e6detkyfX777+jT58+8PPzk8bYHDt2DNu2bcOCBQvQo0cPTJs2DUePHv2i42lzZYtNamoqLl68qPPHcvHiRemAbGJiovduL35+fgCA5s2bK66pOjU1FUuWLMGuXbuyLbrkbBVR8pWwK1euoFWrVjhz5gw0Gg0yrxNkvr9yvaeZ03oWKlQIZcqUAQDExMTA2NgYO3bskCVTph07diA8PFxnkGjRokVlWUvEzs4Oly9fhr29Pbp3745Zs2ahevXqeu2mSl+Gi4sLIiIidAqbXbt2cYr29wgICEDevHmxatUqTh7wHqdPn0bp0qVhYGCA06dPv3dfHx8fPaXSZWRkhNDQUPTs2RPOzs6oXbs26tSpg9q1a8s6GL5MmTKYO3cuZs+erbV97ty50ueWXKZNm4YdO3ZIRQ2QMevXhAkT0LBhQ1kLm6lTp6JevXo4fvw4Xr9+jR9++AHnzp3D48ePERUVJVuuXr16wcvLC3PnzpUWAS9evDgiIyNRrVo1ANDL65YrC5vOnTujR48e+PHHH1GpUiUAGVXjxIkTERgYCACIjIxEqVKl9JpLySfoZ8+eRfny5QFktGxlxQ+1dxswYADc3d0REREBd3d3HDlyBI8fP8bgwYPxyy+/yJbL29sbsbGxWLlyJS5evAgA6NChAwICAmBqaipbLkB5zeivX7/Gs2fPYG9vj+XLl2Py5MlfvKmc9GPw4MEICgrCqVOnpA/WqKgoLFu2DLNmzZI5nXKdPXsW0dHRUhccyl7ZsmWRkJAAR0dHlC1bVuviVlZyX7hctGgRAOD27dvYt28fIiMjMW3aNHz77bcoUKCANCOZvk2ZMgVNmjTBrl27pCnZDx06hJs3b2Lbtm2yZMr07NmzbMeiPnjwAM+fP5chUYY3b94gKCgImzdvxs6dO2FpaYmkpCT4+/srYky0Ei4K5srCZsaMGXBycsKUKVNw7949AICTkxOCg4MxbNgwAEDDhg3RuHFjveaqXbu2Xp/vUyi56Hr58iXmzJnzzjUV5Fz/59ChQ9i9ezfs7e1hYGAAQ0ND1KhRA6GhoQgKCpJt4bPQ0FA4OTnpTKm4ZMkSPHjwQPo7kIPSphavWrUqWrZsiQoVKkAIgaCgoHcWf0uWLNFzOvov+vTpg/z582PatGlYs2YNAKBkyZL466+/0KJFC5nTKVfFihVx8+ZNFjYfcPXqVWltMKWOt8zK1tYW+fLlg62tLWxsbJAnTx5Z1zarXbs2Ll++jHnz5kkX4Pz9/fH999/D2dlZtlwA0KpVK3Tr1g3Tpk2TulUdOXIEQ4cOhb+/v2y5lD4mOtPLly+1uuYD+htukSvH2GT17NkzAMoY7Lh06VJYWFigbdu2WtvXrl2LlJQUdOnSRaZkyhYQEIAdO3agTZs22XaLkHMFYFtbW5w8eRLu7u7w9PTEokWLULduXcTHx8Pb21u2gfpubm5YtWqVdJU605EjR9C+fXtZP4TPnTuHevXqoXz58ti9ezeaN2+u1Yyu7z7g9+7dw4wZMxAfH4/169ejUaNG72w52rBhg16zEclh7dq1GDt2LIYOHQpvb2+dyQPk7FZFn+7HH3/E3r17ER0djZIlS0pd0WrVqqXV1Yr+T0pKCoYMGYIlS5bgzZs3ADIW5e7RowemTp2q011fn5Q6JjolJQU//PAD1qxZg0ePHuncr69Wy1xf2ChJsWLF8Ntvv+lclY6MjETv3r2lFeJJm7W1NbZt2yZ782Z2MgcRtmzZEh07dsSTJ08wcuRILFy4ECdOnMDZs2dlyfWuqcWvXLkCLy8v2QZNK31qcXd3dxw/fhz58uWTNQeRnLKbxj6zm5Xc3aqU7NKlS5gzZw4uXLgAIKN1sH///rK3fBkYGMDBwQHBwcHw9/fXGX8sp8TERBw9ejTb3hiZQwf0LS0tDVFRUfD29oaRkRHi4+MBAJ6enrIWNJkyF98uWrSoosZE9+3bF3v27MH48ePRuXNnzJs3D7dv38Zvv/2GSZMmISAgQC85cmVXNABYt24d1qxZozNTFSBf16UbN25kO9Wzq6srbty4IUMidShYsKBixzyMHDlSmo993LhxaNq0KWrWrIl8+fJ90Vk/PsTFxQVRUVE6v29RUVGyNvErvRldDd1J6P2yTgZha2v73jGCFhYWKFWqFCZPnsxWiCz4d/Dp/v77b7Rv3x4VK1aUxoscPnwYpUuXxurVq9G6dWvZskVHRyMyMhJ79+7FtGnTYGRkJLXa1KlTR7ZCZ/PmzQgICEBSUhKsrKy0/lY1Go1shY2hoSEaNmwoXRxU2rFBqWOiN2/ejLCwMNSpU0eaPa5IkSJwdXXFypUr9VbY5MoWm9mzZ+Onn35C165dsXDhQnTr1g3x8fE4duwY+vbtK9t6FIULF8bcuXO15mwHgE2bNqFv376yDeBTun///RezZ8/GggUL4OrqKnecD3r8+PEHT6i+tClTpmDKlCnS7CkAEBERgR9++AGDBw/GiBEjZMumtGb02bNno3fv3jAxMdGZnedtQUFBekpFn2v58uVo3749jI2NsXz58vfu++rVK2zbtg03b97EiRMn9JRQ2d68eYMSJUpgy5YtKFmypNxxVMPT0xMBAQEYN26c1vYxY8bgjz/+kK76K0FMTAxmzJiBlStXIj09XbYWuGLFisHPzw8TJ07MdkIZOVWsWBGTJ09G/fr15Y6iGhYWFjh//jwKFy6MQoUKYf369fjqq69w9epVeHt7623h0FzZYvPrr79i4cKF6NChA5YtW4YffvgBHh4eGD16NB4/fixbrg4dOiAoKAiWlpaoVasWgIxuaAMGDED79u1ly6V0FStWxMuXL+Hh4QEzMzOd/t5yvqfZyVyISk5Dhw7Fo0eP8P3330stliYmJhg2bJisRQ2gvKnFZ8yYgYCAAJiYmGDGjBnv3E+j0bCwUYGsYxU/Ztyir6+v7AvuKUnevHm5vs9nuHv3brYtDJ06dcLUqVNlSPR/hBCIjo7G3r17sXfvXhw4cADPnj2Dj4+PrJMa3b59G0FBQYoragBgwoQJGDJkiCLXHVQqDw8PXL16FYULF0aJEiWwZs0afPXVV9i8eTNsbGz0liNXttiYmZnhwoULcHV1haOjI3bu3IkyZcogNjYWVapUyXZQkz68fv0anTt3xtq1a5EnT0ZNmZ6ejsDAQCxYsABGRkay5FK6Bg0a4MaNG+jRo0e2kwdw0oV3S0pKwoULF2BqaoqiRYvKuipxJjUsuEq5y+vXr7Ptw1+4cGGZEinbxIkTcfnyZSxatEj6rKL38/PzQ9u2bdGtWzet7UuXLsXq1asRHh4uU7KMSW6SkpJQpkwZqQtazZo19XqymR1/f3+0b98e7dq1kzVHdrKOM1PauoNKNWPGDBgaGiIoKAi7du1Cs2bNIITAmzdvMH36dAwYMEAvOXJlYePh4YG///4b5cqVQ8WKFdGrVy98++232LFjB9q3by/7Ff7Y2FicOnUKpqam8Pb2VkX3KjmZmZnh0KFDsi/YRbnToEGDPmo/jUaDadOmfeE0lJMuX76MHj164ODBg1rbeXLyfq1atUJERAQsLCzg7e2tc7U6c/E9+j8LFizA6NGj0a5dO1SpUgVAxhibtWvXIiQkRGts49vd0b+0rVu3ombNmopoZfjnn3+krx88eIBx48ahW7du2c6+p+/XKavIyMj33q/k5TuU4vr16zhx4gSKFCmi13FKubKw6dmzJ1xcXDBmzBjMmzcPQ4cORfXq1XH8+HH4+/tj8eLFckcEkDHzxpkzZ+Dq6sopF9+jfPny+PXXX6UPC6Kc9LFr57A1SX2qV6+OPHnyYPjw4ShQoIBOay8vlmTv7VaHty1dulRPSdQju5nksvO/XlDzdaIvLVcWNunp6UhPT5ea0P/66y9ERUWhaNGi+O6773SuCujLwIED4e3tjR49eiAtLQ21a9fGwYMHYWZmhi1btqBOnTqy5FK6HTt2ICQkBD///HO2V3WUcBWKiJTH3NwcJ06cQIkSJeSOQkQqlJKSku3sukqbKU0pjh079s7F1PU1fjZXFjZAxqqnp0+f1nlxNRoNmjVrJkumQoUKYePGjahYsSI2btyI77//Hnv37sWKFSuwe/duREVFyZJL6TKv8Lx9tZXdSYjofSpVqoQZM2agRo0ackdRpQcPHkjrqxUvXlzWVerVKDExUfZxLGqjlNfswYMH6NatG/79999s7+d5h66JEydi5MiRKF68uM54aH32eMiVowK3b9+Ozp07ZztJgJwnwg8fPkT+/PkBANu2bUO7du1QrFgxdO/eHbNmzZIlkxrs2bNH7ghEpEKTJ0/GDz/8gIkTJ7K19xMkJydLiwBmXhg0NDREYGAg5syZo8hZrOQ2efJkuLm54ZtvvgEAtG3bFn///TcKFCiAbdu2sdtjNpT8mg0cOBCJiYk4cuQI6tSpgw0bNuDevXuYMGECx1q+w6xZs7BkyRJ07dpV3iAiFypSpIj4/vvvRUJCgtxRtBQuXFiEh4eL1NRU4eLiIrZs2SKEEOLs2bPCxsZG5nRERLmLRqORbgYGBtIt83vKXu/evYWHh4fYtm2bePr0qXj69KnYunWr8PT0FN99953c8RTJzc1NREVFCSGE2LFjh7CxsRHh4eGiR48e4uuvv5Y5nTIp+TXLnz+/OHLkiBBCCEtLS3Hp0iUhhBCbNm0S1atXlzOaYuXPn19cvnxZ7hgiV7bY3Lt3D4MGDYKTk5PcUbR069YN7dq1kwaxNmjQAABw5MgR9gH/gMTERCxevBgXLlwAAJQqVQrdu3eHtbW1zMmISKnY2vt5/v77b6xbt05r3Kefnx9MTU3Rrl07zJ8/X75wCpWQkAAXFxcAwJYtW9CuXTs0bNgQbm5uqFy5sszplEnJr1lycjIcHR0BZEyX/eDBAxQrVgze3t44efKkrNmUKjg4GPPmzcPMmTNlzfFx01OoTJs2bbB37165Y+gYO3YsFi1ahN69eyMqKkpaU8TQ0BDDhw+XOZ1yHT9+HJ6enpgxYwYeP36Mx48fY/r06fD09OQBhojeqXbt2jAwMMDvv/+O4cOHo0iRIqhduzZu3LgBQ0NDueMpVkpKSrYXBh0dHZGSkiJDIuWztbXFzZs3AWR0h8+8cCmE4HiMd1Dya1a8eHFpfFmZMmXw22+/4fbt21iwYAEKFCggazalGjJkCC5dugRPT080a9YM/v7+Wjd9yZUtNnPnzkXbtm2xf//+bPtVy7l6eJs2bXS2cYHJ9wsODkbz5s3x+++/SzPdpaamomfPnhg4cCD27dsnc0IiUqK///4bnTt3RkBAAKKjo/Hq1SsAwNOnTzFx4kRs27ZN5oTKVLVqVYwZMwZhYWEwMTEBALx48QIhISGoWrWqzOmUyd/fHx07dkTRokXx6NEj+Pr6AgCio6NRpEgRmdMpk5JfswEDBuDu3bsAgDFjxqBx48b4448/YGRkhOXLl8uaTamCgoKwZ88e1K1bF/ny5dOZ8ElfcuWsaIsXL8Z3330HExMTnRdXo9HgypUrsmWLiIjAjBkzpC5VJUuWxMCBA6UrFaTL1NQU0dHROt31zp8/j4oVK/IKIhFlq1y5cggODkZgYCAsLS0RExMDDw8PREdHw9fXFwkJCXJHVKQzZ86gcePGePXqlTSAOyYmBiYmJggPD0epUqVkTqg8b968waxZs3Dz5k107doV5cqVA5CxGrulpSV69uwpc0LlUdNrlpKSgosXL6Jw4cKwt7eXO44iWVpaYvXq1WjSpImsOXJlYZM/f34EBQVh+PDhH70YlD78+uuvGDBgANq0aSNd9Tp8+DDWrVuHGTNmoG/fvjInVCYnJyesWLECDRs21NoeHh6OwMBA3Lt3T6ZkRKRkZmZmOH/+PNzc3LQKmytXrsDLywsvX76UO6JipaSkYOXKlbh48SKAjItwAQEBMDU1lTkZ0Zc3aNCgbLdrNBqYmJigSJEiaNGiBezs7PScTLlcXV0RHh4u+5jxXFnY2NnZ4dixY/D09JQ7ipZChQph+PDh6Nevn9b2efPmYeLEibh9+7ZMyZQtKCgIGzZswC+//IJq1aoBAKKiojB06FC0bt1a9oFqRKRMHh4eWLhwIRo0aKBV2ISFhWHSpEk4f/683BEVo3z58oiIiICtrS3GjRuHIUOGcFrnTxQbG/vOxQlHjx4tUyr6HHXr1sXJkyeRlpaG4sWLAwAuX74MQ0NDlChRApcuXYJGo8GBAwfg5eUlc1plWLp0KbZv346lS5fKeuzIlYVNcHAwHBwc8OOPP8odRYuFhQVOnTql03c0NjYW5cqVQ1JSkkzJlO3169cYOnQoFixYgNTUVABA3rx50adPH0yaNEmahIGIKKvQ0FD88ccfWLJkCb7++mts27YN169fR3BwMEaNGoX+/fvLHVExTE1NERsbi0KFCsHQ0BB3796VZoWiD/v999/Rp08f2NvbI3/+/Dpd4DnRjbrMnDkT+/fvx9KlS6X1rp4+fYqePXuiRo0a6NWrFzp27IgXL14gPDxc5rTKUK5cOcTHx0MIATc3N53x7fr6G8iVhU1QUBDCwsJQpkwZ+Pj46Ly406dPlyVXx44dUa5cOQwdOlRr+y+//ILjx49j9erVsuRSi5SUFMTHxwMAPD09eTWRiN5LCIGJEyciNDRUGotnbGyMIUOGYPz48TKnU5aqVavCwsICNWrUQEhICIYMGQILC4ts92Xrgy5XV1d8//33GDZsmNxRKAcULFgQO3fu1GmNOXfuHBo2bIjbt2/j5MmTaNiwIR4+fChTSmUJCQl57/1jxozRS45cWdjUrVv3nfdpNBrs3r1bb1lmz54tff3s2TP88ssvqF69utYYm6ioKAwePBgjR47UWy41efr0KdLS0nT6sj5+/Bh58uTh6uFE9F6vX79GXFwckpKS4OXl9c4T9v9lly5dwpgxYxAfH4+TJ0/Cy8tLmoUyK7Y+ZM/KygqnTp2Ch4eH3FEoB1hYWGDLli1aazkBwN69e9GsWTM8f/4cV65cQdmyZfHs2TN5QlK2cmVhoyTu7u4ftZ/cs7Upma+vL5o1a4bvv/9ea/uCBQvwzz//cMpWIqIcZGBggISEBHZF+wQ9evRApUqV8N1338kdRVUSExOxbt06xMfHY+jQobCzs8PJkyfh5OSEggULypYrICAAhw4dwrRp01CpUiUAwLFjxzBkyBBUq1YNK1aswOrVq6UeN6QcLGxI8ezs7BAVFYWSJUtqbb948SKqV6+OR48eyZSMiIgoYzzX9OnT0aRJE8Wtn6dUp0+fRoMGDWBtbY1r167h0qVL8PDwwMiRI3Hjxg2EhYXJli0pKQnBwcEICwuTxvbmyZMHXbp0wYwZM2Bubo5Tp04BAMqWLStbTtLFwoYUz9zcHIcPH4a3t7fW9jNnzqBy5cpcx4aIKIdxhq9P877eGeyRkb0GDRqgfPnymDJlitashQcPHkTHjh1x7do1uSMiKSlJeu88PDzYjVUFWNjoUffu3d97/5IlS/SURF3q1q2L0qVLY86cOVrb+/bti9OnT2P//v0yJSMiyn04wxfpg7W1NU6ePAlPT0+twub69esoXrw415miz6I7MpC+mCdPnmh9/+bNG5w9exaJiYmoV6+eTKmUb8KECWjQoAFiYmJQv359AEBERASOHTuGHTt2yJyOiCh3mTBhAn7++WfO8PUBgwYNwvjx42Fubv7OBR2BjGJw2rRpekymDsbGxtkOvL98+TIcHBxkSESf682bNyhRogS2bNmiM2xA31jY6NGGDRt0tqWnp6NPnz6KW0xUSapXr45Dhw5h6tSpWLNmDUxNTeHj44PFixejaNGicscjIspVnjx5grZt28odQ/Gio6Px5s0b6et3ydriRf+nefPmGDduHNasWQMg43W6ceMGhg0bhtatW8ucjj5F3rx5FdPCxq5oCnDp0iXUqVMHd+/elTsKERH9j+MMX6QPT58+RZs2bXD8+HE8f/4czs7OSEhIQNWqVbFt2zaYm5vLHZE+wcSJE3H58mUsWrQo26ni9YUtNgoQHx8vzbpB79ekSRMsWrQIBQoUkDsKEVGuVKRIEYwaNUqatIUzfNGXYG1tjZ07d+LAgQM4ffo0kpKSUL58eTRo0EDuaPQZjh07hoiICOzYsQPe3t46hen69ev1koMtNnr0dh9cIQTu3r2LrVu3okuXLpg7d65MydQj6wBDIiLKeZzhi4g+Vbdu3d57/9KlS/WSg4WNHtWtW1frewMDAzg4OKBevXro3r27rE13asHChoiIKHeIiIhAREREttOKc6ZY+hw8k9ajrVu3QgghNc9du3YNGzduhKurK4uaj+Tq6qrTLYKIiP4bzvBF+hYSEoJx48ahYsWKKFCgACdZoBzBs2k9atmyJfz9/fHdd98hMTERVapUQd68efHw4UNMnz4dffr0kTuiYu3fvx+//fYbLC0tYWBgAABYsWIF3N3dUaNGDZnTERGpG2f4In1bsGABli1bhs6dO8sdhXKAu7v7e48P+urCysJGj06ePIkZM2YAANatWwcnJydER0fj77//xujRo1nYvMPff/+Nzp07IyAgANHR0Xj16hWAjBlVJk6ciG3btsmckIhI3fbs2ZPt10RfyuvXr1GtWjW5Y1AOGThwoNb3b968QXR0NLZv346hQ4fqLQfH2OiRmZkZLl68iMKFC6Ndu3YoVaoUxowZg5s3b6J48eJISUmRO6IilStXDsHBwQgMDNQaYxMdHQ1fX18kJCTIHZGIiIg+wbBhw2BhYYFRo0bJHYW+oHnz5uH48eN6mzyALTZ6VKRIEWzcuBGtWrVCeHg4goODAQD379+HlZWVzOmU69KlS6hVq5bOdmtrayQmJuo/EBEREf0nL1++xMKFC7Fr1y74+PjojJ+dPn26TMkoJ/n6+mLEiBEsbHKj0aNHo2PHjggODkb9+vVRtWpVAMCOHTtQrlw5mdMpV/78+REXFwc3Nzet7QcOHODsaERERCp0+vRplC1bFgBw9uxZrfs4liv3WLduHezs7PT2fCxs9KhNmzaoUaMG7t69izJlykjb69evj1atWsmYTNl69eqFAQMGYMmSJdBoNLhz5w4OHTqEIUOGsAmbiIhIhTiWK3cpV66cVkEqhEBCQgIePHiAX3/9VW85OMaGFE8IgYkTJyI0NFQah2RsbIwhQ4Zg/PjxMqcjIiIi+t8WEhKi9X3mWo116tRBiRIl9JaDhQ2pxuvXrxEXF4ekpCR4eXnBwsJC7khERET0kfz9/bFs2TJYWVnB39//vfuuX79eT6koN2FXNFINIyMjeHl5yR2DiIiIPoO1tbXUXcna2lrmNJTT0tLSsHHjRly4cAEAUKpUKTRv3hyGhoZ6y8AWGyIiIiIi+mxxcXHw8/PD7du3Ubx4cQAZs9q6uLhg69at8PT01EsOFjZERERERPTZ/Pz8IITAypUrpVnQHj16hE6dOsHAwABbt27VSw4WNkRERET0xb09c9b7nDx58gunoZxkbm6Ow4cPw9vbW2t7TEwMqlevjqSkJL3k4BgbIiIiIvriWrZsKXcE+kKMjY3x/Plzne1JSUkwMjLSWw622BARERER0WcLDAzEyZMnsXjxYnz11VcAgCNHjqBXr16oUKECli1bppccLGyIiIiISBavX7/G/fv3kZ6errW9cOHCMiWiz5GYmIguXbpg8+bNyJs3LwAgNTUVzZs3x7Jly/Q2Cx4LGyIiIiLSq8uXL6NHjx44ePCg1nYhBDQaDdLS/l979x4V1XW2AfwZ7gOCCKGImIoEEUjlEi1tMBEUBGlqkTQ2RTQoaFdZoSpWU7pWazVZUZOlkWorxiRViTGJMZJaEaMRhhiaVhhGkasXBCIhNQZEuQgyvN8f+Tx1gnILzoT6/NZiLeecPWc/bM4f83r23qM3UTL6Ns6dO4fKykoAgK+vL7y8vIzaPwsbIiIiIjKqqVOnwsLCAmlpaXBzc+uxqUBAQICJktFwxsKGiIiIiIzKzs4OWq0WPj4+po5CQ0BEsH//fuTl5d1xauGBAweMkoO7ohERERGRUfn5+eHKlSumjkFDZPny5Xj11Vcxffp0uLq69ntb76HGJzZEREREZFS5ubn4wx/+gHXr1mHSpEnKgvNbHBwcTJSMBsPJyQl79uzBT37yE5PmYGFDREREREZlZmYGAD3+Z5+bBwxP48ePR05OjsmnFrKwISIiIiKjys/P7/V8aGiokZLQUNi9ezeOHDmCv/3tb1Cr1SbLwcKGiIiIiIgGrb29HbGxsSgoKICHh0ePqYXFxcVGycHNA4iIiIjI6K5evYo33ngDFRUVAICHH34YiYmJRvsyRxo6CQkJ0Gq1mD9/PjcPICIiIqL7R1FREaKioqBWqxEcHAwAKCwsRHt7O44ePYpHHnnExAlpIOzs7PDhhx/iscceM2kOFjZEREREZFSPP/44vLy88Nprr8HC4usJRF1dXVi8eDGqq6vx8ccfmzghDYSPjw/27dsHf39/k+ZgYUNERERERqVWq6HT6XrsolVeXo4pU6agra3NRMloMLKzs7F161Zs374dHh4eJsvBNTZEREREZFQODg6oq6vrUdh89tlnsLe3N1EqGqz58+ejra0NDz30EGxtbXtsHtDY2GiUHCxsiIiIiMionn76aSQlJWHjxo0ICQkBABQUFGDVqlWIi4szcToaqPT0dFNHAMCpaERERERkZJ2dnVi1ahW2b9+Orq4uAIClpSWSk5OxYcMGWFtbmzghDUcsbIiIiIjIJNra2nDhwgUAUKYx0fB248YNdHZ2GhxzcHAwSt8sbIiIiIiIaNBaW1vxu9/9Dvv27cNXX33V47xerzdKDjOj9EJERERERP+TnnvuOeTm5iIjIwPW1tZ4/fXXsXbtWowZMwaZmZlGy8EnNkRERERENGjf//73kZmZibCwMDg4OKC4uBheXl5488038fbbb+Pw4cNGycEnNkRERERENGiNjY3w9PQE8PV6mlvbOz/22GNG/bJVFjZERERERDRonp6euHjxIgDAx8cH+/btAwD84x//gKOjo9FycCoaEREREREN2ubNm2Fubo6lS5fio48+wuzZsyEiuHnzJl555RUsW7bMKDlY2BARERER0ZCpra2FVquFl5cX/P39jdYvCxsiIiIiIhr2LEwdgIiIiIiIhpctW7b0u+3SpUvvYZL/4hMbIiIiIiIakPHjx/ernUqlQnV19T1O8/99sbAhIiIiIqLhjts9ExERERHRsMc1NkRERERENGgrVqy443GVSgUbGxt4eXkhJiYGTk5O9zQHp6IREREREdGgTZ8+HcXFxdDr9Zg4cSIA4OzZszA3N4ePjw+qqqqgUqnwySefwM/P757l4FQ0IiIiIiIatJiYGERERODzzz+HVquFVqvFpUuXMHPmTMTFxaG+vh7Tpk1DamrqPc3BJzZERERERDRo7u7uOHbsWI+nMWVlZYiMjER9fT2Ki4sRGRmJK1eu3LMcfGJDRERERESD1tzcjMuXL/c4/uWXX+LatWsAAEdHR3R2dt7THCxsiIiIiIho0GJiYpCYmIisrCxcunQJly5dQlZWFpKSkjBnzhwAwMmTJ+Ht7X1Pc3AqGhERERERDVpLSwtSU1ORmZmJrq4uAICFhQUSEhKwefNm2NnZ4dSpUwCAwMDAe5aDhQ0REREREX1rLS0tqK6uBgB4enpixIgRRu2fhQ0REREREQ17XGNDRERERETDHgsbIiIiIiIa9ljYEBERERHRsMfChoiIiIiIhj0WNkRERuLh4YH09HRTxxhyNTU1UKlUylaew5VKpcIHH3xg6hgm9b96jxLR/YGFDRHRIOzatQuOjo6mjkFDqKGhAdHR0aaO8Z3CYo+IhhMWNkRE1C+dnZ2mjtCDiChfBvdtjR49GtbW1kNyraH2XRx7IqLvGhY2RHRfun79OuLj42FnZwc3Nzds3rwZYWFhWL58OQCgo6MDK1euhLu7O+zs7PCjH/0IGo0GAKDRaLBo0SI0NzdDpVJBpVJhzZo1A87w+uuvw9HREcePHwcAlJaWIjo6GiNGjICrqysWLFiAK1euAAAyMzPh7OyMjo4Og2vMmTMHCxYsQHNzM8zNzVFUVAQA6O7uhpOTE3784x8rbffs2YMHH3xQeX3mzBnMmDEDarUazs7O+NWvfoWWlhbl/MKFCzFnzhy8+OKLGDNmDCZOnAgAOHnyJIKCgmBjY4MpU6ZAp9MZZGpqakJ8fDxcXFygVqsxYcIE7Ny5s8/xuDWl7Z133kFISAhsbGzwgx/8APn5+UobjUYDlUqFnJwcTJ48GdbW1vjkk0/Q3d2N9evXY/z48VCr1QgICMD+/fuVsRg7diwyMjIM+tPpdDAzM0NtbS2Ank8n+hqf2++X2/8eCxcuVF5v27YNEyZMgI2NDVxdXfHUU0/1OQ63rp2SkoLly5fjgQceQFRUFIDe7xEA2L9/PyZNmqRkjoiIQGtra7/z3s7DwwMAEBsbC5VKpbw+ffo0pk+fDnt7ezg4OGDy5MnKfUdEZEosbIjovrRixQoUFBTg4MGDOHbsGE6cOIHi4mLlfEpKCj799FO88847KCkpwdy5czFr1iycO3cOISEhSE9Ph4ODAxoaGtDQ0ICVK1cOqP+XX34ZaWlpOHr0KMLDw3H16lXMmDEDQUFBKCoqwpEjR/Cf//wHv/jFLwAAc+fOhV6vx8GDB5VrXL58GdnZ2UhMTMTIkSMRGBioFF9nzpyBSqWCTqdTPozn5+cjNDQUANDa2oqoqCiMGjUKhYWFeO+99/DRRx8hJSXFIOfx48dRVVWFY8eO4dChQ2hpacFPf/pT+Pn5QavVYs2aNT1+9z/+8Y8oLy9HTk4OKioqkJGRgQceeKDfY7Nq1Sr89re/hU6nw6OPPorZs2fjq6++MmiTlpaGDRs2oKKiAv7+/li/fj0yMzOxfft2lJWVITU1FfPnz0d+fj7MzMwQFxeHvXv3GlzjrbfewtSpUzFu3LgeGfo7Pr0pKirC0qVL8fzzz6OqqgpHjhzBtGnT+v3+3bt3w8rKCgUFBdi+fXuf90hDQwPi4uKQmJiIiooKaDQaPPnkkxjs93AXFhYCAHbu3ImGhgbldXx8PMaOHYvCwkJotVqkpaXB0tJyUH0QEQ0pISK6z1y7dk0sLS3lvffeU45dvXpVbG1tZdmyZVJbWyvm5uZSX19v8L7w8HD5/e9/LyIiO3fulJEjRw6o33HjxsnmzZvlueeeEzc3NyktLVXOvfDCCxIZGWnQ/rPPPhMAUlVVJSIiycnJEh0drZzftGmTeHp6Snd3t4iIrFixQp544gkREUlPT5enn35aAgICJCcnR0REvLy8ZMeOHSIismPHDhk1apS0tLQo18vOzhYzMzP54osvREQkISFBXF1dpaOjQ2nz6quvirOzs7S3tyvHMjIyBIDodDoREZk9e7YsWrRoQGMjInLx4kUBIBs2bFCO3bx5U8aOHSsvvfSSiIjk5eUJAPnggw+UNjdu3BBbW1v55z//aXC9pKQkiYuLExERnU4nKpVKamtrRUREr9eLu7u7ZGRkKO0BSFZWVr/HJzQ0VJYtW2bQZ0xMjCQkJIiIyPvvvy8ODg5y7dq1AY9FaGioBAUFGRzr6x7RarUCQGpqau56zd7yivz3Hr3l9jG5xd7eXnbt2jXg34mI6F6zMF1JRURkGtXV1bh58yaCg4OVYyNHjlSmWp05cwZ6vR7e3t4G7+vo6ICzs/O36nvTpk1obW1FUVERPD09leOnT59GXl4eRowY0eM9Fy5cgLe3N5YsWYIf/vCHqK+vh7u7O3bt2oWFCxdCpVIBAEJDQ/HGG29Ar9cjPz8fkZGRGD16NDQaDfz9/XH+/HmEhYUBACoqKhAQEAA7Ozuln6lTp6K7uxtVVVVwdXUFAEyaNAlWVlZKm1tPSGxsbJRjjz76qEHe5ORk/PznP0dxcTEiIyMxZ84chISE9HuMbr+ehYUFpkyZgoqKCoM2U6ZMUf59/vx5tLW1YebMmQZtOjs7ERQUBAAIDAyEr68v9u7di7S0NOTn5+Py5cuYO3fuHTP0d3x6M3PmTIwbNw6enp6YNWsWZs2ahdjYWNja2vY9CAAmT55s8LqveyQyMhLh4eGYNGkSoqKiEBkZiaeeegqjRo3qV3/9tWLFCixevBhvvvkmIiIiMHfuXDz00END2gcR0WBwKhoR0Te0tLTA3NwcWq0Wp06dUn4qKirw5z//+Vtd+/HHH4der8e+fft69Dl79myD/k6dOoVz584p05eCgoIQEBCAzMxMaLValJWVGayPmDZtGq5fv47i4mJ8/PHHCAsLQ1hYGDQaDfLz8zFmzBhMmDBhQHlv/2DfX9HR0aitrUVqaio+//xzhIeHD3iq3kBy3Zpql52dbTB25eXlyjob4OspVLemo+3duxezZs36VoWqmZlZj2leN2/eVP5tb2+P4uJivP3223Bzc8Pq1asREBCAq1ev9uv63xz7vu4Rc3NzHDt2DDk5OfDz88PWrVsxceJEXLx4sV95+2vNmjUoKyvDE088gdzcXPj5+SErK2vA1yEiGmosbIjovuPp6QlLS0tlzQAANDc34+zZswC+LiD0ej0uX74MLy8vg5/Ro0cDAKysrKDX6wfcd3BwMHJycrBu3Tps3LhROf7II4+grKwMHh4ePfq8/QPu4sWLsWvXLuzcuRMREREGmwE4OjrC398ff/nLX2BpaQkfHx9MmzYNOp0Ohw4dUtbXAICvry9Onz6tLCwHgIKCApiZmSlPru7E19cXJSUluHHjhnLsX//6V492Li4uSEhIwJ49e5Ceno4dO3b0e4xuv15XVxe0Wi18fX3v2t7Pzw/W1taoq6vrMXa3j8+8efNQWloKrVaL/fv3Iz4+vtffs6/xcXFxQUNDg3Jer9ejtLTU4DoWFhaIiIjAyy+/jJKSEtTU1CA3N7ffY3G7/twjKpUKU6dOxdq1a6HT6WBlZaUUHf3J+02WlpZ3vM+9vb2RmpqKo0eP4sknn+zX5hBERPcaCxsiuu/Y29sjISEBq1atQl5eHsrKypCUlAQzMzOoVCp4e3sjPj4ezzzzDA4cOICLFy/i5MmTWL9+PbKzswF8vWNUS0sLjh8/jitXrqCtra3f/YeEhODw4cNYu3at8mWIzz77LBobGxEXF4fCwkJcuHABH374IRYtWmTwwXLevHm4dOkSXnvtNSQmJva4dlhYGN566y2liHFycoKvry/effddg8ImPj4eNjY2SEhIQGlpKfLy8vCb3/wGCxYs6HWa1bx586BSqbBkyRKUl5fj8OHDBgUaAKxevRp///vfcf78eZSVleHQoUO9Fibf9Ne//hVZWVmorKzEs88+i6ampjv+rrfY29tj5cqVSE1Nxe7du3HhwgUUFxdj69at2L17t9LOw8MDISEhSEpKgl6vx89+9rO7XrM/4zNjxgxkZ2cjOzsblZWVSE5ONngac+jQIWzZsgWnTp1CbW0tMjMz0d3d3Wvh2Ju+7pF///vfWLduHYqKilBXV4cDBw7gyy+/VMa+r7x34uHhgePHj+OLL75AU1MT2tvbkZKSAo1Gg9raWhQUFKCwsHBAf18ionvG1It8iIhM4dq1azJv3jyxtbWV0aNHyyuvvCLBwcGSlpYmIiKdnZ2yevVq8fDwEEtLS3Fzc5PY2FgpKSlRrvHrX/9anJ2dBYD86U9/6rPPby7Mzs/PFzs7O9myZYuIiJw9e1ZiY2PF0dFR1Gq1+Pj4yPLly5XNAW5ZsGCBODk5yY0bN3r0kZWVJQAMFsUvW7ZMAEhlZaVB25KSEpk+fbrY2NiIk5OTLFmyRK5fv66cT0hIkJiYmB59fPrppxIQECBWVlYSGBgo77//vsHmAS+88IL4+vqKWq0WJycniYmJkerq6j7H59bmAXv37pXg4GCxsrISPz8/yc3NVdrc2jygqanJ4L3d3d2Snp4uEydOFEtLS3FxcZGoqCjJz883aLdt2zYBIM8880yP/vGNhfJ9jU9nZ6ckJyeLk5OTfO9735P169cbLMY/ceKEhIaGyqhRo0StVou/v7+8++67fY6DyJ0X+ov0fo+Ul5dLVFSUuLi4iLW1tXh7e8vWrVv7nVek5z168OBB8fLyEgsLCxk3bpx0dHTIL3/5S3nwwQfFyspKxowZIykpKQabSRARmYpKZJD7QBIR/Q9pbW2Fu7s7Nm3ahKSkJFPH6VV4eDgefvhhbNmyxdRRhlRNTQ3Gjx8PnU6HwMBAU8chIqJhhruiEdF9SafTobKyEsHBwWhubsbzzz8PAIiJiTFxsrtramqCRqOBRqPBtm3bTB2HiIjoO4VrbIjovrVx40YEBAQo385+4sSJAX2R5O1OnDiBESNG3PVnKAQFBWHhwoV46aWXBr1Ow5TWrVt31/GJjo42dTyjqaur6/VeqaurM3VEIqJhiVPRiIiGQHt7O+rr6+963svLy4hpvpsaGxvR2Nh4x3NqtRru7u5GTmQaXV1dqKmpuet5Dw8PWFhwQgUR0UCxsCEiIiIiomGPU9GIiIiIiGjYY2FDRERERETDHgsbIiIiIiIa9ljYEBERERHRsMfChoiIiIiIhj0WNkRERERENOyxsCEiIiIiomGPhQ0REREREQ17/wfMRwFo52l4SQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x500 with 1 Axes>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Finally, we use regex to read the response. "
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Create workload\n",
-    "workload = lab.Workload(jobs=[lab.Job(job_function=get_keywords_previous_results)])\n",
-    "\n",
-    "# Run\n",
-    "await workload.async_run(\n",
-    "    messages[:100], \n",
-    "    executor_type=\"parallel\",\n",
-    "    max_parallelism=10, \n",
-    ")\n",
-    "\n",
-    "# Display results\n",
-    "results_df = workload.results_df()\n",
-    "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
-    "\n",
-    "keywords_to_count = (\n",
-    "    augmented_messages_df.explode(\"get_keywords_previous_results\")\n",
-    "    .groupby(\"get_keywords_previous_results\")\n",
-    "    .size()\n",
-    "    .sort_values(ascending=False)\n",
-    ")\n",
-    "keywords_to_count.head(20).plot(\n",
-    "    kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\"\n",
-    ")\n",
-    "\n",
-    "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords_previous_results\"].explode().nunique())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Reuse the results from another job\n",
-    "\n",
-    "Likewise, you can set a `workload` argument. This lets you also use results on other jobs to augment the result of the current one.\n",
-    "\n",
-    "Let's use this to **run the topic extraction on GPT-4 first on a subsample,** and then use GPT-3.5."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "async def get_keywords_previous_jobs(\n",
-    "    message: lab.Message,\n",
-    "    workload: lab.Workload = None, # Add the job as an argument\n",
-    "    model: str=\"openai:gpt-3.5-turbo\",\n",
-    ") -> lab.JobResult:\n",
-    "    \"\"\"\n",
-    "    This function uses OpenAI GPT to extract keywords from a given message.\n",
-    "\n",
-    "    It uses the results of the previous jobs to provide context to the current job.\n",
-    "    The workload argument is used to access the results of the previous jobs.\n",
-    "    The previous jobs are expected to be named `get_keywords`.\n",
-    "\n",
-    "    If the message.id was already processed, the previous result is returned.\n",
-    "    \"\"\"\n",
-    "    provider, model_name = lab.get_provider_and_model(model)\n",
-    "    openai_client = lab.get_async_client(provider)\n",
-    "\n",
-    "    # Using the reference to the job, we can access the results of the other jobs\n",
-    "    # to use them as context for the current job\n",
-    "    previous_keywords = []\n",
-    "    if workload:\n",
-    "        # Get the previous results of the job `get_keywords` \n",
-    "        previous_job_results = workload.jobs[\"get_keywords\"].results.values()\n",
-    "\n",
-    "        # If this message.id was already processed, we return the previous result\n",
-    "        if message.id in previous_job_results:\n",
-    "            return previous_job_results[message.id]\n",
-    "\n",
-    "        # Otherwise, let's flatten the list of lists of keywords\n",
-    "        previous_keywords = [keyword for result in previous_job_results for keyword in result.value]\n",
-    "\n",
-    "    prompt = \"You are an annotator reading Amazon product reviews. Your job is to label \\\n",
-    "    each review with topics that describe important topics covered in the review, relevant \\\n",
-    "    to the e-commerce domain. Do not include generic topics such as 'good', 'bad', 'interesting', etc.\"\n",
-    "    \n",
-    "    # If there are previous results, we add them to the prompt\n",
-    "    if len(previous_keywords) > 0:\n",
-    "        prompt += f\"\"\"\n",
-    "        So far, you've reviewed {len(previous_job_results)} reviews, and the keywords you've found are:\n",
-    "        {\", \".join(previous_keywords)}\n",
-    "\n",
-    "        If possible, reuse the existing topics to label the current review. Do not add \n",
-    "        variations of the same topics.\"\"\"\n",
-    "\n",
-    "    prompt = f\"\"\"The review is: \n",
-    "    {message.content}\n",
-    "\n",
-    "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
-    "    Keywords:\"\"\"\n",
-    "\n",
-    "    response = await openai_client.chat.completions.create(\n",
-    "        model=\"gpt-3.5-turbo\",\n",
-    "        messages=[\n",
-    "            {\n",
-    "                \"role\": \"system\",\n",
-    "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
-    "            },\n",
-    "            {\"role\": \"user\", \"content\": prompt},\n",
-    "        ],\n",
-    "    )\n",
-    "\n",
-    "    response = response.choices[0].message.content\n",
-    "    # Parse the response to extract the keywords with regex\n",
-    "    keywords = re.findall(r\"- (.*)\", response)\n",
-    "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
-    "    return lab.JobResult(\n",
-    "        value=keywords,\n",
-    "        result_type=lab.ResultType.list,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's use this to run 10 expensive calls to GPT-4, and then use those keywords as grounding when calling GPT-3.5."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No job_config provided. Running with empty config\n",
-      "100%|██████████| 100/100 [00:01<00:00, 74.78it/s]\n",
-      "100%|██████████| 100/100 [00:09<00:00, 10.41it/s]\n"
-     ]
     },
     {
-     "data": {
-      "text/plain": [
-       "{'get_keywords': None,\n",
-       " 'get_keywords_previous_jobs': JobResult(value=['computer performance', 'aging computer', 'tips for optimizing performance', 'maximumpc', 'computer parts', 'vendors', 'useful tests', 'computer maintenance', 'performance optimization', 'aging technology'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887336, job_id='get_keywords_previous_jobs')}"
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['Old computer',\n",
+              " 'Computer performance',\n",
+              " 'Advice',\n",
+              " 'MaximumPC',\n",
+              " 'Computer parts',\n",
+              " 'Vendors',\n",
+              " 'Useful tests']"
+            ]
+          },
+          "execution_count": 27,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "response = response.choices[0].message.content\n",
+        "# Parse the response to extract the keywords with regex\n",
+        "keywords = re.findall(r\"- (.*)\", response)\n",
+        "keywords"
       ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# First, we run on GPT-4\n",
-    "# We create a new job config to specify the model\n",
-    "\n",
-    "\n",
-    "class GPT4Config(lab.JobConfig):\n",
-    "    model: str = \"openai:gpt-4\"\n",
-    "\n",
-    "\n",
-    "workload = lab.Workload(\n",
-    "    jobs=[\n",
-    "        # The jobs are executed sequentially, in the order they are defined\n",
-    "        lab.Job(\n",
-    "            job_function=get_keywords,\n",
-    "            config=GPT4Config(), # We specify the model\n",
-    "            sample=0.1, # We only run on 10% of the data\n",
-    "        ),\n",
-    "        lab.Job(job_function=get_keywords_previous_jobs),\n",
-    "    ]\n",
-    ")\n",
-    "results = await workload.async_run(\n",
-    "    messages[:100],\n",
-    "    executor_type=\"parallel\",\n",
-    "    max_parallelism=10,\n",
-    ")\n",
-    "results.get(\"0\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of different keywords extracted: 586\n"
-     ]
     },
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJeCAYAAABmn5DCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACeX0lEQVR4nOzdd1QU1/sG8GdBaYIUaaJIt6Bi77ETa+y9YfebxAr2WMGCmlijEbuCscQSjb1g7x3sAhbsBYIKKAjc3x/82LAuFgzuzJDnc86eI7Pj7sPCLvPO3PtelRBCgIiIiIiISMH0pA5ARERERET0b7GwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIgCAs7MzvvvuO6ljSOrQoUNQqVQ4dOjQv36sHj16wNnZ+V8/zueQ+mfn7OyMHj16SPb8REQACxsi+oSVK1dCpVJBpVLh2LFjWvcLIeDo6AiVSvXVDqwePXqEiRMn4tKlS1/l8YmU4Nq1a5g4cSLu3r0rdZQcI7f39s6dOzFx4kSpYxDRF2JhQ0SfxcjICGvWrNHafvjwYTx48ACGhoZf7bkfPXoEf39/2Rz8EH2OJUuW4ObNmzn2eNeuXYO/v3+uK2zk9N7euXMn/P39pY5BRF+IhQ0RfZYmTZpgw4YNSElJ0di+Zs0aVKhQAfb29hIlI/p8Qgi8efNGJ8+VN2/er1rwExGRJhY2RPRZOnXqhJiYGOzbt0+9LTk5GRs3bkTnzp2z/D8JCQkYOnQoHB0dYWhoiGLFiuGXX36BEEJjv3379uGbb76BhYUFTE1NUaxYMfz0008A0uc8VKpUCQDQs2dP9bC4lStXfjTvw4cP0bt3bzg4OMDQ0BAuLi744YcfkJycrN7n9u3baNeuHaysrGBiYoKqVatix44dGo+TMefijz/+gL+/PwoVKgQzMzO0bdsWL1++RFJSEoYMGQJbW1uYmpqiZ8+eSEpK0ngMlUqFAQMGYMOGDfD09ISxsTGqVauGy5cvAwAWLVoEd3d3GBkZoU6dOlmekd+wYQMqVKgAY2NjWFtbo2vXrnj48KHGPj169ICpqSkePnyIli1bwtTUFDY2Nhg2bBhSU1M/+np9yKpVq5AnTx4MHz5cve306dNo1KgRzM3NYWJigtq1a+P48ePq+w8ePAiVSoU///xT6/HWrFkDlUqFkydP4q+//oJKpUJ4eLj6/k2bNkGlUqF169Ya/69EiRLo0KGD+uuUlBRMmjQJbm5uMDQ0hLOzM3766Set1z5j7smePXtQsWJFGBsbY9GiRQCABw8eoGXLlsiXLx9sbW3h6+ur9f8BICIiAm3atIG9vT2MjIxQuHBhdOzYES9fvvzoa/f+HJu7d+9CpVLhl19+weLFi9XZK1WqhLNnz370sVauXIl27doBAOrWrat+H7w/F+jYsWOoXLkyjIyM4OrqiuDgYK3HiouLw5AhQ9TvS3d3d0yfPh1paWkfzQCkF4aTJ09G4cKFYWJigrp16+Lq1ata+8XGxmLYsGEoXbo0TE1NkT9/fjRu3BhhYWHqfT713j569CjatWuHIkWKwNDQEI6OjvD19dUqTJ88eYKePXuicOHCMDQ0RMGCBdGiRQut99GuXbtQs2ZN5MuXD2ZmZmjatKlG9h49emDBggUAoM6iUqk++ZoQkYwIIqKPWLFihQAgzp49K6pXry66deumvm/Lli1CT09PPHz4UDg5OYmmTZuq70tLSxP16tUTKpVK9OnTR8yfP180a9ZMABBDhgxR73flyhVhYGAgKlasKObOnSuCgoLEsGHDRK1atYQQQjx58kQEBAQIAKJfv34iJCREhISEiKioqA9mfvjwoXBwcBAmJiZiyJAhIigoSIwbN06UKFFC/P333+rHtbOzE2ZmZmLMmDFi1qxZokyZMkJPT09s3rxZ/VgHDx4UAETZsmVFtWrVxLx588SgQYOESqUSHTt2FJ07dxaNGzcWCxYsEN26dRMAhL+/v0YeAMLLy0s4OjqKadOmiWnTpglzc3NRpEgRMX/+fOHp6Slmzpwpxo4dKwwMDETdunWz/BlUqlRJzJ49W4waNUoYGxsLZ2dn9fcjhBDdu3cXRkZGomTJkqJXr15i4cKFok2bNgKA+O233z75s37/Z7ho0SKhUqnEmDFj1NtCQ0OFgYGBqFatmpg5c6aYPXu28PLyEgYGBuL06dPqn72jo6No06aN1nM0adJEuLm5CSGEiImJESqVSvz666/q+wcPHiz09PSEjY2NetuzZ88EADF//nyN7xWAaNu2rViwYIHw8fERAETLli21vid3d3dhaWkpRo0aJYKCgsTBgwdFYmKiKFq0qDAyMhIjRowQc+bMERUqVBBeXl4CgDh48KAQQoikpCTh4uIiHBwcxOTJk8XSpUuFv7+/qFSpkrh79+5HX8/u3bsLJycn9dd37twRAES5cuWEu7u7mD59upgxY4awtrYWhQsXFsnJyR98rKioKDFo0CABQPz000/q98GTJ0/U32exYsWEnZ2d+Omnn8T8+fNF+fLlhUqlEleuXFE/TkJCgvDy8hIFChQQP/30kwgKChI+Pj5CpVKJwYMHf/T7EUKIsWPHCgCiSZMmYv78+aJXr17CwcFBWFtbi+7du6v3O3v2rHBzcxOjRo0SixYtEgEBAaJQoULC3NxcPHz4UAjx6ff2wIEDRZMmTcTUqVPFokWLRO/evYW+vr5o27atRqbq1asLc3NzMXbsWLF06VIxdepUUbduXXH48GH1PsHBwUKlUolGjRqJX3/9VUyfPl04OzsLCwsLcefOHSGEECdOnBDffvutAKDOEhIS8snXhIjkg4UNEX1U5sJm/vz5wszMTCQmJgohhGjXrp36IPz9g+ItW7YIAGLy5Mkaj9e2bVuhUqlEZGSkEEKI2bNnCwDi+fPnH8xw9uxZAUCsWLHiszL7+PgIPT09cfbsWa370tLShBBCDBkyRAAQR48eVd/3+vVr4eLiIpydnUVqaqoQ4p/CplSpUhoHnp06dRIqlUo0btxY4/GrVaumcTArRHphY2hoqD6AEiK9aAAg7O3txatXr9TbR48eLQCo901OTha2traiVKlS4s2bN+r9tm/fLgCI8ePHq7dlHOwHBARoPH+5cuVEhQoVPvaSCSE0f4Zz584VKpVKTJo0SeO18/DwEA0bNlS/jkIIkZiYKFxcXMS3336r8X0YGhqKuLg49bZnz56JPHnyiAkTJqi3lSxZUrRv3179dfny5UW7du0EAHH9+nUhhBCbN28WAERYWJgQQohLly4JAKJPnz4a+YcNGyYAiAMHDmh8TwDE7t27NfadM2eOACD++OMP9baEhATh7u6uUdhcvHhRABAbNmz45Ov3vg8VNgUKFBCxsbHq7Vu3bhUAxLZt2z76eBs2bNDIllnG93nkyBH1tmfPnglDQ0MxdOhQ9bZJkyaJfPnyiVu3bmn8/1GjRgl9fX0RHR39wed/9uyZMDAwEE2bNtX4+f/0008CgEZh8/btW/V7KPP3b2hoqPH7+bH3dsbnTGaBgYFCpVKJe/fuCSGE+PvvvwUA8fPPP38w9+vXr4WFhYXo27evxvYnT54Ic3Nzje39+/cXPOdLpFwcikZEn619+/Z48+YNtm/fjtevX2P79u0fHIa2c+dO6OvrY9CgQRrbhw4dCiEEdu3aBQCwsLAAAGzduvWzhsJ8SlpaGrZs2YJmzZqhYsWKWvdnDC3ZuXMnKleujG+++UZ9n6mpKfr164e7d+/i2rVrGv/Px8cHefPmVX9dpUoVCCHQq1cvjf2qVKmC+/fva81Fql+/vsawpCpVqgAA2rRpAzMzM63tt2/fBgCcO3cOz549w48//ggjIyP1fk2bNkXx4sW1hs4BwPfff6/xdc2aNdWP9zlmzJiBwYMHY/r06Rg7dqx6+6VLlxAREYHOnTsjJiYGL168wIsXL5CQkID69evjyJEj6p+hj48PkpKSsHHjRvX/X79+PVJSUtC1a1eNbEePHgUAvH79GmFhYejXrx+sra3V248ePQoLCwuUKlUKQPrPDgD8/Pw0cg8dOhQAtF4TFxcXNGzYUGPbzp07UbBgQbRt21a9zcTEBP369dPYz9zcHACwZ88eJCYmftbr9ykdOnSApaWl+uuaNWsCQLZ+Rlnx9PRUPxYA2NjYoFixYhqPu2HDBtSsWROWlpbqn9+LFy/g7e2N1NRUHDly5IOPv3//fiQnJ2PgwIEaQ7SGDBmita+hoSH09NIPMVJTUxETE6MeZnrhwoXP+n6MjY3V/05ISMCLFy9QvXp1CCFw8eJF9T4GBgY4dOgQ/v777ywfZ9++fYiLi0OnTp00vmd9fX1UqVIFBw8e/Kw8RCR/LGyI6LPZ2NjA29sba9aswebNm5GamqpxYJjZvXv34ODgoHHQDqTPlci4H0g/yKtRowb69OkDOzs7dOzYEX/88ccXFznPnz/Hq1ev1AfBH3Lv3j0UK1ZMa/v7+TIUKVJE4+uMA15HR0et7WlpaVrzL7Lz/wGoD9IycmSVtXjx4lo5jYyMYGNjo7HN0tLygwd97zt8+DBGjhyJkSNHasyrAdLnmgBA9+7dYWNjo3FbunQpkpKS1N938eLFUalSJfz+++/q///777+jatWqcHd3V2+rWbMmHj9+jMjISJw4cQIqlQrVqlXTKHiOHj2KGjVqqA+U7927Bz09PY3HAQB7e3tYWFhovSYuLi5a3+e9e/fg7u6uNYfi/dfZxcUFfn5+WLp0KaytrdGwYUMsWLDgk/NrPub934WMIudzf0af+7gZj535cSMiIrB7926tn5+3tzcA4NmzZx98/IzX1cPDQ2O7jY2NRqEGpJ9gmD17Njw8PGBoaAhra2vY2NggPDz8s1+76Oho9OjRA1ZWVur5YrVr1wYA9WMYGhpi+vTp2LVrF+zs7FCrVi3MmDEDT5480fieAaBevXpa3/fevXs/+j0TkbLkkToAESlL586d0bdvXzx58gSNGzdWX3H5UsbGxjhy5AgOHjyIHTt2YPfu3Vi/fj3q1auHvXv3Ql9fP2eC/0sfyvGh7eK9Bgn/9v9/rn/7epUsWRJxcXEICQnB//73P42iIKPY/Pnnn1G2bNks/7+pqan63z4+Phg8eDAePHiApKQknDp1CvPnz9fYP+OK2ZEjR3D79m2UL18e+fLlQ82aNTFv3jzEx8fj4sWLmDJlitZzfe7E7sxn/r/EzJkz0aNHD2zduhV79+7FoEGDEBgYiFOnTqFw4cLZfryc/pln53HT0tLw7bffYsSIEVnuW7Ro0X+VIcPUqVMxbtw49OrVC5MmTYKVlRX09PQwZMiQzzppkZqaim+//RaxsbEYOXIkihcvjnz58uHhw4fo0aOHxmMMGTIEzZo1w5YtW7Bnzx6MGzcOgYGBOHDgAMqVK6feNyQkJMvujXny8FCIKLfgu5mIsqVVq1b43//+h1OnTmH9+vUf3M/JyQn79+/H69evNa7a3LhxQ31/Bj09PdSvXx/169fHrFmzMHXqVIwZMwYHDx6Et7d3tjoT2djYIH/+/Lhy5cpH93NycspyjZGs8kkpI8fNmzdRr149jftu3ryZ4zmtra2xceNGfPPNN6hfvz6OHTsGBwcHAICbmxsAIH/+/Ooz/B/TsWNH+Pn5Ye3atXjz5g3y5s2r0dkMSL/KUKRIERw9ehS3b99WD6WqVasW/Pz8sGHDBqSmpqJWrVrq/+Pk5IS0tDRERESor7ABwNOnTxEXF/dZr4mTkxOuXLkCIYTG79eH1p0pXbo0SpcujbFjx+LEiROoUaMGgoKCMHny5E8+V07JiQ5dbm5uiI+P/6yf3/syXteIiAi4urqqtz9//lzratPGjRtRt25dLFu2TGN7XFwcrK2t1V9/6Hu6fPkybt26hVWrVsHHx0e9PXNXxszc3NwwdOhQDB06FBEREShbtixmzpyJ1atXq39vbW1tP/l9swsakbJxKBoRZYupqSkWLlyIiRMnolmzZh/cr0mTJkhNTdU6Qz979myoVCo0btwYQHpb2PdlXA3IaL2bL18+AOkHRZ+ip6eHli1bYtu2bTh37pzW/Rlnr5s0aYIzZ87g5MmT6vsSEhKwePFiODs7w9PT85PPpQsVK1aEra0tgoKCNFoR79q1C9evX0fTpk1z/DkLFy6M/fv3482bN/j2228RExMDAKhQoQLc3Nzwyy+/ID4+Xuv/PX/+XONra2trNG7cGKtXr8bvv/+ORo0aaRzUZqhZsyYOHDiAM2fOqAubsmXLwszMDNOmTYOxsTEqVKig3r9JkyYAgDlz5mg8zqxZswDgs16TJk2a4NGjRxpzgBITE7F48WKN/V69eqU1X6p06dLQ09PLsjX015Sd98GHtG/fHidPnsSePXu07ouLi9P6XjPz9vZG3rx58euvv2pcBXr/5wCkXz16/wrUhg0btFqUf+h7yrj6lPkxhBCYO3euxn6JiYl4+/atxjY3NzeYmZmpfz4NGzZE/vz5MXXqVLx7904ra+bf25x4jYlIOrxiQ0TZ1r1790/u06xZM9StWxdjxozB3bt3UaZMGezduxdbt27FkCFD1GdRAwICcOTIETRt2hROTk549uwZfvvtNxQuXFg9TMnNzQ0WFhYICgqCmZkZ8uXLhypVqmQ5dwJIHwazd+9e1K5dG/369UOJEiXw+PFjbNiwAceOHYOFhQVGjRqFtWvXonHjxhg0aBCsrKywatUq3LlzB5s2bVLP55Ba3rx5MX36dPTs2RO1a9dGp06d8PTpU8ydOxfOzs7w9fX9Ks/r7u6OvXv3ok6dOmjYsCEOHDiA/PnzY+nSpWjcuDFKliyJnj17olChQnj48CEOHjyI/PnzY9u2bRqP4+Pjo56HNWnSpCyfq2bNmvj999+hUqnUP3N9fX1Ur14de/bsQZ06dWBgYKDev0yZMujevTsWL16MuLg41K5dG2fOnMGqVavQsmVL1K1b95PfX9++fTF//nz4+Pjg/PnzKFiwIEJCQmBiYqKx34EDBzBgwAC0a9cORYsWRUpKCkJCQqCvr482bdpk6zX9t8qWLQt9fX1Mnz4dL1++hKGhIerVqwdbW9vPfozhw4fjr7/+wnfffYcePXqgQoUKSEhIwOXLl7Fx40bcvXs3y+ITgHpNpMDAQHz33Xdo0qQJLl68iF27dmn9n++++w4BAQHo2bMnqlevjsuXL+P333/XuNIDfPi9Xbx4cbi5uWHYsGF4+PAh8ufPj02bNmldGbp16xbq16+P9u3bw9PTE3ny5MGff/6Jp0+fomPHjgDSrzAuXLgQ3bp1Q/ny5dGxY0fY2NggOjoaO3bsQI0aNdQnYDIK6EGDBqFhw4bQ19dXPw4RKYAkvdiISDEyt3v+mPfbPQuR3mbV19dXODg4iLx58woPDw/x888/a7SKDQ0NFS1atBAODg7CwMBAODg4iE6dOmm1o926davw9PQUefLk+azWz/fu3RM+Pj7CxsZGGBoaCldXV9G/f3+RlJSk3icqKkq0bdtWWFhYCCMjI1G5cmWxfft2jcfJaPf8frvfD70uEyZM0GpfDUD0799fY7+M1r/vt6n90POtX79elCtXThgaGgorKyvRpUsX8eDBA419unfvLvLly6f1WmRk+pSsfoanT58WZmZmolatWur2uxcvXhStW7cWBQoUEIaGhsLJyUm0b99ehIaGaj1mUlKSsLS0FObm5hrtqjO7evWqACBKlCihsX3y5MkCgBg3bpzW/3n37p3w9/cXLi4uIm/evMLR0VGMHj1avH379pPfU4Z79+6J5s2bCxMTE2FtbS0GDx4sdu/erdFS+fbt26JXr17Czc1NGBkZCSsrK1G3bl2xf//+rF/ETD7U7jmr1sQANNpgf8iSJUuEq6ur0NfX18j5oe+zdu3aonbt2hrbXr9+LUaPHi3c3d2FgYGBsLa2FtWrVxe//PLLR9fSEUKI1NRU4e/vLwoWLCiMjY1FnTp1xJUrV4STk5NWu+ehQ4eq96tRo4Y4efJklnk+9N6+du2a8Pb2FqampsLa2lr07dtXhIWFaezz4sUL0b9/f1G8eHGRL18+YW5uLqpUqaLRxjvDwYMHRcOGDYW5ubkwMjISbm5uokePHuLcuXPqfVJSUsTAgQOFjY2NUKlUbP1MpDAqIf7lbEUiIqIPSElJgYODA5o1a6Y134KIiCgnyWOsBRER5UpbtmzB8+fPNSaAExERfQ28YkNERDnu9OnTCA8Px6RJk2Btbf3ZizISERF9KV6xISKiHLdw4UL88MMPsLW1RXBwsNRxiIjoP4BXbIiIiIiISPF4xYaIiIiIiBSPhQ0RERERESme7BboTEtLw6NHj2BmZgaVSiV1HCIiIiIikogQAq9fv4aDg8MnF8+WXWHz6NEjODo6Sh2DiIiIiIhk4v79+yhcuPBH95FdYWNmZgYgPXz+/PklTkNERERERFJ59eoVHB0d1TXCx8iusMkYfpY/f34WNkRERERE9FlTVNg8gIiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFyyN1gH/DedSOHHusu9Oa5thjERERERGRbvGKDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlK8bBU2gYGBqFSpEszMzGBra4uWLVvi5s2bGvvUqVMHKpVK4/b999/naGgiIiIiIqLMslXYHD58GP3798epU6ewb98+vHv3Dg0aNEBCQoLGfn379sXjx4/VtxkzZuRoaCIiIiIioszyZGfn3bt3a3y9cuVK2Nra4vz586hVq5Z6u4mJCezt7XMmIRERERER0Sf8qzk2L1++BABYWVlpbP/9999hbW2NUqVKYfTo0UhMTPzgYyQlJeHVq1caNyIiIiIiouzI1hWbzNLS0jBkyBDUqFEDpUqVUm/v3LkznJyc4ODggPDwcIwcORI3b97E5s2bs3ycwMBA+Pv7f2kMIiIiIiIiqIQQ4kv+4w8//IBdu3bh2LFjKFy48Af3O3DgAOrXr4/IyEi4ublp3Z+UlISkpCT1169evYKjoyNevnyJ/PnzfzSD86gdXxI9S3enNc2xxyIiIiIion/v1atXMDc3/6za4Iuu2AwYMADbt2/HkSNHPlrUAECVKlUA4IOFjaGhIQwNDb8kBhEREREREYBsFjZCCAwcOBB//vknDh06BBcXl0/+n0uXLgEAChYs+EUBiYiIiIiIPiVbhU3//v2xZs0abN26FWZmZnjy5AkAwNzcHMbGxoiKisKaNWvQpEkTFChQAOHh4fD19UWtWrXg5eX1Vb4BIiIiIiKibBU2CxcuBJC+CGdmK1asQI8ePWBgYID9+/djzpw5SEhIgKOjI9q0aYOxY8fmWGAiIiIiIqL3ZXso2sc4Ojri8OHD/yoQERERERFRdv2rdWyIiIiIiIjkgIUNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixctWYRMYGIhKlSrBzMwMtra2aNmyJW7evKmxz9u3b9G/f38UKFAApqamaNOmDZ4+fZqjoYmIiIiIiDLLVmFz+PBh9O/fH6dOncK+ffvw7t07NGjQAAkJCep9fH19sW3bNmzYsAGHDx/Go0eP0Lp16xwPTkRERERElCFPdnbevXu3xtcrV66Era0tzp8/j1q1auHly5dYtmwZ1qxZg3r16gEAVqxYgRIlSuDUqVOoWrVqziUnIiIiIiL6f/9qjs3Lly8BAFZWVgCA8+fP4927d/D29lbvU7x4cRQpUgQnT57M8jGSkpLw6tUrjRsREREREVF2fHFhk5aWhiFDhqBGjRooVaoUAODJkycwMDCAhYWFxr52dnZ48uRJlo8TGBgIc3Nz9c3R0fFLIxERERER0X/UFxc2/fv3x5UrV7Bu3bp/FWD06NF4+fKl+nb//v1/9XhERERERPTfk605NhkGDBiA7du348iRIyhcuLB6u729PZKTkxEXF6dx1ebp06ewt7fP8rEMDQ1haGj4JTGIiIiIiIgAZPOKjRACAwYMwJ9//okDBw7AxcVF4/4KFSogb968CA0NVW+7efMmoqOjUa1atZxJTERERERE9J5sXbHp378/1qxZg61bt8LMzEw9b8bc3BzGxsYwNzdH79694efnBysrK+TPnx8DBw5EtWrV2BGNiIiIiIi+mmwVNgsXLgQA1KlTR2P7ihUr0KNHDwDA7NmzoaenhzZt2iApKQkNGzbEb7/9liNhiYiIiIiIspKtwkYI8cl9jIyMsGDBAixYsOCLQxEREREREWXHv1rHhoiIiIiISA5Y2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESletgubI0eOoFmzZnBwcIBKpcKWLVs07u/RowdUKpXGrVGjRjmVl4iIiIiISEu2C5uEhASUKVMGCxYs+OA+jRo1wuPHj9W3tWvX/quQREREREREH5Mnu/+hcePGaNy48Uf3MTQ0hL29/ReHIiIiIiIiyo6vMsfm0KFDsLW1RbFixfDDDz8gJibmg/smJSXh1atXGjciIiIiIqLsyPHCplGjRggODkZoaCimT5+Ow4cPo3HjxkhNTc1y/8DAQJibm6tvjo6OOR2JiIiIiIhyuWwPRfuUjh07qv9dunRpeHl5wc3NDYcOHUL9+vW19h89ejT8/PzUX7969YrFDRERERERZctXb/fs6uoKa2trREZGZnm/oaEh8ufPr3EjIiIiIiLKjq9e2Dx48AAxMTEoWLDg134qIiIiIiL6j8r2ULT4+HiNqy937tzBpUuXYGVlBSsrK/j7+6NNmzawt7dHVFQURowYAXd3dzRs2DBHgxMREREREWXIdmFz7tw51K1bV/11xvyY7t27Y+HChQgPD8eqVasQFxcHBwcHNGjQAJMmTYKhoWHOpSYiIiIiIsok24VNnTp1IIT44P179uz5V4GIiIiIiIiy66vPsSEiIiIiIvraWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpXrbbPdPncR61I8ce6+60pjn2WIC8sxERERERfQlesSEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSvDxSByDK4DxqR44+3t1pTXPssXIyW07mIiIiIqJ0vGJDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFC/bhc2RI0fQrFkzODg4QKVSYcuWLRr3CyEwfvx4FCxYEMbGxvD29kZERERO5SUiIiIiItKS7cImISEBZcqUwYIFC7K8f8aMGZg3bx6CgoJw+vRp5MuXDw0bNsTbt2//dVgiIiIiIqKs5Mnuf2jcuDEaN26c5X1CCMyZMwdjx45FixYtAADBwcGws7PDli1b0LFjx3+XloiIiIiIKAs5Osfmzp07ePLkCby9vdXbzM3NUaVKFZw8eTLL/5OUlIRXr15p3IiIiIiIiLIjRwubJ0+eAADs7Ow0ttvZ2anve19gYCDMzc3VN0dHx5yMRERERERE/wGSd0UbPXo0Xr58qb7dv39f6khERERERKQwOVrY2NvbAwCePn2qsf3p06fq+95naGiI/Pnza9yIiIiIiIiyI0cLGxcXF9jb2yM0NFS97dWrVzh9+jSqVauWk09FRERERESklu2uaPHx8YiMjFR/fefOHVy6dAlWVlYoUqQIhgwZgsmTJ8PDwwMuLi4YN24cHBwc0LJly5zMTUREREREpJbtwubcuXOoW7eu+ms/Pz8AQPfu3bFy5UqMGDECCQkJ6NevH+Li4vDNN99g9+7dMDIyyrnUREREREREmWS7sKlTpw6EEB+8X6VSISAgAAEBAf8qGBERERER0eeSvCsaERERERHRv8XChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPGy3e6ZiOTFedSOHHusu9Oa5thjAfLORkRERLkLr9gQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHi5ZE6ABGRrjmP2pGjj3d3WtMcfTwiIiLKPl6xISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESleHqkDEBHRP5xH7cixx7o7rWmOPRbAbEREJG+8YkNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFy/HCZuLEiVCpVBq34sWL5/TTEBERERERqeX5Gg9asmRJ7N+//58nyfNVnoaIiIiIiAjAVyps8uTJA3t7+6/x0ERERERERFq+yhybiIgIODg4wNXVFV26dEF0dPQH901KSsKrV680bkRERERERNmR41dsqlSpgpUrV6JYsWJ4/Pgx/P39UbNmTVy5cgVmZmZa+wcGBsLf3z+nYxAREUnOedSOHH28u9Oa5thj5WS2nMwFMNuX4O/al5FzNsq+HL9i07hxY7Rr1w5eXl5o2LAhdu7cibi4OPzxxx9Z7j969Gi8fPlSfbt//35ORyIiIiIiolzuq8/qt7CwQNGiRREZGZnl/YaGhjA0NPzaMYiIiIiIKBf76uvYxMfHIyoqCgULFvzaT0VERERERP9ROV7YDBs2DIcPH8bdu3dx4sQJtGrVCvr6+ujUqVNOPxURERERERGArzAU7cGDB+jUqRNiYmJgY2ODb775BqdOnYKNjU1OPxURERERERGAr1DYrFu3LqcfkoiIiIiI6KO++hwbIiIiIiKir42FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeLleLtnIiIiIiL6d5xH7cixx7o7rWmOPVZO5gJyNhuv2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPG+WmGzYMECODs7w8jICFWqVMGZM2e+1lMREREREdF/3FcpbNavXw8/Pz9MmDABFy5cQJkyZdCwYUM8e/bsazwdERERERH9x32VwmbWrFno27cvevbsCU9PTwQFBcHExATLly//Gk9HRERERET/cXly+gGTk5Nx/vx5jB49Wr1NT08P3t7eOHnypNb+SUlJSEpKUn/98uVLAMCrV68++VxpSYk5kBif/XzZwWzZl5O5APlm+6/8PAH5ZuPv2pdhtuzj79qXYbbs4+/al2G27NP171rG/UKITz6WSnzOXtnw6NEjFCpUCCdOnEC1atXU20eMGIHDhw/j9OnTGvtPnDgR/v7+ORmBiIiIiIhykfv376Nw4cIf3SfHr9hk1+jRo+Hn56f+Oi0tDbGxsShQoABUKtW/fvxXr17B0dER9+/fR/78+f/14+UUueYCmO1LyTWbXHMBzPal5JpNrrkAZvtScs0m11wAs30puWaTay7gv5NNCIHXr1/DwcHhk/vmeGFjbW0NfX19PH36VGP706dPYW9vr7W/oaEhDA0NNbZZWFjkdCzkz59fdj90QL65AGb7UnLNJtdcALN9Kblmk2sugNm+lFyzyTUXwGxfSq7Z5JoL+G9kMzc3/6z9crx5gIGBASpUqIDQ0FD1trS0NISGhmoMTSMiIiIiIsopX2Uomp+fH7p3746KFSuicuXKmDNnDhISEtCzZ8+v8XRERERERPQf91UKmw4dOuD58+cYP348njx5grJly2L37t2ws7P7Gk/3UYaGhpgwYYLWcDepyTUXwGxfSq7Z5JoLYLYvJddscs0FMNuXkms2ueYCmO1LyTWbXHMBzJaVHO+KRkREREREpGtfZYFOIiIiIiIiXWJhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyL6z3v37h3c3Nxw/fp1qaMQEeWoqKgojB07Fp06dcKzZ88AALt27cLVq1clTkaU81jYkOzVq1cPcXFxWttfvXqFevXq6T6QAqWmpuLSpUv4+++/pY4iS3nz5sXbt2+ljvFRoaGh+Omnn9CnTx/06tVL40aUU1xdXRETE6O1PS4uDq6urhIk0hYZGYk9e/bgzZs3AAA2d/2ww4cPo3Tp0jh9+jQ2b96M+Ph4AEBYWBgmTJggcTr5mjBhAu7duyd1jI+S4/ugV69eeP36tdb2hIQEnf2tyrWFTUpKCvbv349FixapX+RHjx6p39RSOXDggGwPoEJCQlCjRg04ODio39Bz5szB1q1bJc116NAhJCcna21/+/Ytjh49KkGif0RERGDx4sWYPHkyAgICNG5SGjJkCJYtWwYgvaipXbs2ypcvD0dHRxw6dEjSbHLVv39/TJ8+HSkpKVJH0eLv748GDRogNDQUL168wN9//61xo8/z6tUrbNmyhVfmPuLu3btITU3V2p6UlISHDx9KkOgfMTEx8Pb2RtGiRdGkSRM8fvwYANC7d28MHTpU0mzvk8vv2qhRozB58mTs27cPBgYG6u316tXDqVOnJEz2Dzker23duhVubm6oX78+1qxZg6SkJMmyvE/O74NVq1apC63M3rx5g+DgYJ1k+CoLdErt3r17aNSoEaKjo5GUlIRvv/0WZmZmmD59OpKSkhAUFCRZtubNmyMlJQWVKlVCnTp1ULt2bdSoUQPGxsaSZQKAhQsXYvz48RgyZAimTJmi/sNmYWGBOXPmoEWLFjrPFB4erv73tWvX8OTJE/XXqamp2L17NwoVKqTzXBmWLFmCH374AdbW1rC3t4dKpVLfp1KpMH78eMmybdy4EV27dgUAbNu2DXfu3MGNGzcQEhKCMWPG4Pjx45Jla9WqlcZrlUGlUsHIyAju7u7o3LkzihUrptNcZ8+eRWhoKPbu3YvSpUsjX758Gvdv3rxZp3kyCwoKwsqVK9GtWzfJMnzK0aNHsWjRIkRFRWHjxo0oVKgQQkJC4OLigm+++UaSTO3bt0etWrUwYMAAvHnzBhUrVsTdu3chhMC6devQpk0bSXJlCAkJQVBQEO7cuYOTJ0/CyckJc+bMgYuLi84/c//66y/1v/fs2QNzc3P116mpqQgNDYWzs7NOM73P19cXefLkQXR0NEqUKKHe3qFDB/j5+WHmzJmSZZPr79rly5exZs0are22trZ48eKFBIk0yfV47dKlS7h48SJWrFiBwYMHo3///ujYsSN69eqFSpUqSZIpgxzfB69evYIQAkIIvH79GkZGRur7UlNTsXPnTtja2uomjMiFWrRoIbp27SqSkpKEqampiIqKEkIIcfDgQeHu7i5ptuTkZHHs2DExZcoU0aBBA2FqaioMDAxE9erVxZgxYyTLVaJECfHnn38KIYTGa3b58mVRoEABSTKpVCqhp6cn9PT0hEql0rqZmJiIZcuWSZJNCCGKFCkipk2bJtnzf4yhoaG4f/++EEKIvn37isGDBwshhLh9+7YwMzOTMJkQ3bt3F+bm5sLJyUm0bt1atG7dWjg7OwsLCwvRvn17UaxYMWFoaCiOHTum01w9evT46E1KVlZWIjIyUtIMH7Nx40ZhbGws+vTpIwwNDdWfH7/++qto3LixZLns7OzEpUuXhBBC/P7778Ld3V0kJCSI3377TZQtW1ayXEII8dtvvwlra2sxefJkYWxsrH7NVqxYIerUqaPzPBmfq1l93hoYGIiiRYuKbdu26TxXZpl/npn/TkVFRYl8+fJJGU22v2uFChUSx48fF0JovmabN28Wrq6ukuXKIOfjtQzJycli06ZN4rvvvhN58+YVpUuXFnPmzBFxcXGS5JHj+yDz8VpWN319fTF58mSdZMmVhY2VlZW4ceOGEELzh37nzh1hbGwsZTQtV65cEd27dxd58uQRenp6kuUwMjISd+/eFUJovma3bt0SRkZGkmS6e/euuHPnjlCpVOLs2bPi7t276tujR49ESkqKJLkymJmZqV8nuSlSpIjYs2ePSElJEY6OjmL79u1CiPTfNwsLC0mzjRw5Uvzwww8iNTVVvS01NVUMGDBAjB49WqSlpYl+/fqJGjVqSJhSXkaMGCECAgKkjvFBZcuWFatWrRJCaH5+XLhwQdjZ2UmWy8jISERHRwshhOjWrZsYOXKkEEKIe/fuSX4gLMeTSUII4ezsLJ4/fy7Z83+MqampuHXrlvrfGa/Z2bNnhZWVlZTRZPu7NnToUPHNN9+Ix48fCzMzMxERESGOHTsmXF1dxcSJEyXLlUEJx2tJSUli3bp1okGDBiJPnjyiVq1awt3dXZiZmYl169bpPI8c3weHDh0SBw8eFCqVSmzevFkcOnRIfTtx4oR4+PChzrLkyqFoaWlpWY4RfvDgAczMzCRI9I9bt27h0KFDOHToEA4fPoykpCTUrFkTv/zyC+rUqSNZLhcXF1y6dAlOTk4a23fv3q1xqVOXMrKkpaVJ8vyf0q5dO+zduxfff/+91FG09OzZE+3bt0fBggWhUqng7e0NADh9+jSKFy8uabZly5bh+PHj0NP7Z4qfnp4eBg4ciOrVq2Pq1KkYMGAAatasKUm+58+f4+bNmwCAYsWKwcbGRpIcmb19+xaLFy/G/v374eXlhbx582rcP2vWLImSpbt58yZq1aqltd3c3DzLxh+64ujoiJMnT8LKygq7d+/GunXrAAB///23xlAJKdy5cwflypXT2m5oaIiEhAQJEqW7c+eOZM/9KTVr1kRwcDAmTZoEIH34alpaGmbMmIG6detKmk2uv2tTp05F//794ejoiNTUVHh6eiI1NRWdO3fG2LFjJcuVQc7Ha+fPn8eKFSuwdu1aGBoawsfHBwsWLIC7uzsA4Ndff8WgQYPQoUMHneaS4/ugdu3aANI/PxwdHTX+vutarixsGjRogDlz5mDx4sUA0n/o8fHxmDBhApo0aSJptuLFi8PGxgaDBw/GqFGjULp06SznG+ian58f+vfvj7dv30IIgTNnzmDt2rUIDAzE0qVLpY6HiIgIHDx4EM+ePdMqdKSay+Lu7o5x48bh1KlTKF26tNbB5qBBgyTJBQATJ05EqVKlcP/+fbRr1w6GhoYAAH19fYwaNUqyXED6RNEbN26gaNGiGttv3Lih/gNnZGSk8/dFQkICBg4ciODgYPXvmL6+Pnx8fPDrr7/CxMREp3kyCw8PR9myZQEAV65c0bhPDp8f9vb2iIyM1JqDcezYMUk7aQ0ZMgRdunSBqakpihQpoj55dOTIEZQuXVqyXIA8TyZlCA0NRWhoaJaft8uXL5coFTBjxgzUr18f586dQ3JyMkaMGIGrV68iNjZW0nmDgObvmpOTk2x+1wwMDLBkyRKMHz8ely9fRnx8PMqVKwcPDw/JMmUm1+O10qVL48aNG2jQoAGWLVuGZs2aQV9fX2OfTp06YfDgwTrPJuf3gZOTE+Li4nDmzJksPz98fHy+fgidXRvSofv37wtPT09RokQJkSdPHlG1alVRoEABUaxYMfH06VNJsw0ePFiUK1dOGBoaimrVqonRo0eLPXv2iISEBElzCSHE6tWrhbu7u3pcdaFChcTSpUuljiUWL14s9PX1hZ2dnShTpowoW7as+lauXDnJcjk7O3/w5uLiIlmu971580bqCBoGDhworK2txaxZs8TRo0fF0aNHxaxZs4S1tbUYNGiQEEKIJUuW6HwoWr9+/YSrq6vYuXOnePnypXj58qXYsWOHcHNzE99//71OsyjN1KlThaenpzh16pQwMzMTR48eFatXrxY2NjZi3rx5kmY7e/as2Lx5s3j9+rV62/bt23U+h+t9S5YsEYUKFRLr1q0T+fLlE2vXrhWTJ09W/1sqEydOFHp6eqJy5cqiRYsWomXLlho3qcXFxYnJkyeLdu3aicaNG4sxY8aIR48eSR1LCCHEuXPnZPm7JmdyPV4LCAgQDx48kOz5P0Wu74O//vpLmJmZCZVKJczNzYWFhYX6ZmlpqZMMubKwEUKId+/eiZCQEDF8+HDxww8/iCVLlojExESpY6n9/fff4q+//hJDhw4VFStWFMbGxqJ69epSxxJCCJGQkCB5AZiZnCfpy1VKSooICAgQDg4OQl9fXz0Gd+zYsZIXqykpKWLy5MnC3t5eXUTb29uLKVOmqOdN3bt3T938QFcKFCggDh48qLX9wIEDwtraWqdZPub+/fs6f20+JS0tTX1QnvEzNTIyEmPHjpU6mhAifYz8jRs3xLt376SOokGOJ5Ps7e1FcHCwpBko57Ru3TrLv5/Tp08Xbdu2lSCRNrkfr8nNvXv3RFpa2gfvk5KHh4cYPHiwpCfrVULIYEWf/6CYmBgcPnwYBw8exKFDh3Dt2jVYWlpK1n7xzp07SElJ0bo8HRERgbx580ra5jN//vy4dOmSbBaHy0rG20gOw4IAICAgAKtWrUJAQAD69u2LK1euwNXVFevXr8ecOXNw8uRJqSMCSG8RCaT/jKVmYmKC8+fPaw0Dunr1KipXrizpvIe0tDRMnjwZM2fOVK/tYGZmhqFDh2LMmDGSjmfOLDk5GZGRkYiPj4enpydMTU0lzZOYmIiBAwdi1apVANLnOLq6umLgwIEoVKiQ5MMyMyQmJiI+Pl537VA/okCBAjhz5gzc3NykjqLlyJEjH70/q3leuvTgwQP89ddfiI6O1lp7Tap5cDY2Njhw4IDWcLjLly/D29sbT58+lSRXhrdv30o+3y2Dn5/fZ+8r5bxGfX19PH78WOvzIiYmBra2tlnOWdKVfPny4fLly5Ier+XKOTaAPOdkAOnzLjIXMrVq1ULfvn1Rp04dScfh9ujRA7169dIqbE6fPo2lS5dKuqijnCfpBwcH4+eff0ZERAQAoGjRohg+fLjk640EBwdj8eLFqF+/vsbrVqZMGdy4cUPCZJrkUNBkqFatGiZMmIDg4GD1H9o3b97A398f1apVkzTbmDFjsGzZMkybNg01atQAkD5/ZeLEiXj79i2mTJkiab4MBgYG8PT0lDqG2ujRoxEWFoZDhw6hUaNG6u3e3t6YOHGipIVN5pNJJiYm6jlcUp9M6tOnD9asWYNx48ZJ8vwfk1WDncwnk6Q8oAsNDUXz5s3h6uqKGzduoFSpUup1bMqXLy9Zrvj4eI2FOTPkzZtXfWJJSra2tmjVqhW6du2K+vXrS3qS5uLFi5+1n9QnMIUQWWaIj4+XvEhs2LAhzp07x8Imp8l54cTHjx+jX79+qFOnDkqVKiVZjvddvHhRfcCUWdWqVTFgwAAJEv1DrpP0Z82ahXHjxmHAgAEaB5vff/89Xrx4AV9fX0lyAcDDhw/VnVsyS0tLw7t37yRI9I+nT59i2LBh6snJ7180lurgZO7cuWjYsCEKFy6MMmXKAADCwsJgZGSEPXv2SJIpw6pVq7B06VI0b95cvc3LywuFChXCjz/+KElh07p168/eV6rFTbds2YL169ejatWqGn8HSpYsiaioKEkyZZDrySQ5d+D7+++/Nb5+9+4dLl68iHHjxkle3I8ePRrDhg2Dv78/zMzMsGnTJtja2qJLly4aRbWulS5dGuvXr9c67lm3bp0sTkKsWrUKa9asQYsWLWBubo4OHTqga9euqFixos6zHDx4UOfPmR0ZV5RUKhXGjRun0dAmNTUVp0+fVjeZkUrTpk0xfPhwXLt2Lcvjtcx/w76WXDkUzcnJCT/++CNGjhwpdRTFMDc3x6FDh7Taj54/fx516tTB69evJUqW3j3oQ1QqFW7fvq3DNP9wcXGBv7+/VpePVatWYeLEiZK2Ta1QoQJ8fX3RtWtXmJmZISwsDK6urggICMC+fftw9OhRybI1btwY0dHRGDBggLoddWa6XnE9s8TERPz+++/qq1olSpRAly5dYGxsLFkmIL1LXHh4uFYnuZs3b6Js2bJ48+aNzjP17Nnzs/ddsWLFV0zyYSYmJuphmJnfB2FhYahVqxZevnwpSS4g/WrlhQsXtE5AREZGomLFipK1yf5Yu1iVSoUDBw7oMM3nOXz4MPz8/HD+/HnJMpiZmeHSpUtwc3ODpaUljh07hpIlSyIsLAwtWrTA3bt3Jcm1bds2tG7dGp07d0a9evUApF9dWrt2LTZs2ICWLVtKkut9r1+/xsaNG7F27VocOHAArq6u6Nq1q6QnouUm4715+PBhVKtWTeNKnIGBAZydnTFs2DBJO9597IqbSqXSzYlLyWb3fEVyXjhRCCGCg4NF9erVRcGCBdWLYs6ePVts2bJFskzfffedaNeuncailykpKaJNmzaiUaNGkuWSM0NDQxEREaG1/datW8LQ0FCCRP/YsmWLMDc3F9OmTRMmJibi559/Fn369BEGBgZi7969kmYzNTUVFy9elDSD0lSuXFkMHDhQa/uAAQNElSpVJEikDDVr1lR3ZTM1NRW3b98WQqS/bg0bNpQymsifP7+4cOGC1vZz584JU1NTCRIp1/Xr1yVfcNXOzk5cu3ZNCJG++OrWrVuFEEJcunRJ8mzbt28X1atXFyYmJqJAgQKibt264tChQ5Jm+pirV6+KsmXL6nzR8latWomXL1+q//2xm5R69OihzknacuVQNDnPyVi4cCHGjx+PIUOGYMqUKerq1cLCAnPmzJHsbPW0adNQu3ZtFCtWTL0w4tGjR/Hq1SvZnKFLTk7GnTt34Obmhjx5pP/VdXd3xx9//IGffvpJY/v69eslXyOgRYsW2LZtGwICApAvXz6MHz8e5cuXx7Zt2/Dtt99Kms3R0VFr+JkcBAYGws7ODr169dLYvnz5cjx//lzSK8AzZsxA06ZNsX//fvV8n5MnT+L+/fvYuXOnZLkyTJgwAb169dJak0VqU6dORePGjXHt2jWkpKRg7ty5uHbtGk6cOIHDhw9Lmq1WrVoIDAzE2rVr1etjpKamIjAwEN98842k2YD0K0dRUVGoVasWjI2NPziuX5fCw8M1vhZC4PHjx5g2bZrkQ3CqVq2KY8eOoUSJEmjSpAmGDh2Ky5cvY/Pmzahataqk2Zo2bYqmTZtKmuFT3r59i7/++gtr1qzB7t27YWdnh+HDh+s0g7m5ufp33NzcXKfPnR1SXQHPLqkaQ+TKoWiBgYGYNWsWmjZtKqs5GQDg6emJqVOnomXLlhpDI65cuYI6depI1hUNAB49eoT58+cjLCwMxsbG8PLywoABA2BlZSVZJkC+nY02bdqEDh06wNvbWz3H5vjx4wgNDcUff/yBVq1aSZJL7vbu3YuZM2di0aJFknbbe5+zszPWrFmD6tWra2w/ffo0OnbsKPmK7I8ePcKCBQs0hsn9+OOPcHBwkDQXAJQtWxZXrlxB7dq10bt3b7Rp00a9KKzUoqKiMG3aNISFhSE+Ph7ly5fHyJEjJV+g89q1a6hVqxYsLCyyPJkk1RzMmJgYtG/fHgcPHoRKpUJERARcXV3Rq1cvWFpaYubMmZLkAtKHuahUKq0TI1WrVsXy5ctRvHhxiZIBt2/fRnx8PLy8vJCQkIChQ4fixIkT8PDwwKxZsyQv+pOTk7NsplSkSBGJEqXbs2cP1qxZgy1btiBPnjxo27YtunTpInmHO7lp3bo1Vq5cifz5839yfqNUcxqB9JMzU6dORVBQEJ4+fao+Xhs3bhycnZ3Ru3fvr54hVxY2cp2TAQDGxsa4ceMGnJycNAqbiIgIeHl5STJW/t27d2jUqBGCgoIkv9KQlcGDB+P48eOYM2cOGjVqhPDwcLi6umLr1q2YOHHiZ3cy+RrOnz+P2bNn4/r16wDSDzaHDh2qNVeJ/mFpaYnExESkpKTAxMRE68RDbGysJLmMjIxw/fp1rc+P27dvw9PTE2/fvpUkl1JcvHgRK1aswNq1a5GSkoKOHTuiV69eqFSpktTRZEuOJ5N8fHzw7NkzLF26FCVKlFD/jdqzZw/8/Pxw9epVybLdu3dP42s9PT3Y2NhI3glKziIiItCrVy+cOHFCY3vGFTgpO8kB6fPgvvvuO3Tp0gVNmjTR+ntA6Xr27Il58+bBzMzsk/MbpbyiI4elJqQfz/MVSH1m9WNcXFxw6dIlrbM3u3fv1lo/Q1fy5s2rdYlfTuTc2ahChQpYvXq1pBkyWFpafvZQEamKBwCYM2eOZM/9MY6Ojjh+/LhWYXP8+HFJroqEh4ejVKlS0NPT++T708vLS0epPqxcuXIoV64cZs6ciW3btmHFihWoUaMGihcvjt69e6NHjx6SDO9ITU3Fn3/+qT754OnpiRYtWshiOKuDgwOmTp0qdQwNe/fuxZ49e1C4cGGN7R4eHlqFha5JfdXjU+Li4rBx40ZERUVh+PDhsLKywoULF2BnZ4dChQpJkqlHjx7IkycPtm/fnmWzFqk9ffoUZmZmUsfQEhMTg/Hjx39w2RBd/w3NKFaEEPD394eNjY3kTW2yIoelJqT/ZP+P8fPzQ//+/fH27VsIIXDmzBmsXbsWgYGBWLp0qWS5unbtql4nQ26eP3+e5cJ1CQkJOv+QfvXqlXrtlU+tAaDrNVrkWjC8r3v37lJHyFLfvn0xZMgQvHv3TqN70IgRIzB06FCd5ylbtiyePHkCW1tblC1bNsshOIAOO818JiEE3r17h+TkZAghYGlpifnz52PcuHFYsmQJOnTooLMsV69eRfPmzfHkyRMUK1YMADB9+nTY2Nhg27ZtOh/upYRiNSEhQaONbIbY2FhJhhfOmzfvs/eVcph5eHg4vL29YW5ujrt376Jv376wsrLC5s2bER0djeDgYElyXbp0CefPn5d0mN7HmJmZITU1FVu2bNE6+ZAx90wK3bp1Q2RkJHr37g07OzvZFIRCCLi7u+Pq1auyHGEjh6Umck1h4+fnh0mTJiFfvnyfXD1Wyj78ffr0gbGxMcaOHYvExER07twZDg4OmDt3Ljp27ChZrpSUFCxfvhz79+9HhQoVkC9fPo37pXzNKlasiB07dmDgwIEA/lkca+nSpTpfONHS0lK94q+FhUWWH3ZSXeKXa8EAyLsgzDB8+HDExMTgxx9/VK8abmRkhJEjR2L06NE6z3Pnzh3Y2Nio/y1358+fVw9FMzQ0hI+PDxYsWKD+I/frr79i0KBBOi1s+vTpg5IlS+LcuXOwtLQEkL4WSo8ePdCvXz+t4TlfmxKK1Zo1ayI4OBiTJk1SZ0lLS8OMGTM+2gr6a5k9e/Zn7adSqSQtbPz8/NCjRw/MmDFD4wpEkyZN0LlzZ8lyeXp6Sjp391MiIyPRpEkTPHz4UH3yITAwEI6OjtixYwfc3NwkyXX06FEcO3ZMvaaZXOjp6cHDwwMxMTGyLGw8PT1x9OhRraurGzdu1NkQ/VxT2Fy8eFFdDUo55+JzdOnSBV26dEFiYiLi4+OzvBqha1euXFGvjnzr1i2N+6Q+UyGnzkYHDhxQj3+X82JeO3fuhL6+Pho2bKixfe/evUhNTUXjxo11mkfOBWEGlUqF6dOnY9y4cbh+/TqMjY3h4eEh2ST4zH8Y7t27h+rVq2sNn0pJScGJEyckH6JTunRp3LhxAw0aNMCyZcvQrFkzrbOtnTp1wuDBg3Wa69KlSxpFDZD+uzhlyhRJ5v4ooVidMWMG6tevj3PnziE5ORkjRozA1atXERsbi+PHj+s8j1xfp/edPXsWixYt0tpeqFAhPHnyRIJE6aZPn44RI0Zg6tSpWTZTkupEUoZBgwbBzc0Np06dUv9tjYmJQdeuXTFo0CDs2LFDklzFixeXZM7z55g2bRqGDx+OhQsXymqhdwAYP348unfvjocPHyItLQ2bN2/GzZs3ERwcjO3bt+smhK77SxN9icjISNGnTx9RqVIlUaJECdGlSxcRHh4uaaZ79+6JtLQ0re1paWni3r17EiT6R+nSpcWOHTu0tu/atUt4eXnpPM+hQ4fEu3fv1P/+2E1qERERYvfu3SIxMVEIIbL8Geuanp6eePr0qdb2Fy9e6Hyth6wEBASIBw8eSB1Di5eXlwgNDdXaHhoaKkqVKiVBonTJycmiZ8+e6nV15CYuLk5MnjxZtGvXTjRu3FiMGTNGPHr0SOpYsmZjY6Nel8jU1FS9lt7evXtF4cKFJculUqmESqUSenp6GreMbVIzMTHJ8m+51Ov/nDlzRtSrV08cOnRIvHjxQrx8+VLjJiULCwthYGAg9PT0hJGRkbC0tNS4Se3IkSPC29tb2NjYCGNjY1GjRg2xZ88enT1/rrlik1lwcDAqVaqkNRn/7du3+OOPP7RWiv/aypcvj9DQUFhaWqJcuXIfvQJy4cIFHSbTJse1CwDAzc0NS5YskTqGBhcXF/VViMxiY2Ph4uIi6byHiIgIeHp6am0vXrw4IiMjdZ6ndu3aWf5bTj7U5rZ3796St7n90PswJiZGa9ioFMT/z6V535s3b/Dzzz9Ltnp4YGAgBg0ahIkTJ6rXEjl16hQCAgIwffp0jWGRujxznTdvXmzatAnjxo3T2XNmh7m5OcaMGSN1jCw9ePAAf/31F6Kjo9VDRjNIOWS6efPmCAgIwB9//AEg/QpwdHQ0Ro4ciTZt2kiWS84jCwDA0NAQr1+/1toeHx8PAwMDCRKls7CwwKtXr9TzLTMIGXSTk/t82po1a2Lfvn2SPX+ubPesp6eHfPnyYeXKlRofKE+fPoWDg4POfyH9/f0xfPhwmJiYYOLEiR8tFCZMmKDDZP+Q89oF+vr6WRYQMTExsLW1lewDRk9PD0+fPlUPLclw7949eHp6IiEhQZJcAGBvb481a9ZofSjv378fnTt3xrNnz3SaJztd96SaNC3HNrcZ6xVs3boVjRo10hgWl5qaivDwcBQrVgy7d+/WebbM5PwezZDxuZvxJy/z11LNiStbtix8fX11+ryf4+3btwgPD8+yG1Tz5s0lSpXezKN58+ZwdXXFjRs3UKpUKdy9exdCCJQvX17SxaRfvnyJtm3b4ty5c3j9+jUcHBzw5MkTVKtWDTt37pTFCQg58vHxwYULF7Bs2TJUrlwZQPraYX379kWFChWwcuVKSXJVrlwZefLkweDBg7NsHiDXE3RyEh8fr/X5oYsTSLnyig2QXkx069YNly9fxsSJEyXNkrlYkTrLh/j6+iJv3ryIjo7WuNLVoUMH+Pn5SX62OitJSUmSnNHJaE6hUqkwbtw4jQ5CqampOH36tOSrYLdo0QJDhgzBn3/+qZ58GRkZiaFDh0pyYJJ5ovSnrgBKdRAsxza3Ge2RhRAwMzPTaO9pYGCAqlWrom/fvpJky+xDP9ewsDBJ12SR89lqDw8PBAQE4Pjx41k2bJFqIvzu3bvh4+OT5YRzqc9Ujx49GsOGDYO/vz/MzMywadMm2NraokuXLmjUqJFkuYD09+q+fftw7NgxhIeHqxeD9fb2ljQXkD4RftGiRbh9+zY2bNiAQoUKISQkBC4uLvjmm28kzTZv3jx0794d1apVU8//effuHVq0aCHplYkrV67g4sWL6oYGcvN+J7mSJUuiefPmknaSA9LnxA0YMACHDh3SWPtNlyeQcm1h07VrV1SvXh2tWrXClStXEBISInUkAOlderp27Yo6depIHUWDHA/qMtp8qlQqLF26FKampur7UlNTceTIEUlaWGY0pxBC4PLlyxrFlYGBAcqUKYNhw4bpPFdmM2bMQKNGjVC8eHH1z/TBgweoWbMmfvnlF53nyTwB+OLFixg2bBiGDx+u7mp38uRJzJw5EzNmzNB5tgxya3ML/LN2gbOzs/qqr5xkrJ2kUqlQtGhRjeImNTUV8fHxGmsZ6Jqcz6ouW7YMFhYWOH/+PM6fP69xn5QdvgYOHIh27dph/PjxsLOzkyTDh1y/fh1r164FAOTJkwdv3ryBqakpAgIC0KJFC/zwww8SJwS++eYbyYuFzDZt2oRu3bqhS5cuuHDhApKSkgCkX2GaOnUqdu7cKWk+CwsLbN26FZGRkRoLXWfVMliXKlasiPv378uysJFrJzkg/dhbCIHly5dL1iY7Vw5FyzwsIjo6Gs2bN4dKpUJQUBCqV68u6RmnFi1aYM+ePbCxsUHHjh3RtWtXWbQTNDMzw4ULF+Dh4QEzMzP1MJxz586hYcOGiImJ0XmmjIUS7927h8KFC2uciTAwMICzszMCAgJQpUoVnWcD0lcCnjt3ruRdZT5ECIF9+/ZprGpeq1YtqWOhcuXKmDhxIpo0aaKxfefOnRg3bpzWQZ6uNGnSBBUqVMCkSZNgZmaG8PBwODk5oWPHjkhLS8PGjRslyQWkF4YpKSla7T0jIiKQN29eODs7S5Jr1apVEEKgV69emDNnjsYCnBnvUV23ZFfCWjHve394nJTy58+PixcvSnpw9CH29vY4ePAgSpQoAU9PT0ybNg3NmzdHWFgYatSogfj4eJ3mUcIaO+XKlYOvry98fHw0/rZfvHgRjRs3lqRj26eW5MhMqnlTGzZswMSJEzF8+PAsu8lJ+dnRpEkTCCHw+++/a3WS09PTk6yTHACYmpri/Pnz0haEOmtToEMqlUqjg1BCQoJo2bKlMDMzk0UXkNjYWLFo0SJRu3ZtoaenJzw9PcWUKVPEnTt3JMvUuHFjMXbsWCFEekeX27dvi9TUVNGuXTvRpk0byXIJIUSdOnVEbGyspBk+JTo6WkRHR0sdQxGMjIzEtWvXtLZfu3ZNGBkZSZAo3eXLl4Wtra1o1KiRMDAwEG3bthUlSpQQdnZ2IjIyUrJcQghRq1YtsXLlSq3tISEhonbt2roP9J7MXe+klvnzP6PzU0ZnqMw3OfwtWLp0qShZsqQwMDAQBgYGomTJkmLJkiWSZurZs6dYunSppBk+pEWLFmLx4sVCCCGGDh0q3N3dxeTJk0X58uVF/fr1dZ7H2dlZ45YvXz6hUqnU3alUKpXIly+fcHFx0Xm2DMbGxupji8zd2qKiooShoaEkmerUqfNZt7p160qSTwjxwc8MOXx2yLWTnBDpP9t9+/ZJmiFXDkWbMGGCxrAlExMT/Pnnn5gwYQKOHDkiYbJ0lpaW6NevH/r164cHDx5g7dq1WL58OcaPH4+UlBRJMslt7YLM5DpOPiUlBf7+/pg3b576TKGpqSkGDhyICRMmaJ3h+drmzZuHfv36wcjI6JNnEqVcyK5EiRIIDAzE0qVL1cP4kpOTERgYqNXJUJdKlSqFW7duYf78+TAzM0N8fDxat26N/v37o2DBgpLlAtKH79WoUUNre9WqVTFgwAAJEmkyMzPD9evXUbp0aQDpzQ5WrFgBT09PTJw4Uadz4ZSwVgyQvt7DrFmzMHDgQI0hmb6+voiOjkZAQIAkuebPn4927drh6NGjWZ6plvKzY9asWerPWn9/f8THx2P9+vXw8PCQ5Mx+5t+vNWvW4LfffsOyZcvUZ6tv3ryJvn374n//+5/Os2Wwt7dHZGSk1lXdY8eOwdXVVZJMcv2bnpmcPzvk2kkOSF84/fvvv8fDhw9RqlQpaa50SVpW/cclJyeLP//8U7Rp00YYGRkJBwcHSfPIde2ClJQUsXTpUtGpUydRv359UbduXY2bVL7//ntha2srgoKCRFhYmAgLCxNBQUHC3t5efP/99zrP4+zsLF68eKH+94duUp49FEKI06dPC1tbW2FjYyPq168v6tevL2xsbIStra04ffq0pNnkKn/+/Oo1MjI7d+6cMDU1lSCRpooVK4qNGzcKIf45E9ypUyfh7u4uBg8eLG04mbK2thZr1qzR2r5mzRpRoEABCRKlW7p0qciTJ48wNTUVTk5Osvrs6N27tzh48KCkGT7E1dX1g+9RZ2dnCRKlmzp1qvD09BSnTp0SZmZm4ujRo2L16tXCxsZGzJs3T7Jc9OW6desmSpYsKU6dOiXS0tJEWlqaOHnypChVqpTo3r27pNlOnjwpXFxcJL3SlSvn2GS4du2aVq97lUqFZs2aSZgq/WzFmjVrsGnTJqSlpaF169bo0qUL6tWrJ4sx1nIzYMAArFy5Ek2bNkXBggW1XqPZs2dLksvc3Bzr1q1D48aNNbbv3LkTnTp1wsuXLyXJpQQJCQn4/fffcePGDQDpV3E6d+6s85aoSmhDDQDNmjWDsbEx1q5dq55rlpqaig4dOiAhIQG7du2SLBuQ/l64cOEC3NzcMH36dBw4cAB79uzB8ePH0bFjR9y/f1+SXIGBgbCzs0OvXr00ti9fvhzPnz/HyJEjJckFpE+aPnv2rNa8qVu3bqFy5cqIi4uTJJe9vT0GDRqEUaNGabTLlgO5zlEF0keGHD58GJUqVdLYfubMGdSpUweJiYmS5BJCYOrUqQgMDFRnMDQ0xLBhwzBp0iRJMilJVseRgLRtz+Pi4tC9e3ds27ZNfUUkJSUFzZs3x8qVKzXmOuqap6cnSpQogREjRmTZPMDJyenrh9BJ+aRjUVFRwsvLS2t8dcaKu1JycHAQRkZGomXLlmLDhg3i7du3kubJ7M2bN+L06dNi27ZtYuvWrRo3KRUoUEDs2LFD0gxZsbGx+eBcEWtrawkS/cPf318kJCRobU9MTBT+/v4SJJKn988mZV6V+/1tUrp69aooUKCAcHNzEz169BA9evQQbm5uwsbGRly+fFnSbEIIYWZmJm7duiWEEMLb21vMmTNHCCHEvXv3JJ035eTkJI4fP661/dSpU5KeRRdCiAEDBghfX1+t7UOHDhU//vijBInSWVpaSj6n7GPkOEdVCCG+++47Ua5cOXH+/Hn1tnPnzony5cuLZs2aSZgsXVJSkrh69ao4ffq0eP36tdRxZE/Ox5EZbt26Jf766y/x119/iYiICKnjCCHS5/9InSVXXrFp1qwZ9PX1sXTpUri4uODMmTOIiYnB0KFD8csvv6BmzZqSZVuyZAnatWsHCwsLyTJkRc5rFzg4OODQoUMoWrSoZBmyEhAQgBs3bmDFihXqdsBJSUno3bs3PDw8JFtsFZDvgomZyeFMWOZW5p9qQ92yZUud5crKo0ePMH/+fI0udwMGDJB0nZgM9erVg6OjI7y9vdG7d29cu3YN7u7uOHz4MLp37467d+9KksvIyAjXr19Xd1jMcPv2bXh6emqss6BrAwcORHBwMBwdHVG1alUA6QsTRkdHw8fHR2Nsui7nj/j6+sLGxgY//fSTzp7zS2WeoxoRESHZHFUAeP78Obp3747du3drrMfSqFEjrFixQnats+nj5HwceezYMVm1FM+sWbNm6NGjB9q0aSNZhlxZ2FhbW+PAgQPw8vKCubk5zpw5g2LFiuHAgQMYOnSoeh0SKUVGRiIqKgq1atWCsbHxZy1c+DV5eHigQYMGsly7YObMmbh9+zbmz58vq6F6rVq1QmhoKAwNDdXDIcLCwpCcnIz69etr7Lt582adZtPT08PTp0/Vk6gzHDhwAB06dMDz5891miez27dvo1WrVrh8+bJ60U7gn1a3UhVdcm1DrQTh4eHo0qULoqOj4efnpy7qBw4ciJiYGKxZs0aSXBknGLp27aqxPSQkBBMmTMDt27clyQUAdevW/az9VCoVDhw48JXT/GPQoEEIDg5GmTJl4OXlpTX5V6r2u+979+4dduzYgdWrV2PHjh2wsrLCw4cPpY6FiIgI9XosxYsXl+SEXOvWrbFy5Urkz58frVu3/ui+uv7bpBRyPo40MDBAoUKF0KlTJ3Tt2hWenp6SZXnf4sWLMXnyZPTq1SvL5iO6OHGZK7uipaamwszMDED6L+ejR49QrFgxODk54ebNm5Jmi4mJQfv27XHw4EGoVCpERETA1dUVvXv3hqWlJWbOnClJrqdPn8LPz092RQ2Qfnbi4MGD2LVrF0qWLKn1RpHqg9nCwkLrrISjo6MkWTLIfcFEABg8eDBcXFwQGhqa5ZkwqVy+fFnrzD6Qvp7StWvXJEikLTExMcurXFKvx+Ll5YXLly9rbf/5558lXQm7b9++GDJkCN69e4d69eoBAEJDQzFixAgMHTpUslyAfDtDXb58GeXKlQOQvvp6ZnI4sZTVHNXt27erf7665Ofnh0mTJiFfvnxZrs1y6NAh9b91WRCam5urf1ZSzrdQMjkfRz569Ajr1q3D2rVrMW3aNHh5eaFLly7o1KmT1iLrupZxfJFVV0ddjf7JlYVNqVKlEBYWBhcXF1SpUgUzZsyAgYEBFi9eLFl7wwy+vr7ImzcvoqOjNVrbdujQAX5+fpIVNm3btsWhQ4dkuSibhYUFWrVqJXUMLRmrwsvJnDlz1Asm+vv7y2LBxPedPHkSBw4cgLW1NfT09KCnp4dvvvkGgYGBGDRokGRnwuTahhpIH+bSs2fPDzYJkMPQwri4OGzcuBFRUVEYPnw4rKyscO3aNdjZ2aFQoUKSZBo+fDhiYmLw448/qotBIyMjjBw5EqNHj5Ykk9zJteACgEKFCiE2NhaNGjXC4sWL0axZM/UwYClcvHgR7969U//7Q3RdEGb8bRJCwN/fHzY2NjA2NtZpBqWT83GktbU1BgwYgAEDBuDOnTtYs2YNVq1ahdGjR6NWrVo6vcL7vrS0NMmeW0266T1fz+7du8WmTZuEEEJERESIYsWKCZVKJaytrUVoaKik2ezs7MSlS5eEENqLZUm5sFJCQoJo0qSJ6N69u/jll1/E3LlzNW6kHO/evRMrV66U7YKhFhYW4vbt20KI9BapBw4cEEIIERkZKYyNjSXLJec21J07dxY1atQQZ8+eFfny5RN79+4VISEholixYmL79u2SZhNCiLCwMGFtbS3c3d1Fnjx51J9rY8aMEd26dZM4nRCvX78WZ86cEZcvX5ZVwxY5Wr58uUhMTJQ6RpYWL14s/v77b6ljKEZqaqrImzevurEHfVxYWJhITU0VQqQfR27evFkIIb/jyPelpKSIbdu2ibJly8qmsYGUcuUcm6zExsaqh+lIyczMDBcuXICHhwfMzMwQFhYGV1dXnDt3Dg0bNkRMTIwkuZYtW4bvv/8eRkZGKFCggMbrpFKpJB2LnuH58+fqS8DFihXTmj+iC+XLl0doaCgsLS1Rrly5j/4+XbhwQYfJNJmYmOD69eu6aa2YTTVr1sTQoUPRsmVLdO7cGX///TfGjh2LxYsX4/z581rDX3RJLm2o31ewYEFs3boVlStXRv78+XHu3DkULVoUf/31F2bMmIFjx45Jms/b2xvly5fHjBkzND7XTpw4gc6dO0vWPCCD3OY0ypmdnR3evHmDdu3aoXfv3qhevbrUkehfKFmyJJYtW6ZuUEEflrnpjqurK86ePYsCBQqo75fLcWSG48eP4/fff8fGjRvx9u1btGjRAl26dEGjRo0kzRUaGorQ0FA8e/ZM6wrO8uXLv/rz58qhaFmRQ+cgIP2gLjg4WN0/XqVSIS0tDTNmzPjsyaRfw5gxY+Dv7y/LtQsSEhLUHYQy3iT6+vrw8fHBr7/+ChMTE51ladGihXrog9Rdsj6mcuXKuHjxoiwLm7FjxyIhIQFA+jjc7777DjVr1kSBAgWwfv16SbPly5cP/fr1kzRDVhISEtQd7iwtLfH8+XMULVoUpUuXlrSAznD27FksWrRIa3uhQoXw5MkTCRKlk+ucRjl7+PAhtm3bhpUrV6JOnTpwdXVFz5490b17d9jb20sdj7Jp2rRpGD58OBYuXIhSpUpJHUfWLCwscOfOHdja2uLu3btaB+VyOY4cPXo01q1bh0ePHuHbb7/F3Llz0aJFC50eC32Iv78/AgICULFixSzXHdSFXFnYtGrVKssXU6VSwcjICO7u7ujcuTOKFSum82w///wz6tWrh3PnziE5ORkjRozA1atXERsbi+PHj+s8T4bk5GR06NBBdkUNkD5B8/Dhw9i2bRtq1KgBIL2hwKBBgzB06FAsXLhQZ1kyuj2lpqaibt268PLykl3rbgD48ccfMXToUDx48AAVKlTQuuIg5WTzhg0bqv/t7u6OGzduyO5MmNwUK1YMN2/ehLOzM8qUKYNFixbB2dkZQUFBKFiwoNTxYGhoiFevXmltv3XrliRXVjPIdU6jnOXJkwetWrVCq1at8PTpU6xevRqrVq3CuHHj0KhRI/Tu3RvNmjWT5d8K0ubj44PExESUKVMGBgYGWnNtYmNjJUomP23atEHt2rXVB+QVK1b8YPMTKUexHDlyBMOHD0f79u1hbW0tWY6sBAUFYeXKlejWrZtkGXLlULQePXpgy5YtsLCwQIUKFQCkDwuKi4tDgwYNEBYWhrt37yI0NFR9oKwLGT3tAwMDsW/fPoSFhSE+Ph7ly5dH//79JT1AkfPaBdbW1ti4cSPq1Kmjsf3gwYNo3769ZK2LP7RGhhx87KBD6nWJMnB40OdbvXo1UlJS0KNHD5w/fx6NGjVCbGwsDAwMsHLlSnTo0EHSfH369EFMTAz++OMPWFlZITw8HPr6+mjZsiVq1aqFOXPmSJLL3t4ee/bsQZkyZTSGyN2+fRteXl6Ij4+XJJeSnD59GsuXL8eqVatQsGBB/P3337C0tMSKFSu0PpNJflatWvXR+7t3766jJMqwe/duREZGYtCgQQgICFB3Rnvf4MGDdZxMGQoUKIAzZ85I2ogqV16xsbe3R+fOnTF//nz1AV5aWhoGDx4MMzMzrFu3Dt9//z1Gjhyp07HpefPmRXh4OCwtLTFmzBidPe/nSE1NxYwZM7Bnzx7ZrV2QmJiYZRtqW1tbJCYmSpAoXalSpXD79m1ZFjZ37tyROsIHcXjQ53n16hXy588PABrrsFSoUAH37t3DjRs3UKRIEVmcsZs5cybatm0LW1tbvHnzBrVr18aTJ09QrVo1TJkyRbJcCQkJWQ7PiI2NlbSbltw9ffoUISEhWLFiBW7fvo2WLVti+/bt8Pb2RkJCAgICAtC9e3eNBW5Jnli4ZE/G/JTz58+rjxnlSg6LXL+vT58+WLNmDcaNGydZhlx5xcbGxgbHjx/XWhjr1q1bqF69Ol68eIHLly+jZs2aiIuL02k2X19fGBoaYtq0aTp93k/52PweXS8Q97769eujQIECCA4OhpGREQDgzZs36N69O2JjY7F//35Jcu3evRujR4/GpEmTshzulXFQKqWsPvhUKhWaNWsmWSYfHx88e/YMS5cuRYkSJdRn0ffs2QM/Pz9cvXpVsmxyknkia7169bB582ZZDnvM7Pjx4xpXor29vSXN06RJE1SoUAGTJk2CmZkZwsPD4eTkhI4dOyItLQ0bN26UNJ8cNWvWDHv27EHRokXRp08f+Pj4aM0tePbsGezt7eXR2pU+KSoqCitWrEBUVBTmzp0LW1tb7Nq1C0WKFEHJkiWljkfZJNdFroH0K1nBwcHw8vKS7CR5rrxik5KSghs3bmgVNjdu3FD/wI2MjCQZ9pKSkoLly5dj//79WR4MS3VlRM5rF8yZMweNGjVC4cKFUaZMGQBAWFgYDA0NsXfvXslyZaxQ37x5c43fpYwhVVJ+uMj5g2/v3r3Ys2eP1kJiHh4ekp8BzmotlgsXLkiyFoupqSliYmJga2uLQ4cOqdfLkAsrKyvcunUL1tbW6NWrF+bOnYsaNWrodHjvp8h1TqOc2dra4vDhwx9d78rGxkbWV4XpH4cPH0bjxo1Ro0YNHDlyBFOmTIGtrS3CwsKwbNkyFvcKJNdFrgEgPDwcZcuWBSDdAr+5srDp1q0bevfujZ9++gmVKlUCkN61Z+rUqfDx8QGQ/maX4kzFlStXUL58eQDpV5Ay4/yCrJUuXRoREREabXg7deqELl26SLromJyLwfc/+E6fPo3Y2FhZfPDJdXhQeHg4vL29YW5ujrt376Jv376wsrLC5s2bER0djeDgYJ3m8fb2Rt26ddWT3lu1aqVeOPR9UlxRTU5OxqtXr2BtbY1Vq1Zh+vTpshq28e7dOwwaNAjbtm3Dvn37YGZmhvj4eLRu3VryOY1ytmzZsk/uo1KpZNlxkbSNGjUKkydPhp+fn8b7s169epg/f76EyehLyXWRa0Aex0W5srCZPXs27OzsMGPGDDx9+hRAem9+X19fjBw5EgDQoEEDSXp9y+GHnpW3b9/i119/xcGDB7PsPS5lS9nAwEDY2dmhb9++GtuXL1+O58+fq3+mula7dm1JnvdzvP/Bp6+vL5sPPrm2PPfz80OPHj3Ua7FkaNKkCTp37qzzPBndqKKiotQnYuTQzjNDtWrV0LJlS1SoUAFCCAwaNOiDJxp0sXbB++Q8p1HuDh8+jF9++QXXr18HAHh6emL48OGoWbOmxMkouy5fvow1a9Zobbe1tcWLFy8kSET/VmpqqvpvlLW1NR49eoRixYrByclJvdbff1muLGz09fUxZswYjBkzRt2C9P35DkWKFJEimmz17t0be/fuRdu2bVG5cmVZXT1atGhRlh/MJUuWRMeOHSUrbFasWAFTU1O0a9dOY/uGDRuQmJgo6aRNOX/wyXV4kNzWYjE2Nsb3338PADh37hymT58uqzk2q1evxuzZsxEVFQWVSoWXL1/i7du3UsfS0LVrVyxbtkx2cxrlbPXq1ejZsydat26NQYMGAUifO1W/fn2sXLlSkiKfvpyFhQUeP36s1eTm4sWLOh9eSzmjVKlSCAsLg4uLC6pUqYIZM2bAwMAAixcvhqurq87ztG7dGitXrkT+/PnRunXrj+67efPmr54nVxY2mclhArcSbN++HTt37pTV+PgMT548yXLYiI2NDR4/fixBonSBgYFZHgjb2tqiX79+khY2cvvgyyDn4UFyXYsF0L7Sm5qaisuXL8PJyQmWlpaSZLKzs1MXDC4uLggJCdFYpVsO5DqnUc6mTJmCGTNmwNfXV71t0KBBmDVrFiZNmsTCRmEyTv5t2LBBfXX8+PHjGDZsmHpoPslfeHg4SpUqBT09PYwdO1bdEVYOi1ybm5urT4abm5vr/Pnflyu7ogHAxo0b8ccff2TZCk8OK3XLjaenJ9atWyfpwo0f4uHhgQkTJmi0vAWAkJAQTJgwQbKFsoyMjHDjxg04OztrbL979y5KlCiBN2/eSJILAPbs2YOEhAS0bt0akZGR+O6773Dr1i31B1+9evUky2ZjY4MTJ07Aw8NDsgxZketaLAAwZMgQlC5dGr1790Zqaipq1aqFkydPwsTEBNu3b+d6Ih8g526PcmVoaIirV6/C3d1dY3tkZCRKlSolu6ty9HHJycno378/Vq5cidTUVOTJkwepqano3LkzVq5c+cEFKEleMnfJdHV1xdmzZzVOJHGR63/kyis28+bNw5gxY9CjRw9s3boVPXv2RFRUFM6ePYv+/ftLHU+WZs6ciZEjRyIoKEh2k0L79u2LIUOG4N27d+oD8tDQUIwYMQJDhw6VLJetrS3Cw8O1CpuwsDDJz1w3bNhQ/W93d3fcuHFDNh98ch0eJNe1WID04Y0Zhf22bdtw9+5d3LhxAyEhIRgzZowkQ/jmzZuHfv36wcjICPPmzfvovhlDmnRNrnMa5czR0RGhoaFahc3+/fvh6OgoUSr6UgYGBliyZAnGjRuHK1euID4+HuXKlZPdiSX6OAsLC9y5cwe2tra4e/eu1jzo91uy/5flyis2xYsXx4QJE9CpUyeN1abHjx+P2NhYdgLJwvPnz9G+fXscOXIEJiYmWr3HY2NjJUqW3j551KhRmDdvnvrqm5GREUaOHInx48dLlmvkyJFYv349VqxYgVq1agFIn3Tbq1cvtG3bVvLuY3I1cOBABAcHw8PDQ5bDg44dO4bw8HDZrMUCpP++R0ZGonDhwujXrx9MTEwwZ84c3LlzB2XKlMlyCN3X5uLignPnzqFAgQIfXaRWpVJJdlWVsm/hwoUYMmQIevXqherVqwNIn2OzcuVKzJ07F//73/8kTkhf6v22/6Qc/fr1Q3BwMAoWLIjo6GgULlz4g1fbpP68lXrEVK4sbExMTHD9+nU4OTnB1tYW+/btQ5kyZRAREYGqVasiJiZG6oiy4+3tjejoaPTu3Rt2dnZaH3xyWL04Pj4e169fh7GxMTw8PCRfOTw5ORndunXDhg0bkCdP+sXPtLQ0+Pj4ICgo6IOtef/rODwo+5ycnLBkyRLUr18fLi4uWLhwIZo2bYqrV6/im2++wd9//y11RMpF/vzzT8ycOVPdFa1EiRIYPnw4WrRoIXEy+hLLli3D7NmzERERASB9ePeQIUPQp08fiZNRduzevRuRkZEYNGgQAgICPthef/DgwTpO9o/MI6YWL16sNWJKF6MfcuVQNHt7e8TGxsLJyQlFihTBqVOnUKZMGdy5cwe5sI7LESdOnMDJkyfVC2DKkampqXpdIjkwMDDA+vXrMXnyZFy6dAnGxsYoXbq07IbyyY2chwedPXv2gy3PpbyS1LNnT7Rv3x4FCxaESqVSX0U6ffo0ihcvLkkmPz+/z9pPpVJh5syZXzkN5aRWrVqhVatWUsegHDB+/HjMmjULAwcOVC+6evLkSfj6+iI6OhoBAQESJ6TPlbFEyfnz5zF48GBZrRuW4bfffsPixYvRqVMnrFy5EiNGjNAYMaULubKwqVevHv766y+UK1cOPXv2hK+vLzZu3Ihz5859shXdf1Xx4sUlneyuZB4eHvDw8FB3qsqfP79knaroy02dOhVjx45FsWLFtK5aSj10Y+LEiShVqhTu37+Pdu3aqa9W6uvrY9SoUZJk+ty1kKR+7Yj+yxYuXIglS5agU6dO6m3NmzeHl5cXBg4cyMJGgVasWCF1hA+Kjo5WD2E1NjbG69evAQDdunVD1apVdTIVJFcORUtLS0NaWpp6eND69etx/PhxeHh44Pvvv9eaP0LA3r174e/vjylTpqB06dJarxHbZmt7v1NV7dq1ceLECXaqUig7OztMnz4dPXr0kDoKkU5ZWVnh1q1bsLa2/mSDEVNTU5QsWRLTp0+XZRdN0mRhYYGzZ89qNQu4desWKleujLi4OGmCUa7k6uqKTZs2oVy5cqhYsSL69u2L//3vf9i7dy86duyok6s2ubKwAYC3b98iPDxca0iJSqVCs2bNJEwmT3p6egC0z64KIaBSqZCamipFLFkrXLgwtmzZgooVK2LLli348ccfcejQIYSEhODAgQOSLjZJ2VewYEEcOXJENt2ClNB1jHKHVatWoWPHjjA0NMSqVas+um9SUhJ27tyJ+/fv4/z58zpKSF9q4MCByJs3r9ZQ2mHDhuHNmzdYsGCBRMkoN+rTpw8cHR0xYcIELFiwAMOHD0eNGjXUI6aWLVv21TPkysJm9+7d6NatW5ZNAniQnrXDhw9/9P7atWvrKIlyyLFTFX25GTNm4NGjR5KuV5MZu46RXN2/fx8VKlTAs2fPpI5Cn5DRhdLR0RFVq1YFkD43Lzo6Gj4+PhqjM6TuSEnK9/6IqXXr1qnXrfvf//6nk6ZKubKw8fDwQIMGDTB+/HjY2dlJHYdyKXaqyl3S0tLQtGlT3Lp1C56enlrDMTdv3ixRMiLdS05OzrKJRpEiRSRKRF/iY10oM2NHSsoJ0dHRcHR0zHL0z/3793Xy+ZErmwc8ffoUfn5+LGqyKS4uDsuWLVO3+CxZsiR69eoFc3NziZPJkxw7VdGXGzRoEA4ePIi6deuiQIECspr0HhAQgGHDhsHExERj+5s3b/Dzzz9Lup4T5S63bt1C7969ceLECY3tHJasTHLuQkm5j4uLCx4/fgxbW1uN7bGxsXBxcdHJ50euvGLTq1cv1KhRA71795Y6imKcO3cODRs2hLGxMSpXrgwgvfXtmzdvsHfvXpQvX17ihPK0ceNGdaeqwoULA0gfr25hYcE1HxTGzMwM69atQ9OmTaWOokVfXz/LPxYxMTGwtbXlwSblmBo1aiBPnjwYNWqU+qRNZnJeEoC0PX/+HDY2Nlned/nyZZQuXVrHiSg309PTw9OnT7V+5+7duwdPT08kJCR89Qy5srBJTExEu3btYGNjk2WHL0601VazZk24u7tjyZIl6rGRKSkp6NOnD27fvo0jR45InJDo63JycsKePXtkebXtQ38sDhw4gA4dOuD58+cSJaPcJl++fDh//rws3weUffb29li2bJnWCZtffvkF48aN4zIPlCMy1jWbO3cu+vbtqzG6IDU1FadPn4a+vr5OmirlyqFoa9euxd69e2FkZIRDhw5prUfBwkbbuXPnNIoaAMiTJw9GjBiBihUrSphM3kJDQzF79myNFbqHDBmiHpZGyjFx4kRMmDABK1as0BryJZWM1rsqlQpFixbV+CxLTU1FfHw8vv/+ewkTUm7j6emJFy9eSB2Dcoifnx/atGmDnj17YtasWYiNjYWPjw8uX76MNWvWSB2PcomMdc2EELh8+bJGkwADAwOUKVMGw4YN00mWXHnFxt7eHoMGDcKoUaPUbYzp4+zs7BASEoIGDRpobN+zZw98fHzw9OlTiZLJ12+//YbBgwejbdu26hWdT506hY0bN2L27Nno37+/xAkpO8qVK4eoqCgIIeDs7Kx1pffChQs6z7Rq1SoIIdCrVy/MmTNHY76bgYEBnJ2d1b97RDnhwIEDGDt2LKZOnco1zXKJixcvolu3bkhKSkJsbCyqVKmC5cuXw97eXupolMv07NkT8+bNg5mZmWQZcmVhY2VlhbNnz8LNzU3qKIoxaNAg/Pnnn/jll1/Uq8YeP34cw4cPR5s2bWTTAldOChcujFGjRmHAgAEa2xcsWICpU6fi4cOHEiWjL+Hv7//R+ydMmKCjJNoOHz6M6tWrc3Fh+uoynwzMfIWQzQOU6/Xr1+jbty82bdoEAFi6dCm6d+8ucSrKbd69ewdjY2NcunQJpUqVkixHrixsfH19YWNjg59++knqKIqRnJyM4cOHIygoCCkpKQCAvHnz4ocffsC0adNgaGgocUL5MTU1xaVLl+Du7q6xPSIiAuXKlUN8fLxEySg3e/v2LZKTkzW28Sw65RSuaZa7HD9+HF27doWVlRVWr16N48ePw8/PD40bN0ZQUBAsLS2ljki5iKurK/78809Jm4zkysJm0KBBCA4ORpkyZeDl5aV1lpOLUH1YYmIioqKiAABubm6ymWsgR507d0a5cuUwfPhwje2//PILzp07h3Xr1kmUjP6N8+fPa7Q8L1eunMSJ0t+XI0aMwB9//JHlwsM8i0456ejRo1i0aBGioqKwceNGFCpUCCEhIXBxccE333wjdTzKBkNDQ/j6+mLSpEnqY6GoqCh07doV9+/fx4MHDyROSLnJsmXLsHnzZoSEhMDKykqSDLmyecDly5fVByNXrlzRuE9Oa1PIycuXL5GamgorKyuN9o+xsbHIkycPzwj/v3nz5qn/7enpiSlTpuDQoUMac2yOHz+OoUOHShWRvtCzZ8/QsWNHHDp0CBYWFgDS13aqW7cu1q1b98GWqbowfPhwHDx4EAsXLkS3bt2wYMECPHz4EIsWLcK0adMky0W5z6ZNm9CtWzd06dIFFy9eRFJSEoD0vxFTp07Fzp07JU5I2bF3716tq2xubm44fvw4pkyZIlEqyq3mz5+PyMhIODg4wMnJCfny5dO4XxdzVXPlFRvKvsaNG6NZs2b48ccfNbYHBQXhr7/+4h+z/+fi4vJZ+6lUKty+ffsrp6Gc1KFDB9y+fRvBwcEoUaIEAODatWvo3r073N3dsXbtWsmyFSlSBMHBwahTpw7y58+PCxcuwN3dHSEhIVi7di3fn5RjypUrB19fX/j4+MDMzAxhYWFwdXXFxYsX0bhxYzx58kTqiPQFIiMjERUVhVq1asHY2Fg9Z4ooJ8lhrioLGwKQ3nDh+PHj6gO6DDdu3ECNGjWyHP5ClJuYm5tj//79qFSpksb2M2fOoEGDBoiLi5MmGNLnc127dg1FihRB4cKFsXnzZlSuXBl37txB6dKlOZ+LcoyJiQmuXbsGZ2dnjcLm9u3b8PT0xNu3b6WOSNkQExOD9u3b4+DBg1CpVIiIiICrqyt69eoFKysr/PLLL1JHJMpR7IVMAICkpCR104DM3r17xwW86D8hLS0ty65jefPmRVpamgSJ/uHq6oo7d+4AAIoXL44//vgDALBt2zb1sDminGBvb4/IyEit7ceOHYOrq6sEiejf8PX1Rd68eREdHa0xZ7ZDhw7YtWuXhMkot4qLi8PSpUsxevRoxMbGAkgfgqarTrG5co4NZV/lypWxePFi/Prrrxrbg4KCUKFCBYlSyVuvXr0+ev/y5ct1lIRyQr169TB48GCsXbsWDg4OAICHDx/C19cX9evXlzRbz549ERYWhtq1a2PUqFFo1qwZ5s+fj3fv3rEZCuWovn37YvDgwVi+fDlUKhUePXqEkydPYtiwYRg3bpzU8Sib9u7diz179qBw4cIa2z08PHDv3j2JUlFuFR4eDm9vb5ibm+Pu3bvo27cvrKyssHnzZkRHRyM4OPirZ2BhQwCAyZMnw9vbG2FhYeqDuNDQUJw9exZ79+6VOJ08/f333xpfv3v3DleuXEFcXBzq1asnUSr6UvPnz0fz5s3h7OwMR0dHAMD9+/dRqlQprF69WtJsvr6+6n97e3vjxo0bOH/+PNzd3eHl5SVhMsptRo0ahbS0NNSvXx+JiYmoVasWDA0NMWzYMAwcOFDqeJRNCQkJWXY3jY2N5TIOlOP8/PzQo0cPzJgxQ2ORziZNmqBz5846ycA5NqR26dIl/Pzzz7h06RKMjY3h5eWF0aNHw8PDQ+poipGWloYffvgBbm5uGDFihNRxKJuEENi/fz9u3LgBAChRogS8vb0lTpW1uLg4DkOjryY5ORmRkZGIj4+Hp6cnTE1NpY5EX6BJkyaoUKECJk2aBDMzM4SHh8PJyQkdO3ZEWloaNm7cKHVEykXMzc1x4cIFuLm5aczRu3fvHooVK6aTOXosbIhy2M2bN1GnTh08fvxY6iiUS0yfPh3Ozs7o0KEDAKB9+/bYtGkT7O3tsXPnTkkXQyMi+bpy5Qrq16+P8uXL48CBA2jevDmuXr2K2NhYHD9+HG5ublJHpFzE1tYWe/bsQbly5TQKm3379qFXr164f//+V8/AoWikpWnTpli6dCkKFiwodRRFioqKyrIRA8lfaGgoQkND8ezZM62GAVLOmQoKCsLvv/8OANi3bx/27duHXbt24Y8//sDw4cM5XJSIslSqVCncunUL8+fPh5mZGeLj49G6dWv079+ff+MpxzVv3hwBAQHqBjcqlQrR0dEYOXIk2rRpo5MMvGJDWjJX2fRhfn5+Gl8LIfD48WPs2LED3bt3x/z58yVKRl/C398fAQEBqFixIgoWLKi1xsOff/4pUTLA2NgYt27dgqOjIwYPHoy3b99i0aJFuHXrFqpUqaI134uIiEjXXr58ibZt2+LcuXN4/fo1HBwc8OTJE1SrVg07d+7UWrDza+AVG6IvdPHiRY2v9fT0YGNjg5kzZ36yYxrJT1BQEFauXIlu3bpJHUWLpaUl7t+/D0dHR+zevRuTJ08GkF5Mp6amSpyOiIgofY7Nvn37cPz4cYSFhSE+Ph7ly5fX6VxVFjakxcnJKcv1PEjTjh07IIRQn4G4e/cutmzZAicnJ+TJw7eW0iQnJ6N69epSx8hS69at0blzZ3h4eCAmJgaNGzcGkF5cu7u7S5yOiIgICA4ORocOHVCjRg3UqFFDvT05ORnr1q2Dj4/PV8/ABTpJ7ejRo+jatSvMzMygp5f+qxESEoJjx45JnEyeWrZsiZCQEADpHaqqVq2KmTNnomXLlli4cKHE6Si7+vTpgzVr1kgdI0uzZ8/GgAED4OnpiX379qk7VD1+/Bg//vijxOmIiIjS11x7+fKl1vbXr1+jZ8+eOsnA08oEANi0aRO6deuGLl264OLFi0hKSgKQPl5y6tSp2Llzp8QJ5efChQuYPXs2AGDjxo2ws7PDxYsXsWnTJowfPx4//PCDxAnpUzLPk0pLS8PixYuxf/9+eHl5aV21lHIhzLx582LYsGFa2zOvb0NElJkQAvfv34etrS2MjIykjkP/AUIIrfmpAPDgwQOYm5vrJAMLGwKQvkBnUFAQfHx8sG7dOvX2GjVqqMfzk6bExET1AlR79+5F69atoaenh6pVq3JFZ4V4f55U2bJlAaS3SM0sqw9qIiI5E0LA3d0dV69e5Xp09FWVK1cOKpUKKpUK9evX1xiOn5qaijt37qBRo0Y6ycLChgCkr71Sq1Ytre3m5uaIi4vTfSAFcHd3x5YtW9CqVSvs2bNHffb82bNnyJ8/v8Tp6HMcPHhQ6ghERF+Fnp6eel4eCxv6mlq2bAkgfaH3hg0baizoa2BgAGdnZ521e2ZhQwAAe3t7REZGwtnZWWP7sWPH2Pb5A8aPH4/OnTvD19cX9evXR7Vq1QCkX70pV66cxOmIiOi/btq0aRg+fDgWLlyIUqVKSR2HcqkJEyYAgHohaSmHPnIdGwIABAYGYvXq1Vi+fDm+/fZb7Ny5E/fu3YOvry/GjRuHgQMHSh1Rlp48eYLHjx+jTJky6oYLZ86cQf78+VG8eHGJ01FukJqaiuPHj8PLywsWFhZSxyEiBbG0tERiYiJSUlJgYGAAY2NjjftjY2MlSka5WXJycpYLXRcpUuSrPzcLGwKQPhZ36tSpCAwMRGJiIgDA0NAQw4YNw6RJkyROR/TfZmRkhOvXr8PFxUXqKESkIKtWrfro/d27d9dREvoviIiIQK9evXDixAmN7RlNBXSx7hoLG9KQnJyMyMhIxMfHw9PTU2OcJBFJo2LFipg+fTrq168vdRQiIqIs1ahRA3ny5MGoUaNQsGBBrcY7ZcqU+eoZWNgQEcnc7t27MXr0aEyaNAkVKlRQLwqbgc0qiOhDoqKisGLFCkRFRWHu3LmwtbXFrl27UKRIEZQsWVLqeJSL5MuXD+fPn5d0KD4X6CQikrkmTZogLCwMzZs3R+HChWFpaQlLS0tYWFjA0tJS6nhEJFOHDx9G6dKlcfr0aWzevBnx8fEAgLCwMPWEb6Kc4unpiRcvXkiagVdsiIhk7vDhwx+9v3bt2jpKQkRKUq1aNbRr1w5+fn4wMzNDWFgYXF1dcebMGbRu3RoPHjyQOiLlIgcOHMDYsWMxdepUlC5dWmuha12MLmBhQ0RERJQLmZqa4vLly3BxcdEobO7evYvixYvj7du3UkekXCSjOyygubC1LpsHcB0bIiIFOHr0KBYtWoTbt29jw4YNKFSoEEJCQuDi4oJvvvlG6nhEJEMWFhZ4/PixVkfFixcvolChQhKlotxKDotec44NEZHMbdq0CQ0bNoSxsTEuXLiApKQkAMDLly8xdepUidMRkVx17NgRI0eOxJMnT6BSqZCWlobjx49j2LBh8PHxkToe5TK1a9eGnp4elixZglGjRsHd3R21a9dGdHQ09PX1dZKBhQ0RkcxNnjwZQUFBWLJkicaY5Ro1auDChQsSJiMiOZs6dSqKFy8OR0dH9TIOtWrVQvXq1TF27Fip41Euk/kk3MWLFyU5Ccc5NkREMmdiYoJr167B2dlZY5z87du34enpyXHyRPRR9+/fx+XLlxEfH49y5crBw8ND6kiUC5UrVw6+vr7w8fHR+Fv1f+3de1DVdf4/8Oc53A6goigqIoGIyiVBjGVLvC2YSi2rTlmjhKhII+MNFV2anVwvo6irRVhhul5T002zLRGzDNDITZSjchNDEV3DdUwUEQU8vL5/9OPz43TUYDM/H9znY8aZzvvzPp/Pk7fNyOu8L8doNCIiIgJXrlz5zTNwjw0RkcZ17doVpaWl8PT0NGv/5ptv4OXlpU4oImo13N3d4e7uDpPJhPz8fFRWVvKoeHrkSkpKMHjwYIt2Jycn3Lhx47Fk4FI0IiKNi4uLw6xZs/Ddd99Bp9Phhx9+wPbt25GYmIj4+Hi14xGRRiUkJGDDhg0AAJPJhCFDhqB///5wd3dHVlaWuuHoidP4IdzPPc4P4ThjQ0SkcUlJSWhoaEB4eDhqamowePBg2NnZITExETNmzFA7HhFp1O7du/Haa68BAD7//HOcP38eZ86cwYcffoi//OUvyMnJUTkhPUkaP4TbuHGj8iHc0aNHkZiYiDfffPOxZOAeGyKiVqKurg6lpaXKJuA2bdqoHYmINMxgMKC0tBTdu3fH66+/DgcHB6SkpKCsrAyBgYGoqqpSOyI9QUQEy5YtQ3JyMmpqagBA+RBuyZIljyUDCxsiIiKiJ5CHhwfWr1+P8PBw9OjRA2lpaXjxxRdRWFiIgQMHorKyUu2I9ARS80M4LkUjItK4u3fvYs2aNcjMzMTVq1fR0NBgdp1HPhPR/UyaNAmvvPIKXF1dodPpMGzYMADAd999Bx8fH5XT0ZPK1tYWfn5+qjybhQ0RkcbFxsbi4MGDePnllxESEgKdTqd2JCJqBRYuXIinn34aly5dwtixY2FnZwcAsLKyQlJSksrpiB49LkUjItI4Jycn7N+/H6GhoWpHISIi0izO2BARaZybmxvatm2rdgwiamUWL1780OsLFix4TEmIHg/O2BARaVxGRgZSU1Oxdu1aeHh4qB2HiFqJoKAgs9f19fUoKyuDtbU1evbsyf159MThjA0RkcYFBwfj7t278PLygoODA2xsbMyuX79+XaVkRKRlRqPRoq2qqgoTJ07EmDFjVEhE9NvijA0RkcYNGzYMFy9eRGxsLLp06WJxeEBMTIxKyYioNcrPz0dkZCQuXLigdhSiR4ozNkREGvftt9/i6NGjCAwMVDsKET0Bbt68iZs3b6odg+iRY2FDRKRxPj4+uHPnjtoxiKiVSU1NNXstIqioqMCHH36IiIgIlVIR/Xa4FI2ISOMOHjyIRYsWYenSpejbt6/FHpt27dqplIyItKxHjx5mr/V6PVxcXBAWFoY33niDpy3SE4eFDRGRxun1egCw2FsjItDpdDCZTGrEIiIi0hQuRSMi0rjMzEy1IxAREWkeZ2yIiIiIiKjV44wNEVErcOPGDWzYsAHFxcUAAH9/f0yePBlOTk4qJyMiItIGztgQEWnc8ePHMWLECNjb2yMkJAQAkJubizt37uDgwYPo37+/ygmJiIjUx8KGiEjjBg0aBG9vb6xfvx7W1j9NtN+7dw9TpkzB+fPncfjwYZUTEhERqY+FDRGRxtnb28NoNMLHx8esvaioCMHBwaipqVEpGRERkXbo1Q5AREQP165dO1y8eNGi/dKlS/weCiIiov+HhQ0Rkca9+uqriI2Nxa5du3Dp0iVcunQJO3fuxJQpUzBu3Di14xEREWkCT0UjItK4VatWQafTYcKECbh37x4AwMbGBvHx8Vi+fLnK6YiIiLSBe2yIiFqJmpoanDt3DgDQs2dPODg4qJyIiIhIO7gUjYhI4yZPnoxbt27BwcEBffv2Rd++feHg4IDbt29j8uTJascjIiLSBM7YEBFpnJWVFSoqKtC5c2ez9mvXrqFr167K8jQiIqL/ZdxjQ0SkUVVVVRARiAhu3boFg8GgXDOZTNi/f79FsUNERPS/ioUNEZFGtW/fHjqdDjqdDr1797a4rtPpsGjRIhWSERERaQ+XohERaVR2djZEBGFhYdizZw+cnZ2Va7a2tvDw8EC3bt1UTEhERKQdLGyIiDSuvLwcTz31FHQ6ndpRiIiINIunohERaVxxcTFycnKU1++99x769euH8ePHo7KyUsVkRERE2sHChohI4+bNm4eqqioAQH5+PubMmYMXXngBZWVlmDNnjsrpiIiItIGHBxARaVxZWRn8/PwAAHv27EFkZCSWLVuGvLw8vPDCCyqnIyIi0gbO2BARaZytrS1qamoAAF999RWGDx8OAHB2dlZmcoiIiP7XccaGiEjjBg4ciDlz5iA0NBTHjh3Drl27AABnz55F9+7dVU5HRESkDZyxISLSuHfffRfW1tbYvXs30tLS4ObmBgDIyMjAyJEjVU5HRESkDTzumYiIiIiIWj0uRSMi0riLFy8+9PpTTz31mJIQERFpF2dsiIg0Tq/XP/TLOU0m02NMQ0REpE2csSEi0jij0Wj2ur6+HkajEW+99RaWLl2qUioiIiJt4YwNEVErlZ6ejr/97W/IyspSOwoREZHqeCoaEVEr1adPH+Tm5qodg4iISBO4FI2ISON+/iWcIoKKigosXLgQvXr1UikVERGRtrCwISLSuPbt21scHiAicHd3x86dO1VKRUREpC3cY0NEpHFZWVlmhY1er4eLiwu8vb1hbc3Pp4iIiAAWNkRERERE9ATg4QFERBqXnJyMjRs3WrRv3LgRK1asUCERERGR9rCwISLSuA8++AA+Pj4W7f7+/li7dq0KiYiIiLSHhQ0RkcZduXIFrq6uFu0uLi6oqKhQIREREZH2sLAhItI4d3d35OTkWLTn5OSgW7duKiQiIiLSHh6nQ0SkcXFxcUhISEB9fT3CwsIAAIcOHcL8+fMxd+5cldMRERFpA09FIyLSOBFBUlISUlNTUVdXBwAwGAz485//jAULFqicjoiISBtY2BARtRLV1dUoLi6Gvb09evXqBTs7O7UjERERaQYLGyIiIiIiavV4eAAREREREbV6LGyIiIiIiKjVY2FDREREREStHgsbIiIiIiJq9VjYEBFpiKenJ1JSUtSO8chduHABOp0OJ0+eVDvKr6LT6fDpp5+qHQMAMHHiRIwePbrZ/bOysqDT6XDjxo3fLBMRkZr4BZ1ERL+RzZs3IyEhgb9IPkEqKirQoUMHtWMAAN555x3wYFMiov+PhQ0RET0ydXV1sLW1VTuGGRGByWSCtfWv/yeva9eujyDRo+Hk5KR2BCIiTeFSNCKiB7h16xaioqLg6OgIV1dXvP322xg6dCgSEhIAALW1tUhMTISbmxscHR3x+9//HllZWQB+WvYzadIk3Lx5EzqdDjqdDgsXLmxxhr///e9o3749Dh06BAAoKChAREQE2rRpgy5duiA6OhrXrl0DAGzduhUdO3ZEbW2t2T1Gjx6N6Oho3Lx5E1ZWVjh+/DgAoKGhAc7Oznj22WeVvtu2bYO7u7vyOj8/H2FhYbC3t0fHjh3x+uuvo7q6WrneuBxq6dKl6NatG/r06QMAOHbsGIKCgmAwGBAcHAyj0WiWqbKyElFRUXBxcVG+cHTTpk2/OB6NS9p27tyJAQMGwGAw4Omnn0Z2drbSp3HJVUZGBp555hnY2dnhm2++QUNDA5KTk9GjRw/Y29sjMDAQu3fvVsaie/fuSEtLM3ue0WiEXq9HeXk5AMulaL80Pk3/f2n69zFx4kTl9fvvv49evXrBYDCgS5cuePnll39xHADLpWi1tbWYOXMmOnfuDIPBgIEDByI3N9fifTk5OQgICIDBYMCzzz6LgoIC5Vp5eTkiIyPRoUMHODo6wt/fH/v3729WHiIitbGwISJ6gDlz5iAnJwefffYZvvzySxw5cgR5eXnK9enTp+Po0aPYuXMnTp8+jbFjx2LkyJH4/vvvMWDAAKSkpKBdu3aoqKhARUUFEhMTW/T8lStXIikpCQcPHkR4eDhu3LiBsLAwBAUF4fjx4zhw4AD+85//4JVXXgEAjB07FiaTCZ999plyj6tXryI9PR2TJ0+Gk5MT+vXrpxRf+fn50Ol0MBqNyi/j2dnZGDJkCADg9u3bGDFiBDp06IDc3Fx8/PHH+OqrrzB9+nSznIcOHUJJSQm+/PJL7Nu3D9XV1fjjH/8IPz8/nDhxAgsXLrT42d98800UFRUhIyMDxcXFSEtLQ6dOnZo9NvPmzcPcuXNhNBrx3HPPITIyEj/++KNZn6SkJCxfvhzFxcUICAhAcnIytm7dirVr16KwsBCzZ8/Ga6+9huzsbOj1eowbNw47duwwu8f27dsRGhoKDw8PiwzNHZ+HOX78OGbOnInFixejpKQEBw4cwODBg5v9/qbmz5+PPXv2YMuWLcjLy4O3tzdGjBiB69evm/WbN28eVq9ejdzcXLi4uCAyMhL19fUAgGnTpqG2thaHDx9Gfn4+VqxYgTZt2vxXeYiIHjshIiILVVVVYmNjIx9//LHSduPGDXFwcJBZs2ZJeXm5WFlZyeXLl83eFx4eLm+88YaIiGzatEmcnJxa9FwPDw95++23Zf78+eLq6ioFBQXKtSVLlsjw4cPN+l+6dEkASElJiYiIxMfHS0REhHJ99erV4uXlJQ0NDSIiMmfOHHnxxRdFRCQlJUVeffVVCQwMlIyMDBER8fb2lnXr1omIyLp166RDhw5SXV2t3C89PV30er1cuXJFRERiYmKkS5cuUltbq/T54IMPpGPHjnLnzh2lLS0tTQCI0WgUEZHIyEiZNGlSi8ZGRKSsrEwAyPLly5W2+vp66d69u6xYsUJERDIzMwWAfPrpp0qfu3fvioODg3z77bdm94uNjZVx48aJiIjRaBSdTifl5eUiImIymcTNzU3S0tKU/gBk7969zR6fIUOGyKxZs8yeOWrUKImJiRERkT179ki7du2kqqqqxWMRExMjo0aNEhGR6upqsbGxke3btyvX6+rqpFu3brJy5Uqzcdm5c6fS58cffxR7e3vZtWuXiIj07dtXFi5c2OIsRERawD02RET3cf78edTX1yMkJERpc3JyUpZa5efnw2QyoXfv3mbvq62tRceOHX/Vs1evXo3bt2/j+PHj8PLyUtpPnTqFzMzM+36Cfu7cOfTu3RtxcXH43e9+h8uXL8PNzQ2bN2/GxIkTodPpAABDhgzBhg0bYDKZkJ2djeHDh6Nr167IyspCQEAASktLMXToUABAcXExAgMD4ejoqDwnNDQUDQ0NKCkpQZcuXQAAffv2NdtX0zhDYjAYlLbnnnvOLG98fDxeeukl5OXlYfjw4Rg9ejQGDBjQ7DFqej9ra2sEBwejuLjYrE9wcLDy36WlpaipqcHzzz9v1qeurg5BQUEAgH79+sHX1xc7duxAUlISsrOzcfXqVYwdO/a+GZo7Pg/z/PPPw8PDA15eXhg5ciRGjhyJMWPGwMHB4ZcHoYlz586hvr4eoaGhSpuNjQ1CQkIsxqXp2Dk7O6NPnz5Kn5kzZyI+Ph4HDx7EsGHD8NJLLyEgIKBFWYiI1MKlaERE/4Xq6mpYWVnhxIkTOHnypPKnuLgY77zzzq+696BBg2AymfCPf/zD4pmRkZFmzzt58iS+//57ZflSUFAQAgMDsXXrVpw4cQKFhYVm+zkGDx6MW7duIS8vD4cPH8bQoUMxdOhQZGVlITs7G926dUOvXr1alLfpL/bNFRERgfLycsyePRs//PADwsPDW7xUryW5Gpfapaenm41dUVGRss8GAKKiopTlaDt27MDIkSN/VaGq1+stTi5rXPYFAG3btkVeXh4++ugjuLq6YsGCBQgMDFTtJL0pU6bg/PnziI6ORn5+PoKDg7FmzRpVshARtRQLGyKi+/Dy8oKNjY3Z5uubN2/i7NmzAH4qIEwmE65evQpvb2+zP40nZ9na2sJkMrX42SEhIcjIyMCyZcuwatUqpb1///4oLCyEp6enxTOb/hI/ZcoUbN68GZs2bcKwYcPMDgNo3749AgIC8O6778LGxgY+Pj4YPHgwjEYj9u3bp+yvAQBfX1+cOnUKt2/fVtpycnKg1+uVmav78fX1xenTp3H37l2l7V//+pdFPxcXF8TExGDbtm1ISUnBunXrmj1GTe937949nDhxAr6+vg/s7+fnBzs7O1y8eNFi7JqOz/jx41FQUIATJ05g9+7diIqKeujP+Uvj4+LigoqKCuW6yWQy26wP/DTjNGzYMKxcuRKnT5/GhQsX8PXXXzd7LACgZ8+esLW1RU5OjtJWX1+P3Nxc+Pn5mfVtOnaVlZU4e/as2di5u7tj6tSp+OSTTzB37lysX7++RVmIiNTCwoaI6D7atm2LmJgYzJs3D5mZmSgsLERsbCz0ej10Oh169+6NqKgoTJgwAZ988gnKyspw7NgxJCcnIz09HcBPX7ZZXV2NQ4cO4dq1a6ipqWn28wcMGID9+/dj0aJFyhd2Tps2DdevX8e4ceOQm5uLc+fO4YsvvsCkSZPMCqjx48fj3//+N9avX4/Jkydb3Hvo0KHYvn27UsQ4OzvD19cXu3btMitsoqKiYDAYEBMTg4KCAmRmZmLGjBmIjo5+6DKr8ePHQ6fTIS4uDkVFRdi/f79ZgQYACxYswD//+U+UlpaisLAQ+/bte2hh8nPvvfce9u7dizNnzmDatGmorKy878/aqG3btkhMTMTs2bOxZcsWnDt3Dnl5eVizZg22bNmi9PP09MSAAQMQGxsLk8mEP/3pTw+8Z3PGJywsDOnp6UhPT8eZM2cQHx9vNhuzb98+pKam4uTJkygvL8fWrVvR0NDw0MLxfhwdHREfH4958+bhwIEDKCoqQlxcHGpqahAbG2vWd/HixTh06BAKCgowceJEdOrUSTldLSEhAV988QXKysqQl5eHzMzMFv29EBGpSu1NPkREWlVVVSXjx48XBwcH6dq1q7z11lsSEhIiSUlJIvLT5uwFCxaIp6en2NjYiKurq4wZM0ZOnz6t3GPq1KnSsWNHASB//etff/GZjYcHNMrOzhZHR0dJTU0VEZGzZ8/KmDFjpH379mJvby8+Pj6SkJCgHA7QKDo6WpydneXu3bsWz9i7d68AMNsUP2vWLAEgZ86cMet7+vRp+cMf/iAGg0GcnZ0lLi5Obt26pVxvuoG9qaNHj0pgYKDY2tpKv379ZM+ePWaHByxZskR8fX3F3t5enJ2dZdSoUXL+/PlfHJ/GwwN27NghISEhYmtrK35+fvL1118rfRo3yVdWVpq9t6GhQVJSUqRPnz5iY2MjLi4uMmLECMnOzjbr9/777wsAmTBhgsXz0eTwgOaMT11dncTHx4uzs7N07txZkpOTzQ4POHLkiAwZMkQ6dOgg9vb2EhAQoGzk/yU/H/s7d+7IjBkzpFOnTmJnZyehoaFy7Ngxi3H5/PPPxd/fX2xtbSUkJEROnTql9Jk+fbr07NlT7OzsxMXFRaKjo+XatWvNykNEpDadCL+2mIioOW7fvg03NzesXr3a4lNwrQkPD4e/vz9SU1PVjvJIXbhwAT169IDRaES/fv3UjqOqcePGwcrKCtu2bVM7ChGRJnApGhHRAxiNRnz00UfKsqXG/RajRo1SOdmDVVZWYu/evcjKysK0adPUjkO/gXv37qGoqAhHjx6Fv7+/2nGIiDSDxz0TET3EqlWrUFJSAltbWzzzzDM4cuRIi75IsqkjR44gIiLigdebfmP9fysoKAiVlZVYsWJFi/dpaMGyZcuwbNmy+14bNGgQ0tLSHnMidVy8eNFi039TNTU1iIiIwNSpUx9jKiIibeNSNCKix+TOnTu4fPnyA697e3s/xjTadP36dVy/fv2+1+zt7eHm5vaYE6nj3r17uHDhwgOve3p6wtqan00SETXFwoaIiIiIiFo97rEhIiIiIqJWj4UNERERERG1eixsiIiIiIio1WNhQ0RERERErR4LGyIiIiIiavVY2BARERERUavHwoaIiIiIiFq9/wM+FRku2WWYJQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 1000x500 with 1 Axes>"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Turn this into a phospho job\n",
+        "\n",
+        "Okay, let's muscle up and turn this proof of concept into a function.\n",
+        "\n",
+        "However, let's respect the phospho job convention. To respect the convention, we need the function to take a lab.Message as an input, and return a lab.JobResult as an output.\n",
+        "\n",
+        "Respecting this format helps us parallelize the calls later on. \n",
+        "\n",
+        "Here's what the function looks like:"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "async def get_keywords(\n",
+        "    message: lab.Message,\n",
+        "    model: str=\"openai:gpt-3.5-turbo\",\n",
+        ") -> lab.JobResult:\n",
+        "    \"\"\"\n",
+        "    This function uses OpenAI GPT to extract keywords from a given message.\n",
+        "    \"\"\"\n",
+        "    provider, model_name = lab.get_provider_and_model(model)\n",
+        "    openai_client = lab.get_async_client(provider)\n",
+        "\n",
+        "    # Label every message with keywords it contains\n",
+        "    prompt = f\"\"\"You are an annotator reading Amazon product reviews. Your job is to label\n",
+        "    each review with topics that describe important topics covered in the review, relevant\n",
+        "    to the e-commerce domain. Do not include generic topics such as \"good\", \"bad\", \"interesting\", etc.\n",
+        "    \n",
+        "    The review is: \n",
+        "    {message.content}\n",
+        "\n",
+        "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
+        "    Keywords:\"\"\"\n",
+        "\n",
+        "    response = await openai_client.chat.completions.create(\n",
+        "        model=\"gpt-3.5-turbo\",\n",
+        "        messages=[\n",
+        "            {\n",
+        "                \"role\": \"system\",\n",
+        "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
+        "            },\n",
+        "            {\"role\": \"user\", \"content\": prompt},\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "    response = response.choices[0].message.content\n",
+        "    # Parse the response to extract the keywords with regex\n",
+        "    keywords = re.findall(r\"- (.*)\", response)\n",
+        "    # Let's trim and lowercase the keywords\n",
+        "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
+        "    return lab.JobResult(\n",
+        "        value=keywords,\n",
+        "        result_type=lab.ResultType.list,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Easy, right ? Let's try the function on a single keyword:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'maximumpc', 'advice', 'maximize', 'old computer', 'performance tweaks'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887291, job_id=None)"
+            ]
+          },
+          "execution_count": 29,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Try the function one a single message\n",
+        "await get_keywords(messages[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Run the job on multiple messages\n",
+        "\n",
+        "Now, let's run the jobs on the dataset. \n",
+        "\n",
+        "### Without phospho\n",
+        "\n",
+        "With a simple for loop, you have to wait for a full API call to complete before running the next one. This takes a long time.  \n",
+        "\n",
+        "With **parallelism**, you can make multiple calls at the same time, but debugging becomes much harder.\n",
+        "\n",
+        "Moreover, OpenAI and model providers have set up **rate limits.** If you parallelize without care, you will reach rate limits of OpenAI, and your requests will fail.\n",
+        "\n",
+        "### With phospho\n",
+        "\n",
+        "phospho introduces the abstraction of a Workload. A workload is a set of jobs to run. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "No job_config provided. Running with empty config\n"
+          ]
+        }
+      ],
+      "source": [
+        "workload = lab.Workload(jobs=[lab.Job(job_function=get_keywords)])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "A workload offers quick configuration for the problem presented before:\n",
+        "- `executor_mode`: switch between `sequential` to debug and `parallel` to parallelize API cals\n",
+        "- `max_parallelism`: slow down purposefuly the number of requests per second to avoid being rate limited.\n",
+        "\n",
+        "Here is how to run a workload."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 31,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 100/100 [00:10<00:00,  9.25it/s]\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{'get_keywords': JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'optimization', 'maximumpc', 'advice', 'maximize', 'old computer'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887295, job_id='get_keywords')}"
+            ]
+          },
+          "execution_count": 31,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Run the workload on the messages\n",
+        "results = await workload.async_run(\n",
+        "    messages[:100], # Replace by messages to run on the whole dataset\n",
+        "    executor_type=\"parallel\", # Run the job on every messages in parallel\n",
+        "    max_parallelism=10, # Start at most 10 jobs per second to avoid rate limiting\n",
+        ")\n",
+        "results.get(\"0\") # Get the result for the first message"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Results are stored in the workload, in a dictionary: `message_id -> job_id -> JobResult`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 32,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'get_keywords': JobResult(value=['computer performance', 'tips', 'computer parts', 'vendors', 'tests', 'optimization', 'maximumpc', 'advice', 'maximize', 'old computer'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887295, job_id='get_keywords')}"
+            ]
+          },
+          "execution_count": 32,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "workload.results[\"0\"]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Display results\n",
+        "\n",
+        "Now that we ran the keyword detection on our dataset, let's get the results in a format more adapted for analytics."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>get_keywords</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>[computer performance, tips, computer parts, v...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>[men's magazine, articles, stories, know &amp; tel...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>[glamour magazine, articles, clothes, fashion,...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                         get_keywords\n",
+              "0   [computer performance, tips, computer parts, v...\n",
+              "1   [men's magazine, articles, stories, know & tel...\n",
+              "10  [glamour magazine, articles, clothes, fashion,..."
+            ]
+          },
+          "execution_count": 33,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# In this df, the index is the message_id, and the column is the job_id\n",
+        "results_df = workload.results_df()\n",
+        "results_df.head(3)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "And join back the outputs with the original dataframe. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>get_keywords</th>\n",
+              "      <th>overall</th>\n",
+              "      <th>verified</th>\n",
+              "      <th>reviewTime</th>\n",
+              "      <th>reviewerID</th>\n",
+              "      <th>asin</th>\n",
+              "      <th>reviewerName</th>\n",
+              "      <th>reviewText</th>\n",
+              "      <th>summary</th>\n",
+              "      <th>unixReviewTime</th>\n",
+              "      <th>vote</th>\n",
+              "      <th>style</th>\n",
+              "      <th>image</th>\n",
+              "      <th>id</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>[computer performance, tips, computer parts, v...</td>\n",
+              "      <td>4</td>\n",
+              "      <td>True</td>\n",
+              "      <td>02 26, 2014</td>\n",
+              "      <td>A5QQOOZJOVPSF</td>\n",
+              "      <td>B00005N7P0</td>\n",
+              "      <td>John L. Mehlmauer</td>\n",
+              "      <td>I'm old, and so is my computer.  Any advice th...</td>\n",
+              "      <td>Cheapskates guide</td>\n",
+              "      <td>1393372800</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>[men's magazine, articles, stories, know &amp; tel...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>False</td>\n",
+              "      <td>03 6, 2004</td>\n",
+              "      <td>A5RHZE7B8SV5Q</td>\n",
+              "      <td>B00005N7PS</td>\n",
+              "      <td>gorillazfan249</td>\n",
+              "      <td>There's nothing to say, but if you want a REAL...</td>\n",
+              "      <td>The best mature Men's magazine.</td>\n",
+              "      <td>1078531200</td>\n",
+              "      <td>3.0</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>1</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>[glamour magazine, articles, clothes, fashion,...</td>\n",
+              "      <td>5</td>\n",
+              "      <td>True</td>\n",
+              "      <td>06 12, 2017</td>\n",
+              "      <td>A2VRQ8RNTKY1XT</td>\n",
+              "      <td>B00005N7QC</td>\n",
+              "      <td>Barbara M. Fox</td>\n",
+              "      <td>I love glamour mag. I have read it for over 25...</td>\n",
+              "      <td>Great magazine</td>\n",
+              "      <td>1497225600</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>{'Format:': ' Kindle Edition'}</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>10</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                                         get_keywords  overall  verified  \\\n",
+              "0   [computer performance, tips, computer parts, v...        4      True   \n",
+              "1   [men's magazine, articles, stories, know & tel...        5     False   \n",
+              "10  [glamour magazine, articles, clothes, fashion,...        5      True   \n",
+              "\n",
+              "     reviewTime      reviewerID        asin       reviewerName  \\\n",
+              "0   02 26, 2014   A5QQOOZJOVPSF  B00005N7P0  John L. Mehlmauer   \n",
+              "1    03 6, 2004   A5RHZE7B8SV5Q  B00005N7PS     gorillazfan249   \n",
+              "10  06 12, 2017  A2VRQ8RNTKY1XT  B00005N7QC     Barbara M. Fox   \n",
+              "\n",
+              "                                           reviewText  \\\n",
+              "0   I'm old, and so is my computer.  Any advice th...   \n",
+              "1   There's nothing to say, but if you want a REAL...   \n",
+              "10  I love glamour mag. I have read it for over 25...   \n",
+              "\n",
+              "                            summary  unixReviewTime  vote  \\\n",
+              "0                 Cheapskates guide      1393372800   NaN   \n",
+              "1   The best mature Men's magazine.      1078531200   3.0   \n",
+              "10                   Great magazine      1497225600   NaN   \n",
+              "\n",
+              "                             style image  id  \n",
+              "0                              NaN   NaN   0  \n",
+              "1                              NaN   NaN   1  \n",
+              "10  {'Format:': ' Kindle Edition'}   NaN  10  "
+            ]
+          },
+          "execution_count": 34,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
+        "augmented_messages_df.head(3)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 35,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of different keywords extracted: 398\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords\"].explode().nunique())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We can now have tons of fun with the extracted keywords and do all kind of data analytics. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 36,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "<Axes: title={'center': 'Most common keywords in the dataset'}, xlabel='get_keywords'>"
+            ]
+          },
+          "execution_count": 36,
+          "metadata": {},
+          "output_type": "execute_result"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJlCAYAAAAIImesAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACmRUlEQVR4nOzddVhU6f8+8HvoLglFkbQRuxXFFrsb29VVsddYC921dm1dY22/dreg2NgFtoAidi4iqCjw/P7gx/kwDubinDns/bquuS44czhzM8Mw532eUgkhBIiIiIiIiBRMT+4ARERERERE/xYLGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIgIAuLm5oUGDBnLHkNXhw4ehUqlw+PDhf32szp07w83N7V8f52vI/dq5ubmhc+fOsj0+ERHAwoaIvmD58uVQqVRQqVQ4fvy4xv1CCLi4uEClUv2wE6uHDx9i3LhxuHTp0g85PpESXLt2DePGjUNMTIzcUbKMrr239+zZg3Hjxskdg4i+EwsbIvoqJiYmWLNmjcb2I0eO4P79+zA2Nv5hj/3w4UMEBQXpzMkP0df4+++/cfPmzSw73rVr1xAUFJTtChtdem/v2bMHQUFBcscgou/EwoaIvoq/vz82btyI5ORkte1r1qxBqVKlkDNnTpmSEX09IQTevn2rlccyNDT8oQU/ERGpY2FDRF+lbdu2ePHiBfbv3y9te//+PTZt2oR27dpl+jOJiYkYPHgwXFxcYGxsjAIFCuDPP/+EEEJtv/3796Ny5cqwsbGBhYUFChQogJEjRwJIG/NQpkwZAECXLl2kbnHLly//bN4HDx6gW7ducHZ2hrGxMdzd3dG7d2+8f/9e2uf27dto2bIl7OzsYGZmhvLly2P37t1qx0kfc7FhwwYEBQUhd+7csLS0RIsWLfDq1SskJSVhwIABcHR0hIWFBbp06YKkpCS1Y6hUKvTt2xcbN25E4cKFYWpqigoVKuDy5csAgIULF8LLywsmJiaoVq1aplfkN27ciFKlSsHU1BT29vbo0KEDHjx4oLZP586dYWFhgQcPHqBJkyawsLCAg4MDhgwZgpSUlM8+X5+yYsUKGBgYYOjQodK206dPo27durC2toaZmRmqVq2KsLAw6f5Dhw5BpVJh69atGsdbs2YNVCoVTp48iR07dkClUiEiIkK6f/PmzVCpVGjWrJnazxUqVAitW7eWvk9OTsaECRPg6ekJY2NjuLm5YeTIkRrPffrYk+DgYJQuXRqmpqZYuHAhAOD+/fto0qQJzM3N4ejoiIEDB2r8PABERkaiefPmyJkzJ0xMTJAnTx60adMGr169+uxz9/EYm5iYGKhUKvz5559YtGiRlL1MmTI4e/bsZ4+1fPlytGzZEgDg5+cnvQ8+Hgt0/PhxlC1bFiYmJvDw8MDKlSs1jhUXF4cBAwZI70svLy9MmTIFqampn80ApBWGv/32G/LkyQMzMzP4+fnh6tWrGvu9fPkSQ4YMQdGiRWFhYQErKyvUq1cP4eHh0j5fem8fO3YMLVu2RN68eWFsbAwXFxcMHDhQozB9/PgxunTpgjx58sDY2Bi5cuVC48aNNd5He/fuRZUqVWBubg5LS0vUr19fLXvnzp0xb948AJCyqFSqLz4nRKRDBBHRZyxbtkwAEGfPnhUVK1YUHTt2lO7btm2b0NPTEw8ePBCurq6ifv360n2pqamievXqQqVSie7du4u5c+eKhg0bCgBiwIAB0n5XrlwRRkZGonTp0mLWrFliwYIFYsiQIcLX11cIIcTjx4/F+PHjBQDRs2dPsWrVKrFq1SoRHR39ycwPHjwQzs7OwszMTAwYMEAsWLBAjB49WhQqVEj8888/0nGdnJyEpaWl+PXXX8X06dNFsWLFhJ6entiyZYt0rEOHDgkAonjx4qJChQpi9uzZIjAwUKhUKtGmTRvRrl07Ua9ePTFv3jzRsWNHAUAEBQWp5QEgfHx8hIuLi5g8ebKYPHmysLa2Fnnz5hVz584VhQsXFtOmTROjRo0SRkZGws/PL9PXoEyZMmLGjBli+PDhwtTUVLi5uUm/jxBCdOrUSZiYmIgiRYqIrl27ivnz54vmzZsLAOKvv/764mv98Wu4cOFCoVKpxK+//iptCw0NFUZGRqJChQpi2rRpYsaMGcLHx0cYGRmJ06dPS6+9i4uLaN68ucZj+Pv7C09PTyGEEC9evBAqlUrMmTNHur9///5CT09PODg4SNuePn0qAIi5c+eq/a4ARIsWLcS8efNEQECAACCaNGmi8Tt5eXkJW1tbMXz4cLFgwQJx6NAh8ebNG5E/f35hYmIifvnlFzFz5kxRqlQp4ePjIwCIQ4cOCSGESEpKEu7u7sLZ2Vn89ttvYvHixSIoKEiUKVNGxMTEfPb57NSpk3B1dZW+v3PnjgAgSpQoIby8vMSUKVPE1KlThb29vciTJ494//79J48VHR0tAgMDBQAxcuRI6X3w+PFj6fcsUKCAcHJyEiNHjhRz584VJUuWFCqVSly5ckU6TmJiovDx8RE5cuQQI0eOFAsWLBABAQFCpVKJ/v37f/b3EUKIUaNGCQDC399fzJ07V3Tt2lU4OzsLe3t70alTJ2m/s2fPCk9PTzF8+HCxcOFCMX78eJE7d25hbW0tHjx4IIT48nu7X79+wt/fX0ycOFEsXLhQdOvWTejr64sWLVqoZapYsaKwtrYWo0aNEosXLxYTJ04Ufn5+4siRI9I+K1euFCqVStStW1fMmTNHTJkyRbi5uQkbGxtx584dIYQQJ06cELVq1RIApCyrVq364nNCRLqDhQ0RfVbGwmbu3LnC0tJSvHnzRgghRMuWLaWT8I9Pirdt2yYAiN9++03teC1atBAqlUpERUUJIYSYMWOGACCePXv2yQxnz54VAMSyZcu+KnNAQIDQ09MTZ8+e1bgvNTVVCCHEgAEDBABx7Ngx6b7Xr18Ld3d34ebmJlJSUoQQ/ytsvL291U4827ZtK1QqlahXr57a8StUqKB2MitEWmFjbGwsnUAJkVY0ABA5c+YU8fHx0vYRI0YIANK+79+/F46OjsLb21u8fftW2m/Xrl0CgBgzZoy0Lf1kf/z48WqPX6JECVGqVKnPPWVCCPXXcNasWUKlUokJEyaoPXf58uUTderUkZ5HIYR48+aNcHd3F7Vq1VL7PYyNjUVcXJy07enTp8LAwECMHTtW2lakSBHRqlUr6fuSJUuKli1bCgDi+vXrQgghtmzZIgCI8PBwIYQQly5dEgBE9+7d1fIPGTJEABAHDx5U+50AiH379qntO3PmTAFAbNiwQdqWmJgovLy81AqbixcvCgBi48aNX3z+PvapwiZHjhzi5cuX0vbt27cLAGLnzp2fPd7GjRvVsmWU/nsePXpU2vb06VNhbGwsBg8eLG2bMGGCMDc3F7du3VL7+eHDhwt9fX0RGxv7ycd/+vSpMDIyEvXr11d7/UeOHCkAqBU27969k95DGX9/Y2Njtb/Pz7230//PZDRp0iShUqnE3bt3hRBC/PPPPwKA+OOPPz6Z+/Xr18LGxkb06NFDbfvjx4+FtbW12vY+ffoIXvMlUi52RSOir9aqVSu8ffsWu3btwuvXr7Fr165PdkPbs2cP9PX1ERgYqLZ98ODBEEJg7969AAAbGxsAwPbt27+qK8yXpKamYtu2bWjYsCFKly6tcX9615I9e/agbNmyqFy5snSfhYUFevbsiZiYGFy7dk3t5wICAmBoaCh9X65cOQgh0LVrV7X9ypUrh3v37mmMRapRo4Zat6Ry5coBAJo3bw5LS0uN7bdv3wYAnDt3Dk+fPsXPP/8MExMTab/69eujYMGCGl3nAKBXr15q31epUkU63teYOnUq+vfvjylTpmDUqFHS9kuXLiEyMhLt2rXDixcv8Pz5czx//hyJiYmoUaMGjh49Kr2GAQEBSEpKwqZNm6SfX79+PZKTk9GhQwe1bMeOHQMAvH79GuHh4ejZsyfs7e2l7ceOHYONjQ28vb0BpL12ADBo0CC13IMHDwYAjefE3d0dderUUdu2Z88e5MqVCy1atJC2mZmZoWfPnmr7WVtbAwCCg4Px5s2br3r+vqR169awtbWVvq9SpQoAfNNrlJnChQtLxwIABwcHFChQQO24GzduRJUqVWBrayu9fs+fP0fNmjWRkpKCo0ePfvL4Bw4cwPv379GvXz+1LloDBgzQ2NfY2Bh6emmnGCkpKXjx4oXUzfTChQtf9fuYmppKXycmJuL58+eoWLEihBC4ePGitI+RkREOHz6Mf/75J9Pj7N+/H3FxcWjbtq3a76yvr49y5crh0KFDX5WHiHQfCxsi+moODg6oWbMm1qxZgy1btiAlJUXtxDCju3fvwtnZWe2kHUgbK5F+P5B2klepUiV0794dTk5OaNOmDTZs2PDdRc6zZ88QHx8vnQR/yt27d1GgQAGN7R/nS5c3b16179NPeF1cXDS2p6amaoy/+JafByCdpKXnyCxrwYIFNXKamJjAwcFBbZutre0nT/o+duTIEQwbNgzDhg1TG1cDpI01AYBOnTrBwcFB7bZ48WIkJSVJv3fBggVRpkwZrF69Wvr51atXo3z58vDy8pK2ValSBY8ePUJUVBROnDgBlUqFChUqqBU8x44dQ6VKlaQT5bt370JPT0/tOACQM2dO2NjYaDwn7u7uGr/n3bt34eXlpTGG4uPn2d3dHYMGDcLixYthb2+POnXqYN68eV8cX/M5H/8tpBc5X/safe1x04+d8biRkZHYt2+fxutXs2ZNAMDTp08/efz05zVfvnxq2x0cHNQKNSDtAsOMGTOQL18+GBsbw97eHg4ODoiIiPjq5y42NhadO3eGnZ2dNF6satWqACAdw9jYGFOmTMHevXvh5OQEX19fTJ06FY8fP1b7nQGgevXqGr93SEjIZ39nIlIWA7kDEJGytGvXDj169MDjx49Rr149qcXle5mamuLo0aM4dOgQdu/ejX379mH9+vWoXr06QkJCoK+vnzXB/6VP5fjUdvHRBAn/9ue/1r99vooUKYK4uDisWrUKP/30k1pRkF5s/vHHHyhevHimP29hYSF9HRAQgP79++P+/ftISkrCqVOnMHfuXLX901vMjh49itu3b6NkyZIwNzdHlSpVMHv2bCQkJODixYv4/fffNR7rawd2Z7zy/z2mTZuGzp07Y/v27QgJCUFgYCAmTZqEU6dOIU+ePN98vKx+zb/luKmpqahVqxZ++eWXTPfNnz//v8qQbuLEiRg9ejS6du2KCRMmwM7ODnp6ehgwYMBXXbRISUlBrVq18PLlSwwbNgwFCxaEubk5Hjx4gM6dO6sdY8CAAWjYsCG2bduG4OBgjB49GpMmTcLBgwdRokQJad9Vq1ZlOnujgQFPhYiyC76bieibNG3aFD/99BNOnTqF9evXf3I/V1dXHDhwAK9fv1Zrtblx44Z0fzo9PT3UqFEDNWrUwPTp0zFx4kT8+uuvOHToEGrWrPlNMxM5ODjAysoKV65c+ex+rq6uma4xklk+OaXnuHnzJqpXr652382bN7M8p729PTZt2oTKlSujRo0aOH78OJydnQEAnp6eAAArKyvpCv/ntGnTBoMGDcLatWvx9u1bGBoaqs1sBqS1MuTNmxfHjh3D7du3pa5Uvr6+GDRoEDZu3IiUlBT4+vpKP+Pq6orU1FRERkZKLWwA8OTJE8TFxX3Vc+Lq6oorV65ACKH29/WpdWeKFi2KokWLYtSoUThx4gQqVaqEBQsW4LfffvviY2WVrJihy9PTEwkJCV/1+n0s/XmNjIyEh4eHtP3Zs2carU2bNm2Cn58flixZorY9Li4O9vb20vef+p0uX76MW7duYcWKFQgICJC2Z5yVMSNPT08MHjwYgwcPRmRkJIoXL45p06bh//7v/6S/W0dHxy/+3pwFjUjZ2BWNiL6JhYUF5s+fj3HjxqFhw4af3M/f3x8pKSkaV+hnzJgBlUqFevXqAUibFvZj6a0B6VPvmpubA0g7KfoSPT09NGnSBDt37sS5c+c07k+/eu3v748zZ87g5MmT0n2JiYlYtGgR3NzcULhw4S8+ljaULl0ajo6OWLBggdpUxHv37sX169dRv379LH/MPHny4MCBA3j79i1q1aqFFy9eAABKlSoFT09P/Pnnn0hISND4uWfPnql9b29vj3r16uH//u//sHr1atStW1ftpDZdlSpVcPDgQZw5c0YqbIoXLw5LS0tMnjwZpqamKFWqlLS/v78/AGDmzJlqx5k+fToAfNVz4u/vj4cPH6qNAXrz5g0WLVqktl98fLzGeKmiRYtCT08v06mhf6RveR98SqtWrXDy5EkEBwdr3BcXF6fxu2ZUs2ZNGBoaYs6cOWqtQB+/DkBa69HHLVAbN27UmKL8U79TeutTxmMIITBr1iy1/d68eYN3796pbfP09ISlpaX0+tSpUwdWVlaYOHEiPnz4oJE1499tVjzHRCQfttgQ0Tfr1KnTF/dp2LAh/Pz88OuvvyImJgbFihVDSEgItm/fjgEDBkhXUcePH4+jR4+ifv36cHV1xdOnT/HXX38hT548UjclT09P2NjYYMGCBbC0tIS5uTnKlSuX6dgJIK0bTEhICKpWrYqePXuiUKFCePToETZu3Ijjx4/DxsYGw4cPx9q1a1GvXj0EBgbCzs4OK1aswJ07d7B582ZpPIfcDA0NMWXKFHTp0gVVq1ZF27Zt8eTJE8yaNQtubm4YOHDgD3lcLy8vhISEoFq1aqhTpw4OHjwIKysrLF68GPXq1UORIkXQpUsX5M6dGw8ePMChQ4dgZWWFnTt3qh0nICBAGoc1YcKETB+rSpUqWL16NVQqlfSa6+vro2LFiggODka1atVgZGQk7V+sWDF06tQJixYtQlxcHKpWrYozZ85gxYoVaNKkCfz8/L74+/Xo0QNz585FQEAAzp8/j1y5cmHVqlUwMzNT2+/gwYPo27cvWrZsifz58yM5ORmrVq2Cvr4+mjdv/k3P6b9VvHhx6OvrY8qUKXj16hWMjY1RvXp1ODo6fvUxhg4dih07dqBBgwbo3LkzSpUqhcTERFy+fBmbNm1CTExMpsUnAGlNpEmTJqFBgwbw9/fHxYsXsXfvXo2fadCgAcaPH48uXbqgYsWKuHz5MlavXq3W0gN8+r1dsGBBeHp6YsiQIXjw4AGsrKywefNmjZahW7duoUaNGmjVqhUKFy4MAwMDbN26FU+ePEGbNm0ApLUwzp8/Hx07dkTJkiXRpk0bODg4IDY2Frt370alSpWkCzDpBXRgYCDq1KkDfX196ThEpACyzMVGRIqRcbrnz/l4umch0qZZHThwoHB2dhaGhoYiX7584o8//lCbKjY0NFQ0btxYODs7CyMjI+Hs7Czatm2rMR3t9u3bReHChYWBgcFXTf189+5dERAQIBwcHISxsbHw8PAQffr0EUlJSdI+0dHRokWLFsLGxkaYmJiIsmXLil27dqkdJ32654+n+/3U8zJ27FiN6asBiD59+qjtlz7178fT1H7q8davXy9KlCghjI2NhZ2dnWjfvr24f/++2j6dOnUS5ubmGs9FeqYvyew1PH36tLC0tBS+vr7S9LsXL14UzZo1Ezly5BDGxsbC1dVVtGrVSoSGhmocMykpSdja2gpra2u16aozunr1qgAgChUqpLb9t99+EwDE6NGjNX7mw4cPIigoSLi7uwtDQ0Ph4uIiRowYId69e/fF3ynd3bt3RaNGjYSZmZmwt7cX/fv3F/v27VObUvn27duia9euwtPTU5iYmAg7Ozvh5+cnDhw4kPmTmMGnpnvObGpiAGrTYH/K33//LTw8PIS+vr5azk/9nlWrVhVVq1ZV2/b69WsxYsQI4eXlJYyMjIS9vb2oWLGi+PPPPz+7lo4QQqSkpIigoCCRK1cuYWpqKqpVqyauXLkiXF1dNaZ7Hjx4sLRfpUqVxMmTJzPN86n39rVr10TNmjWFhYWFsLe3Fz169BDh4eFq+zx//lz06dNHFCxYUJibmwtra2tRrlw5tWm80x06dEjUqVNHWFtbCxMTE+Hp6Sk6d+4szp07J+2TnJws+vXrJxwcHIRKpeLUz0QKoxLiX45WJCIi+oTk5GQ4OzujYcOGGuMtiIiIspJu9LUgIqJsadu2bXj27JnaAHAiIqIfgS02RESU5U6fPo2IiAhMmDAB9vb2X70oIxER0fdiiw0REWW5+fPno3fv3nB0dMTKlSvljkNERP8BbLEhIiIiIiLFY4sNEREREREpns6tY5OamoqHDx/C0tKSKwATEREREf2HCSHw+vVrODs7f3mNuW+ZG3rixImidOnSwsLCQjg4OIjGjRuLGzduqO1TtWpVAUDt9tNPP331Y9y7d0/j53njjTfeeOONN9544423/+7t3r17X6wjvqnF5siRI+jTpw/KlCmD5ORkjBw5ErVr18a1a9dgbm4u7dejRw+MHz9e+v7jlZw/x9LSEgBw7949WFlZfUs8IiIiIiLKRuLj4+Hi4iLVCJ/zTYXNvn371L5fvnw5HB0dcf78efj6+krbzczMkDNnzm85tCS9+5mVlRULGyIiIiIi+qohKv9q8oBXr14BAOzs7NS2r169Gvb29vD29saIESPw5s2bTx4jKSkJ8fHxajciIiIiIqJv8d2TB6SmpmLAgAGoVKkSvL29pe3t2rWDq6srnJ2dERERgWHDhuHmzZvYsmVLpseZNGkSgoKCvjcGERERERHR969j07t3b+zduxfHjx9Hnjx5PrnfwYMHUaNGDURFRcHT01Pj/qSkJCQlJUnfp/eje/XqFbuiERERERH9h8XHx8Pa2vqraoPvarHp27cvdu3ahaNHj362qAGAcuXKAcAnCxtjY2MYGxt/TwwiIiIiIiIA31jYCCHQr18/bN26FYcPH4a7u/sXf+bSpUsAgFy5cn1XQCIiIiIioi/5psKmT58+WLNmDbZv3w5LS0s8fvwYAGBtbQ1TU1NER0djzZo18Pf3R44cORAREYGBAwfC19cXPj4+P+QXICIiIiIi+qYxNp+aZm3ZsmXo3Lkz7t27hw4dOuDKlStITEyEi4sLmjZtilGjRn31eJlv6UdHRERERETZ1w8bY/OlGsjFxQVHjhz5lkMSERERERH9a/9qHRsiIiIiIiJdwMKGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixfumBTp1jdvw3Vl2rJjJ9bPsWEREREREpF1ssSEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHifVNhM2nSJJQpUwaWlpZwdHREkyZNcPPmTbV93r17hz59+iBHjhywsLBA8+bN8eTJkywNTURERERElNE3FTZHjhxBnz59cOrUKezfvx8fPnxA7dq1kZiYKO0zcOBA7Ny5Exs3bsSRI0fw8OFDNGvWLMuDExERERERpTP4lp337dun9v3y5cvh6OiI8+fPw9fXF69evcKSJUuwZs0aVK9eHQCwbNkyFCpUCKdOnUL58uWzLjkREREREdH/96/G2Lx69QoAYGdnBwA4f/48Pnz4gJo1a0r7FCxYEHnz5sXJkyczPUZSUhLi4+PVbkRERERERN/iuwub1NRUDBgwAJUqVYK3tzcA4PHjxzAyMoKNjY3avk5OTnj8+HGmx5k0aRKsra2lm4uLy/dGIiIiIiKi/6jvLmz69OmDK1euYN26df8qwIgRI/Dq1Svpdu/evX91PCIiIiIi+u/5pjE26fr27Ytdu3bh6NGjyJMnj7Q9Z86ceP/+PeLi4tRabZ48eYKcOXNmeixjY2MYGxt/TwwiIiIiIiIA39hiI4RA3759sXXrVhw8eBDu7u5q95cqVQqGhoYIDQ2Vtt28eROxsbGoUKFC1iQmIiIiIiL6yDe12PTp0wdr1qzB9u3bYWlpKY2bsba2hqmpKaytrdGtWzcMGjQIdnZ2sLKyQr9+/VChQgXOiEZERERERD/MNxU28+fPBwBUq1ZNbfuyZcvQuXNnAMCMGTOgp6eH5s2bIykpCXXq1MFff/2VJWGJiIiIiIgy802FjRDii/uYmJhg3rx5mDdv3neHIiIiIiIi+hb/ah0bIiIiIiIiXcDChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgU75sLm6NHj6Jhw4ZwdnaGSqXCtm3b1O7v3LkzVCqV2q1u3bpZlZeIiIiIiEjDNxc2iYmJKFasGObNm/fJferWrYtHjx5Jt7Vr1/6rkERERERERJ9j8K0/UK9ePdSrV++z+xgbGyNnzpxfdbykpCQkJSVJ38fHx39rJCIiIiIi+o/7IWNsDh8+DEdHRxQoUAC9e/fGixcvPrnvpEmTYG1tLd1cXFx+RCQiIiIiIsrGsrywqVu3LlauXInQ0FBMmTIFR44cQb169ZCSkpLp/iNGjMCrV6+k271797I6EhERERERZXPf3BXtS9q0aSN9XbRoUfj4+MDT0xOHDx9GjRo1NPY3NjaGsbFxVscgIiIiIqL/kB8+3bOHhwfs7e0RFRX1ox+KiIiIiIj+o354YXP//n28ePECuXLl+tEPRURERERE/1Hf3BUtISFBrfXlzp07uHTpEuzs7GBnZ4egoCA0b94cOXPmRHR0NH755Rd4eXmhTp06WRqciIiIiIgo3TcXNufOnYOfn5/0/aBBgwAAnTp1wvz58xEREYEVK1YgLi4Ozs7OqF27NiZMmMBxNERERERE9MN8c2FTrVo1CCE+eX9wcPC/CkRERERERPStfvgYGyIiIiIioh+NhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFO+bC5ujR4+iYcOGcHZ2hkqlwrZt29TuF0JgzJgxyJUrF0xNTVGzZk1ERkZmVV4iIiIiIiIN31zYJCYmolixYpg3b16m90+dOhWzZ8/GggULcPr0aZibm6NOnTp49+7dvw5LRERERESUGYNv/YF69eqhXr16md4nhMDMmTMxatQoNG7cGACwcuVKODk5Ydu2bWjTps2/S0tERERERJSJLB1jc+fOHTx+/Bg1a9aUtllbW6NcuXI4efJkpj+TlJSE+Ph4tRsREREREdG3yNLC5vHjxwAAJycnte1OTk7SfR+bNGkSrK2tpZuLi0tWRiIiIiIiov8A2WdFGzFiBF69eiXd7t27J3ckIiIiIiJSmCwtbHLmzAkAePLkidr2J0+eSPd9zNjYGFZWVmo3IiIiIiKib5GlhY27uzty5syJ0NBQaVt8fDxOnz6NChUqZOVDERERERERSb55VrSEhARERUVJ39+5cweXLl2CnZ0d8ubNiwEDBuC3335Dvnz54O7ujtGjR8PZ2RlNmjTJytxERERERESSby5szp07Bz8/P+n7QYMGAQA6deqE5cuX45dffkFiYiJ69uyJuLg4VK5cGfv27YOJiUnWpSYiIiIiIspAJYQQcofIKD4+HtbW1nj16tUXx9u4Dd+dZY8bM7l+lh2LiIiIiIj+vW+pDWSfFY2IiIiIiOjfYmFDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4hnIHSC74uKhRERERETawxYbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIpnIHcA0j634buz7Fgxk+tn2bGIiIiIiL4XW2yIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpnoHcAYjSuQ3fnaXHi5lcP8uOlZXZsjIXoNvZiIiIiLSFLTZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8bK8sBk3bhxUKpXarWDBgln9MERERERERBKDH3HQIkWK4MCBA/97EIMf8jBEREREREQAflBhY2BggJw5c/6IQxMREREREWn4IWNsIiMj4ezsDA8PD7Rv3x6xsbGf3DcpKQnx8fFqNyIiIiIiom+R5S025cqVw/Lly1GgQAE8evQIQUFBqFKlCq5cuQJLS0uN/SdNmoSgoKCsjkFEOsBt+O4sO1bM5PpZdqyszAXobraszAUwGxER6bYsb7GpV68eWrZsCR8fH9SpUwd79uxBXFwcNmzYkOn+I0aMwKtXr6TbvXv3sjoSERERERFlcz98VL+NjQ3y58+PqKioTO83NjaGsbHxj45BRERERETZ2A9fxyYhIQHR0dHIlSvXj34oIiIiIiL6j8rywmbIkCE4cuQIYmJicOLECTRt2hT6+vpo27ZtVj8UERERERERgB/QFe3+/fto27YtXrx4AQcHB1SuXBmnTp2Cg4NDVj8UERERERERgB9Q2Kxbty6rD0lERERERPRZP3yMDRERERER0Y/GwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFy/IFOomIiCiN2/DdWXq8mMn1s+xYWZktK3MBzPY9dPlvjUhb2GJDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeIZyB2AiIiIiLIvt+G7s+xYMZPrZ9mxAGb7HlmZC8jabGyxISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLF+2GFzbx58+Dm5gYTExOUK1cOZ86c+VEPRURERERE/3E/pLBZv349Bg0ahLFjx+LChQsoVqwY6tSpg6dPn/6IhyMiIiIiov84gx9x0OnTp6NHjx7o0qULAGDBggXYvXs3li5diuHDh6vtm5SUhKSkJOn7V69eAQDi4+O/+DipSW+yLPPXPN63YLZvl5W5AN3N9l95PQHdzca/te/DbN+Of2vfh9m+Hf/Wvg+zfTtt/62l3y+E+OKxVOJr9voG79+/h5mZGTZt2oQmTZpI2zt16oS4uDhs375dbf9x48YhKCgoKyMQEREREVE2cu/ePeTJk+ez+2R5i83z58+RkpICJycnte1OTk64ceOGxv4jRozAoEGDpO9TU1Px8uVL5MiRAyqV6l/niY+Ph4uLC+7duwcrK6t/fbysoqu5AGb7XrqaTVdzAcz2vXQ1m67mApjte+lqNl3NBTDb99LVbLqaC/jvZBNC4PXr13B2dv7ivj+kK9q3MDY2hrGxsdo2GxubLH8cKysrnXvRAd3NBTDb99LVbLqaC2C276Wr2XQ1F8Bs30tXs+lqLoDZvpeuZtPVXMB/I5u1tfVX7ZflkwfY29tDX18fT548Udv+5MkT5MyZM6sfjoiIiIiIKOsLGyMjI5QqVQqhoaHSttTUVISGhqJChQpZ/XBEREREREQ/pivaoEGD0KlTJ5QuXRply5bFzJkzkZiYKM2Spk3GxsYYO3asRnc3uelqLoDZvpeuZtPVXACzfS9dzaaruQBm+166mk1XcwHM9r10NZuu5gKYLTNZPitaurlz5+KPP/7A48ePUbx4ccyePRvlypX7EQ9FRERERET/cT+ssCEiIiIiItKWLB9jQ0REREREpG0sbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNE9P/FxcVh8eLFGDFiBF6+fAkAuHDhAh48eCBrrqNHjyI5OVlje3JyMo4ePSpDIuDDhw/w9PTE9evXZXl8Il0SHR2NUaNGoW3btnj69CkAYO/evbh69arMyYj+W1jYyCglJQWXLl3CP//8I3cUov+8iIgI5M+fH1OmTMGff/6JuLg4AMCWLVswYsQIWbP5+flJhVZGr169gp+fnwyJAENDQ7x7906Wx/5aFy5cwOXLl6Xvt2/fjiZNmmDkyJF4//69bLmePHmCjh07wtnZGQYGBtDX11e7yUlXnzNdduTIERQtWhSnT5/Gli1bkJCQAAAIDw/H2LFjZU5H2U316tWlz6eM4uPjUb16de0H+khUVBSCg4Px9u1bAIC2J1/OttM9Jycn4/Dhw4iOjka7du1gaWmJhw8fwsrKChYWFrJkGjBgAIoWLYpu3bohJSUFVatWxYkTJ2BmZoZdu3ahWrVqsuRKFxkZiUOHDuHp06dITU1Vu2/MmDEypUo7CRgyZAhCQ0Px9OlTjTdJSkqKTMk0xcfH4+DBgyhQoAAKFSokdxxF0JXnrGbNmihZsiSmTp0KS0tLhIeHw8PDAydOnEC7du0QExMjWzY9PT08efIEDg4Oattv3bqF0qVLIz4+XpZcEydOxK1bt7B48WIYGPyQ9Z7/lTJlymD48OFo3rw5bt++jSJFiqBp06Y4e/Ys6tevj5kzZ8qSq169eoiNjUXfvn2RK1cuqFQqtfsbN24sSy5Ad5+zjHTt871ChQpo2bIlBg0apPa/48yZM2jWrBnu37+v9UxfEhcXBxsbG7lj6LzU1FRERUVlel7k6+srSyY9PT08fvwYjo6OatufPn2K3Llz48OHD7LkevHiBVq3bo2DBw9CpVIhMjISHh4e6Nq1K2xtbTFt2jSt5NC9T6IscPfuXdStWxexsbFISkpCrVq1YGlpiSlTpiApKQkLFiyQJdemTZvQoUMHAMDOnTtx584d3LhxA6tWrcKvv/6KsLAwWXIBwN9//43evXvD3t4eOXPmVPugValUshY2nTt3RmxsLEaPHp3pSYCcWrVqBV9fX/Tt2xdv375F6dKlERMTAyEE1q1bh+bNm8uab9WqVViwYAHu3LmDkydPwtXVFTNnzoS7u7tsJ0+6+pydPXsWCxcu1NieO3duPH78WIZEQLNmzQCkvQc7d+6stoJzSkoKIiIiULFiRVmyAWnPWWhoKEJCQlC0aFGYm5ur3b9lyxaZkqW5desWihcvDgDYuHEjfH19sWbNGoSFhaFNmzaynaQfP34cx44dk7LpEl19ztLp4uf75cuXsWbNGo3tjo6OeP78udbzfGzKlClwc3ND69atAaT9D968eTNy5syJPXv2oFixYrJla9q0aaaf6SqVCiYmJvDy8kK7du1QoEABrWc7deoU2rVrh7t372pcUFWpVFq/qBoRESF9fe3aNbXPpZSUFOzbtw+5c+fWaqaMBg4cCAMDA8TGxqpdpGzdujUGDRrEwubf6N+/P0qXLo3w8HDkyJFD2t60aVP06NFDtlzPnz9Hzpw5AQB79uxBy5YtkT9/fnTt2hWzZs2SLRcA/Pbbb/j9998xbNgwWXNkRpdPAo4ePYpff/0VALB161YIIRAXF4cVK1bgt99+k7WwmT9/PsaMGYMBAwbg999/l/4J29jYYObMmbIVNrr6nBkbG2fa8nHr1i2NlhJtsba2BpDWlG9paQlTU1PpPiMjI5QvX17W/2k2NjayF++fI4SQrrIeOHAADRo0AAC4uLjIesLp4uKi9e4ZX0tXn7N0uvj5bmNjg0ePHsHd3V1t+8WLF2U90Uy3YMECrF69GgCwf/9+7N+/H3v37sWGDRswdOhQhISEyJbN2toa27Ztg42NDUqVKgUgrTtkXFwcateujfXr12PKlCkIDQ1FpUqVtJqtV69eKF26NHbv3q0TF1WLFy8OlUoFlUqVaZczU1NTzJkzR4ZkaUJCQhAcHIw8efKobc+XLx/u3r2rvSAiG7KzsxM3btwQQghhYWEhoqOjhRBC3LlzR5iamsqWK2/evCI4OFgkJycLFxcXsWvXLiGEEFeuXBE2Njay5RJCCEtLS+l50jWFChUSFy5ckDtGpkxMTERsbKwQQoiOHTuKYcOGCSGEuHv3rjA3N5czmihUqJDYunWrEEL9fXD58mWRI0cO2XLp6nPWrVs30aRJE/H+/XthYWEhbt++Le7evStKlCgh+vfvL1suIYQYN26cSEhIkDWDEvn5+YmAgACxcuVKYWhoKCIjI4UQQhw+fFi4urrKlis4OFjUrl1b3LlzR7YMn6Krz1k6Xfx8Hzx4sKhcubJ49OiRsLS0FJGRkeL48ePCw8NDjBs3TpZMGWX8nxsYGCh69uwphBDi5s2bsp97DBs2TPTu3VukpKRI21JSUkTfvn3FiBEjRGpqqujZs6eoVKmS1rOZmZlJf/+6ICYmRty5c0eoVCpx9uxZERMTI90ePnwokpOTZc1nYWEhbt26JX2d/t48e/assLOz01qObFnY2NjYiKtXrwoh1J/cY8eOCUdHR9lyjR07VlhbW4uCBQuKvHnzinfv3gkhhFiyZIkoX768bLmEEKJr165i/vz5smb4FF0+CciXL59Yv369SEhIEA4ODiI0NFQIIcSlS5dkLR6ESPswi4mJEUKovw9u3bolTExMZMulq89ZXFycqFmzprCxsRH6+vrCxcVFGBoaCl9fXxYVX/D06VNx7NgxcezYMfH06VO540guXbokvL29hZWVldoJZt++fUXbtm1ly2VjYyOMjIyEnp6esLCwELa2tmo3OYWHh+vkc5ZOFz/fk5KSRPfu3YWBgYFQqVTC0NBQ6OnpiQ4dOsh+simEELly5RJhYWFCCCHy588vNmzYIIQQ4saNG8LS0lLOaMLe3l7cvHlTY/vNmzelz4OIiAhhbW2t5WRpRf7evXu1/rhKVa9ePTFq1CghhJAuDqakpIiWLVuK5s2bay1HtuyKVrt2bcycOROLFi0CkNYXMiEhAWPHjoW/v79sucaNGwdvb2/cu3cPLVu2lPrL6+vrY/jw4bLlAgAvLy+MHj0ap06dQtGiRWFoaKh2f2BgoEzJ0vpnvnnzBp6enjAzM9PIltlsUdoyYMAAtG/fHhYWFsibN680AcTRo0dRtGhR2XIBgLu7Oy5dugRXV1e17fv27ZN1kH7G58zV1VVnnjNra2vs378fYWFhCA8PR0JCAkqWLImaNWvKlimdrk6gkZiYiH79+mHlypVS9yV9fX0EBARgzpw5MDMzkyVXumLFiqnN8JXujz/+kHWyA7nHqXyOj4/PJ58zuWdsA3Tz893IyAh///03Ro8ejStXriAhIQElSpRAvnz5ZMnzsWbNmqFdu3bIly8fXrx4gXr16gFI6yrn5eUla7bk5GTcuHED+fPnV9t+48YN6f+aiYmJLN3A+vXrh8GDB+Px48eZnhf5+PhoPVM6XZzsaerUqahRowbOnTuH9+/f45dffsHVq1fx8uVLrY4hz5azot2/fx916tSBEAKRkZEoXbo0IiMjYW9vj6NHj2rMJCGHd+/ewcTERO4Yko/7BmekUqlw+/ZtLaZRt2LFis/e36lTJy0lydy5c+dw79491KpVS5qRZ/fu3bCxsdF6n+CMFi9ejHHjxmHatGno1q0bFi9ejOjoaEyaNAmLFy9GmzZtZMt2/vx5xMbG6txzpqt0dRatn376CQcOHMDcuXOl1+348eMIDAxErVq1MH/+fFlypfPw8MDZs2fVxmIAaTNClSxZUtb/a7ru3Llz0hpFhQoVQunSpWVOlEYJn++65sOHD5g1axbu3buHzp07o0SJEgCAGTNmwNLSEt27d5ctW2BgINauXYuRI0eiTJkyANImJZk4cSLatWuHWbNmYfHixVi+fDmOHz+u1Wx6eporoqhUKgghZJk8IN2XJnu6cOGCLLmAtCUI5s6dq3ZxsE+fPsiVK5fWMmTLwgZIuwqwbt06RERESE9u+/bt1QbfaltKSgomTpyIBQsW4MmTJ7h16xY8PDwwevRouLm5oVu3brJlo3/n/fv3uHPnDjw9PXVq2tvVq1dj3LhxiI6OBgA4OzsjKCiIf2uZCAwMhJeXl0br5Ny5cxEVFSXrVXZLS0udnEDD3t4emzZt0piq/tChQ2jVqhWePXsmT7D/71PToj558gQuLi6yrsuSkpKCbdu2ScVDkSJF0KhRI9lbRe7fv4+2bdsiLCxMmg44Li4OFStWxLp16zQGBstB1z7fU1JSsHz5cqlF9eMr6AcPHpQllxKkpKRg8uTJmDt3Lp48eQIAcHJyQr9+/TBs2DDo6+sjNjYWenp6Wv/b+9KA9497Q2iLq6srfv75Z52b7Ck2NhYuLi6Ztq7FxsYib968WsmRbQsbXTR+/HisWLEC48ePR48ePXDlyhV4eHhg/fr1mDlzJk6ePCl3RAD/W0xJ7hlAMtLVk4A3b96gX79+UqtSerHar18/5M6dW/YuhunevHmDhIQEnbmaef/+fezYsQOxsbEaJ5fTp0+XJVPu3LmxY8cOaWaedBcuXECjRo1kXYuicOHCWL16tXSlVVeYmZnh/PnzGl0br169irJlyyIxMVGWXDt27AAANGnSBCtWrJBmlwPS/peEhoZi//79uHnzpiz5oqKi4O/vjwcPHkjT2N68eRMuLi7YvXs3PD09ZckFAHXr1pVmKcyYrUuXLrCyssK+fftkywboXm8HAOjbty+WL1+O+vXrZ9qiOmPGDJmS/c+qVauwcOFC3L59W2em/v9Y+qyUVlZWMifRbVZWVrh06RI8PDzkjqJGX18fjx490jjPePHiBRwdHbXXwqW10TxaduvWLbFw4UIxYcIEERQUpHaTi6enpzhw4IAQQn3Q4/Xr12WfmUQIIVasWCG8vb2FsbGxMDY2FkWLFhUrV66UO5aIjIwU+fLlE2ZmZqJEiRKiRIkSwszMTBQoUEBERUXJmi0wMFCUKlVKHDt2TJibm0uv6bZt20Tx4sVlzXb79m1phpKMbt26JetEDAcOHBBmZmbC29tbGBgYiOLFiwsbGxthbW0t/Pz8ZMtlbGyc6Qw4kZGRwtjYWIZE/6OrE2hUr15dtGzZUrx9+1ba9ubNG9GyZUtRo0YN2XKpVCqhUqmEnp6e9HX6zcjISOTPn1/s3LlTtnz16tUTdevWFS9evJC2PX/+XNStW1f4+/vLlkuItElHMpuF8ty5c7LOKprO0tJSBAQEiJCQELWZtOSUI0cOsXv3brljfNJff/0l7O3txW+//SZMTU2lz6lly5aJatWqyZxOt0VFRYm+ffuKGjVqiBo1aoh+/frJft6hq5M9qVSqTCePiYmJEWZmZlrLoTt9ZrKQri42+eDBg0wH6qWmpsq2Umy66dOnY/To0ejbt69aX/levXrh+fPnGDhwoGzZAgMD4enpiVOnTsHOzg5A2hWADh06IDAwELt375Yt27Zt27B+/XqUL19e7e+sSJEiUvcvuXTu3Bldu3bVGMB6+vRpLF68GIcPH5Yl14gRIzBkyBAEBQXB0tISmzdvhqOjI9q3b4+6devKkglIm0Bj37596Nu3r9r2vXv3yn5lTFcn0Jg1axbq1KmDPHnySIv8hYeHw8TEBMHBwbJkAiB1BXJ3d8fZs2dhb28vW5bMHDlyRO3/GQDkyJEDkydPln2MmYuLS6afRykpKXB2dpYhkboVK1ZgzZo1aNy4MaytrdG6dWt06NBB1jFARkZGsg/C/5w5c+bg77//RpMmTTB58mRpe+nSpTFkyBAZk+nuxCgAEBwcjEaNGqF48eLS+zIsLAxFihTBzp07UatWLVly6dpkT4MGDQKQdn49evRotUljUlJScPr0aa12o86WhY2uLjZZuHBhHDt2TKNf5qZNm2TvYjJnzhzMnz8fAQEB0rZGjRqhSJEiGDdunKyFjS6fBDx79izT7l2JiYmyd+W7ePFips9P+fLlNU7eten69etYu3YtAMDAwABv376FhYUFxo8fj8aNG6N3796y5Bo0aBD69u2LZ8+eSYufhYaGYtq0abLPYiX343+Kt7c3IiMjsXr1aty4cQMA0LZtW9nHM6a7c+eO3BEyZWxsjNevX2tsT0hIgJGRkQyJ/uePP/5Av379MG/ePKlYOHfuHPr3748///xT1mxA2kKcTZs2xevXr7Fp0yasXbsW5cuXh4eHBzp06CDLhcvBgwdj1qxZmDt3ruz/9zNz586dTM8xjI2NZesumq5z586IjY3F6NGjdWIRzIyGDx+OgQMHqhWD6duHDRsmW2GzaNEiWFhY4MiRIzhy5IjafSqVSuuFzcWLFwGkDWO4fPmy2v8wIyMjFCtWTLsFtNbahrRIVxeb3LZtm7C2thaTJ08WZmZm4o8//hDdu3cXRkZGIiQkRNZsn+qGc+vWLdm74dja2kpz8Gd0/Phx2dd8qFKlipg9e7YQ4n/ztguRtuZDnTp15IwmrKysPtmlxMLCQoZEaZycnMS1a9eEEGmLiG7fvl0IkbbmiNyLmv71118id+7cUrcld3d3sWLFClkz0b9z4MABMWLECNGtWzfRpUsXtZtcOnbsKIoUKSJOnTolUlNTRWpqqjh58qTw9vYWnTp1ki2XEOpr7BgZGal9rUvr7WR09epVUbx4caGnpyfL4zdp0kRYW1sLd3d30aBBA9G0aVO1m9wKFSoktm3bJoRQ7wY/e/ZsUaJECTmjCQsLC3Hx4kVZM3yKsbFxpt25b968Kft5kS7q3LmzePXqldwxsmdXtJYtWyIkJAS9evWSO4qaxo0bY+fOnRg/fjzMzc0xZswYlCxZUtYmzXReXl7YsGEDRo4cqbZ9/fr1ss/F36BBA/Ts2RNLlixB2bJlAaR1p+rVqxcaNWoka7aJEyeiXr16uHbtGpKTkzFr1ixcu3YNJ06c0LiSom2+vr6YNGkS1q5dK02ykJKSgkmTJqFy5cqy5SpfvjyOHz+OQoUKwd/fH4MHD8bly5exZcsWlC9fXrZcANC7d2/07t0bz549g6mpqTQVtS6Ijo7GsmXLEB0djVmzZsHR0RF79+5F3rx5UaRIEVkyTZo0CU5OTujatava9qVLl+LZs2eyt5oHBQVh/PjxKF26tE5dDZ49ezY6deqEChUqSN1IkpOT0ahRI8yaNUvWbLraOvixd+/eYceOHVizZg327dsHJycnDB06VJYsNjY2aNq0qSyP/TUGDRqEPn364N27dxBC4MyZM1i7dq009b+cXFxcNLqf6QoHBwdcunRJ4xzo0qVLOjERj67Nxrps2TK5IwDIprOiTZo0CdOnT0f9+vV1ov+hEmzevBmtW7dGzZo11fqShoaGYsOGDbL+046Li0OnTp2wc+dOjZOA5cuXq814JIfo6GhMnjxZbd72YcOGyb5A57Vr1+Dr6wsbGxtUqVIFAHDs2DHEx8fj4MGD8Pb2liXX7du3kZCQAB8fHyQmJmLw4ME4ceIE8uXLh+nTp8s2haYuO3LkCOrVq4dKlSrh6NGjuH79Ojw8PDB58mScO3cOmzZtkiWXm5sb1qxZg4oVK6ptP336NNq0aSN7V7BcuXJh6tSp6Nixo6w5PiUyMlLqwleoUCGdHqehK4KDg7FmzRps27YNBgYGaNGiBdq3bw9fX1+5o+k0XZ36PyQkBNOmTcPChQvh5uYma5aPjR8/HjNmzMDw4cOl/3FhYWGYMmUKBg0ahNGjR8uSS5dmY23WrBmWL18OKysrNGvW7LP7btmyRSuZsmVho8uLTeqy8+fPY8aMGWqLsg0ePFj28T/peBLw7R4+fCgtlmVqagofHx/07dtXbbzSf1nJkiURGhoKW1tblChR4rNX9OVc9KxChQpo2bIlBg0aBEtLS4SHh8PDwwNnzpxBs2bNZJuK2sTEBNevX9f4n3v79m0ULlwY7969kyVXuhw5cuDMmTOyTp+sBPHx8dIUu+lT7n6K3FPxmpmZoUGDBmjfvj38/f01LlySuuTkZKxZswZ16tSBk5OTzk39b2trizdv3iA5OVmnJkYB0saMzJw5E9OmTcPDhw8BpBWEQ4cORWBgoGwtwP3790dYWBhmzpyJunXrIiIiAh4eHti+fTvGjRsnjXnRhi5dumD27NmwtLREly5dPruvtlp0smVho0tsbW2/+o9fzjcwfb+UlBRs3bpVKggLFy6Mxo0b60TTsK6Ki4vDpk2bEB0djaFDh8LOzg4XLlyAk5MTcufOrbUcQUFBGDp0KMzMzDBu3LjPvlfHjh2rtVwfs7CwwOXLl+Hu7q5W2MTExKBgwYKyFRD58uXD2LFj0aFDB7Xtq1atwtixY2W/iDRs2DBYWFjIdmU1o0GDBmHChAkwNzeXZhH6FG2v5ZRx/Qk9Pb1M3wdC5tXW071+/RqWlpayZgCUc1EESCsGr1+/rpOt4emtDp/SqVMnLSX5vPTJPnThb8/V1VWajTXj50FUVBRKliz5xYsTP4IQAvfu3YODg4PsE8fwzOsH0+X+yrp8lU6XTwIyunr1Kho1aoTHjx9Li9lNmTIFDg4O2Llzp9a7e0VERMDb2xt6enqIiIj47L4+Pj5aSqUuIiICNWvWhLW1NWJiYtCjRw/Y2dlhy5YtiI2NxcqVK7WWJWOxMm7cOK097reysbHBo0ePNFpGLl68qNVC8GM9evTAgAED8OHDB7WZ5H755RcMHjxYtlzp3r17h0WLFuHAgQPw8fHRuBqszf8dFy9elKZR1uYV1a9x8OBBqRV32bJlcHFx0Vj8ODU1FbGxsXLEU2NpaamxYHP6xSRtLtjcuHFjGBsbS1/ryvitzJQtWxYXL17UycJGVwqXL9GFgiadLs7GKoSAl5cXrl69Kvu47GzTYqOUE2FdostX6fz8/LB161bY2NjAz8/vs/seOnRIS6k0VahQAQ4ODlixYgVsbW0BAP/88w86d+6MZ8+e4cSJE1rNo6enh8ePH6u9ppm9xeW88lqzZk2ULFkSU6dOVbvadOLECbRr1w4xMTGy5OrevTs6dOiAatWqyfL4nzNkyBCcPn0aGzduRP78+XHhwgU8efIEAQEBCAgIkK01SQiB4cOHY/bs2Xj//j2AtO5pw4YNk229sIw+979DpVLh4MGDWkyjDDqzevgnREVFwd/fHw8ePJAuJt28eRMuLi7YvXs3ux1mYsOGDRgxYgQGDhyIUqVKwdzcXO1+bV/k0uWLqkpoifP19UXLli3Rr18/WFpaIiIiAu7u7ujXrx8iIyOxb98+WXIVKVIES5YskX0SoGxT2CjhRHjPnj3Q19dHnTp11LaHhIQgJSUF9erV02qeI0eOoFKlSjAwMPjiDF5Vq1bVUiplMTU1xblz5zRmpbpy5QrKlCmDt2/fajXP3bt3kTdvXqhUKty9e/ez+8p19c7a2hoXLlyAp6enWmFz9+5dFChQQLZuVY0bN0ZwcDAcHBzQpk0bdOjQQVp0Um7v379Hnz59sHz5cqSkpMDAwAApKSlo164dli9frtUr1ZlJSEjA9evXYWpqinz58klXsilzXbt2xaxZszSuAicmJqJfv35YunSpTMnSLo48efIEDg4Oatvv3r2LwoULy77uib+/P4QQWL16tcaCzXp6erIs2Ny1a1dUrVpVo/UhPj4eAwYMkPX1BNJe04+lX/SS4yKXLl9UVUL35OPHj6NevXro0KEDli9fjp9++kltNtZSpUrJkmvnzp2YOnUq5s+fL9vkREA2KmyUwMfHB5MnT4a/v7/a9n379mHYsGEIDw+XKRkQGxsLFxcXjTdxer/JvHnzypRMt08CihUrhhkzZkjdcNIdPHgQ/fv3x+XLl2XJ9eHDB/z0008YPXr0ZyfTkIOjoyOCg4NRokQJtcJm//796Nq1K+7duydbtn/++QcbN27EmjVrcOzYMRQsWBDt27dHu3btdGLGnnv37uHy5ctISEhAiRIlZG/yTxcVFYXo6Gj4+vrC1NRUOinRFbqW71OtIs+fP0fOnDmRnJys9UzpPR1mzZqFHj16ZLp6uL6+PsLCwrSeLSNzc3NpxfWMwsPDUalSJSQkJGg9k56eHkxNTdGtWzfMnDlTKiSePHkCZ2dn2Vu5dO0iFy+q/nu6OBtrxokgjIyMNMbaaGscebYsbFauXIkyZcqgUKFCatvfvXuHDRs2ICAgQJZcpqamuH79usYJUkxMDIoUKSLrlTBd7n6giycB6fbs2YNffvkF48aNk5pfT506hfHjx2Py5Mlq68Vou0nd2toaly5d0rnCpnv37njx4gU2bNgAOzs7REREQF9fH02aNIGvr6/OjEu7f/8+1q5di6VLlyIyMlLWv7Px48djyJAhaiebAPD27Vv88ccfsnX7evHiBVq1aoVDhw5BpVIhMjISHh4e6Nq1K2xtbTFt2jRZculqvvj4eAghYGtri8jISLVWkZSUFOzcuRPDhw+XZmDSpvSeDkeOHEGFChU0Vg93c3PDkCFDZC+m7ezssGvXLo0pxsPCwtCwYUNZJuHR09PDwYMH0b17d7i7u2PDhg2wtbXVmcKGvo+HhwfOnj2LHDlyqG2Pi4tDyZIlZZ8cRdfoykQQ2bKw0dPTg7m5OZYvX47mzZtL2+X+J5MzZ06sWbNG4+r+gQMH0K5dOzx9+lSWXIBudj/Q5ZOAdBmb+NOvAKe/pTJ+L0eTeqdOnVC8eHEMHDhQq4/7Ja9evUKLFi1w7tw5vH79Gs7Oznj8+DEqVKiAPXv2aPT/lsOHDx+we/du/N///R92794NOzs7PHjwQLY8unrhISAgAE+fPsXixYtRqFAhqfUtODgYgwYNwtWrV2XJpav5PtXtJp1KpUJQUBB+/fVXLaZS16VLF8yaNUv2aZ0/JSAgABcuXNBYsLlHjx4oVaoUli9frvVM6WMb9fX10bx5czx48AA7duyAnZ2dThQ2X5qQRdsXe780sU1Gck1yA6iPWc3oyZMncHFxkcYVapuufh7oimw7K1pQUBA6duyIy5cv68xsR40bN8aAAQOwdetWaYBjVFQUBg8ejEaNGsmSKb37gUqlwujRozPtflC8eHFZstnY2EClUkGlUiF//vwa96efBMhJzokLviRfvnwYP348wsLCMh0wKtdCtdbW1ti/fz+OHz+OiIgIqRm9Zs2asuTJ6NChQ1izZg02b96M1NRUNGvWDLt27dK4GKFtn+o6FR4eLuuaRCEhIQgODkaePHnUtufLl++L3V+0QdfyHTp0CEIIVK9eHZs3b1Z77YyMjODq6gpnZ2et58pIV1YP/5TZs2ejU6dOqFChgjTL3YcPH9C4cWPZWnvT35s5cuTAgQMH0KtXL1SoUAF//PGHLHk+1r9/f7XvP3z4gDdv3sDIyAhmZmZaL2yKFy+uNsbnc+Q4Sd+xY4f0dXBwsNoi4CkpKQgNDZW1J8Sn2iOSkpLUWlrl8PGMhUWKFEGjRo20Og402xY2HTp0QMWKFdG0aVNcuXIFq1atkjsSpk6dirp166JgwYLSB+39+/dRpUoV/Pnnn7JkSp92VAiBy5cva3Q/KFasGIYMGSJLNiWcBOhy/98lS5bAxsYG58+fx/nz59XuU6lUshU26SpXrqzWVU9uuXPnxsuXL1G3bl0sWrQIDRs2lH0QfPo6WOnFfcaTgJSUFCQkJKBXr16y5UtMTNToHgek9aWW+7kDdC9f+v+LO3fuwMXFJdNB3fR5NjY22L59O6KiotQWk5ZzweaMJ5oGBgZYvHgxChcujJ9//lm2TBn9888/GtsiIyPRu3dvDB06VOt57ty5I3198eJFDBkyBEOHDkWFChUAACdPnsS0adMwdepUrWcDgCZNmgBI+5z8uPuUoaEh3NzcZOlmO3v2bCnX4sWLYWFhId2XkpKCo0ePomDBglrPlS6zGQsnTZqk9RkLs2VXtIzNdLGxsWjUqBFUKhUWLFiAihUrytpMJ4TA/v371VaC9/X1lS1POl3ufpBxpi9doIS1Yj72cfc4bUv/h/w15Cq4/v77b7Rs2RI2NjayPH5mVqxYASEEunbtipkzZ6pdOUwf95B+MiAHf39/lCpVChMmTJCmHXV1dUWbNm2QmpqKTZs2yZZN1/P9888/WLJkidpaLF26dJG1BU5XfWkJh4zkWM4h42D4jA4cOICwsDBZF/f9nHPnzqFDhw64ceOGbBnKli2LcePGaUyqtGfPHowePVrjopw2ubu74+zZs7C3t5ctQ0bprUR3795Fnjx51FpB0j8Pxo8fj3LlysmST1dmLMyWhc3H/SLfvHmD9u3bIzQ0FImJif/5/odfkj4rlYuLi8xJ0ixbtgwWFhZo2bKl2vaNGzfizZs3Wl/gSwlrxaRbsmQJZsyYgcjISABpXXAGDBiA7t27azXHx832z549w5s3b6QiIi4uDmZmZnB0dJRlQOaHDx9gamqKS5cuyTpN5accOXIEFStW1FhgUm5XrlxBjRo1ULJkSRw8eBCNGjXC1atX8fLlS4SFhcm+poiu5jt69CgaNmwIa2trlC5dGgBw/vx5xMXFYefOnTpxsUuXfGkJh3Rcm+jbXLp0Cb6+vrKsVJ/O1NQUFy5c0Jjs6fr16yhZsqTWl0xQAj8/P2zZskVaO09X6MqMhdmyK9rYsWPVmujMzMywdetWjB07FkePHtVqltmzZ6Nnz54wMTH54lVrObsGJScnIygoCLNnz5b++CwsLNCvXz+MHTtW1hOqSZMmYeHChRrbHR0d0bNnT60XNnfu3JEmMsjYpK5rxowZg+nTp6Nfv35qTfwDBw5EbGwsxo8fr7UsGZ+nNWvW4K+//sKSJUvUFtjr0aMHfvrpJ61lysjQ0BB58+aVvRD9lKpVqyI1NRW3bt3C06dPkZqaqna/XCfC3t7euHXrFubOnQtLS0skJCSgWbNm6NOnD3LlyiVLJiXk69OnD1q3bo358+dLV11TUlLw888/o0+fPrJNE6+rdHksY7r79+9jx44diI2N1RhULvei4BnHjABpLfiPHj3C3LlzUalSJZlSpSlUqBAmTZqExYsXS13h379/j0mTJmkUO3JITEzEkSNHMn1d5Tpn09X3g7GxMV6/fq2xPSEhQbtjfwT9UG5ubuL58+fS15+6ubu7y5qzV69ewtHRUSxYsECEh4eL8PBwsWDBApEzZ07Rq1cvWbMZGxuLO3fuaGy/c+eOMDEx0X4ghbC3txdr1qzR2L5mzRqRI0cOGRKl8fDwEBcuXNDYfu7cOeHm5iZDojSLFy8W/v7+4sWLF7Jl+JSTJ08Kd3d3oaenJ1QqldpNT09P7nj0jUxMTMSNGzc0tt+4cYP/0xTowIEDwszMTHh7ewsDAwNRvHhxYWNjI6ytrYWfn5/c8TL9n+Hk5CTatm0rHj58KGu206dPC0dHR+Hg4CBq1KghatSoIRwcHISjo6M4ffq0rNkuXLggcubMKaysrIS+vr5wcHAQKpVKmJuby3rOlpycLBYvXizatm0ratSoIfz8/NRucunYsaMoUqSIOHXqlEhNTRWpqani5MmTwtvbW3Tq1ElrObJli026a9euaVTZKpUKDRs21FqGjFeqdfnq/po1a7Bu3TrUq1dP2ubj4wMXFxe0bdsW8+fPly2bo6MjIiIiNNb/CQ8P15hfXtsmTZoEJycndO3aVW370qVL8ezZMwwbNkymZGndq9K7uWRUqlQpWddkefToUaaPn5KSgidPnsiQKM3cuXMRFRUFZ2dnuLq6aswid+HCBZmSAb169ULp0qWxe/du5MqVS9bxZkqZqjXdu3fvEBERkWlLl1yzUZYsWRLXr1+XWizTXb9+HcWKFZMlE32/ESNGYMiQIQgKCoKlpSU2b94MR0dHtG/fHnXr1pU7nsbfvS4pW7Ysbt++jdWrV0tjfVq3bo127drJPvX/wIED0bBhQyxYsADW1tY4deoUDA0N0aFDB42Z5rSpf//+WL58OerXrw9vb2+dGX+c2YyFycnJaNSoEWbNmqW9IForobQoOjpa+Pj4SFcmMl6lkPPqZlBQkEhMTNTY/ubNGxEUFCRDov9xcHAQ165d09h+7do1YW9vL0Oi//nll1+Eq6urOHjwoEhOThbJyckiNDRUuLq6isGDB8uazdXVVYSFhWlsP3XqlKytD0II0bdvXzFw4ECN7YMHDxY///yzDInSNGjQQJQoUUKcP39e2nbu3DlRsmRJ0bBhQ9lyjRs37rM3OZmZmYnIyEhZM6TL+H81/X9qZv9ndaElae/evdJVVl1q6Vq3bp3Imzev+OOPP8SxY8fEsWPHxB9//CHc3NzEunXrpFbz8PBw2TLS17OwsBBRUVFCCCFsbGzElStXhBBCXLp0Sbi6usqYLI0un3voMmtra6ll1draWjpHOnXqlChQoIBsuXLkyCF2794t2+N/ya1bt8SOHTvEjh07ZPncypaFTYMGDUTjxo3Fs2fPhIWFhbh27Zo4duyYKFu2rDh69KhsufT09MSTJ080tj9//lz2k4CgoCDRtm1b8e7dO2nbu3fvRPv27WU/qUtKShKtWrUSKpVKGBoaCkNDQ6Gvry+6dOkikpKSZM1mbGwsbt++rbE9OjpaGBsby5Dof/r27SusrKxEkSJFRLdu3US3bt2Et7e3sLKykoqe9Js2PX36VNSrV0+oVCphZGQkjIyMhEqlEvXq1ROPHz/Wahal8PPzE3v37pU7hhBCiJiYGOm2detW4enpqdGFNV++fGLr1q1yRxVeXl7i559/1rm/q8wKrY+LLrmLL/p6Tk5O0klvoUKFxPbt24UQaYWNubm5nNGEELp97pHu6tWrYu/evWL79u1qNznZ29uLW7duCSGEyJcvn9i3b58QQojr168LMzMz2XLlypVL3Lx5U7bH/5Rjx47JHUEIkU27op08eRIHDx6Evb099PT0oKenh8qVK2PSpEkIDAyU1m7RNqGji+wBaXPJh4aGIk+ePFJXiPDwcLx//x41atRAs2bNpH23bNmi1WxGRkZYv349JkyYIE2TXbRoUbi6umo1R2ZcXFwQFhamMetXWFiY7GvsXLlyBSVLlgQAREdHAwDs7e1hb2+PK1euSPtpuxnbwcEBe/bsQWRkpDTVbcGCBTNdhFXb4uLisGnTJkRHR2Po0KGws7PDhQsX4OTkhNy5c8uWq1+/fhg8eDAeP36MokWLakzmoc0uXxnfdy1btsTs2bPVpmpN78I6evRoaT0IuTx58gSDBg2Ck5OTrDk+psvdkunblS9fHsePH0ehQoXg7++PwYMH4/Lly9iyZQvKly8vdzydPve4ffs2mjZtisuXL6vNMJqeV84JXUqUKIGzZ88iX758qFq1KsaMGYPnz59j1apVss6eOXjwYMyaNQtz587VmW5oAFC9enXkzp0bbdu2RYcOHVC4cGFZcmTLwiYlJQWWlpYA0k7kHj58iAIFCsDV1RU3b97Ueh5dX2QPSFv0rHnz5mrbdGW653T58+fXiZPfjHr06IEBAwbgw4cP0ur0oaGh+OWXXzB48GBZs+nSzCmDBg3ChAkTYG5unumaFIcPH5a+lmsGoYiICNSsWRPW1taIiYlBjx49YGdnhy1btiA2NhYrV66UJRcA6b2ZcSxXxpW75frwv3z5cqYrcLu7u+PatWsyJFLXokULHD58WPZppz+mCxdlKOtMnz5dmk00KCgICQkJWL9+PfLlyyfrjGhKOPfo378/3N3dERoaCnd3d5w5cwYvXrzA4MGDZVu4PN3EiROlWb5+//13BAQEoHfv3siXLx+WLl0qW67jx4/j0KFD2Lt3L4oUKaJxoUvbF5/TPXz4EOvWrcPatWsxefJk+Pj4oH379mjbtq20KL02ZMt1bKpUqYLBgwejSZMmaNeuHf755x+MGjUKixYtwvnz59WuVmuDri+ypwS6OpWmEALDhw/H7NmzpVwmJiYYNmwYxowZI1suXePn54etW7fCxsbms2tSyLkORc2aNVGyZElMnToVlpaWCA8Ph4eHB06cOIF27dohJiZGllxA2oJsnyPXiXLJkiXh7e2tMVVr9+7dceXKFVknXADS1jBr2bIlHBwcMm3p0uZ0rTt27EC9evVgaGioMf3ux+Sa1ICyFyWce9jb2+PgwYPw8fGBtbU1zpw5gwIFCuDgwYMYPHiwbD1sdFmXLl0+e/+yZcu0lOTT7ty5gzVr1mDt2rW4ceMGfH19tfbZni0Lm+DgYCQmJqJZs2aIiopCgwYNcOvWLeTIkQPr16+XrqxrU3JyMlavXo3q1avrXEuIrgsNDUWjRo3g4eGBGzduwNvbGzExMRBCSAvvyS0hIQHXr1+Hqakp8uXLB2NjY7kj0TeytrbGhQsX4OnpqVbY3L17FwUKFMC7d+/kjqhzzpw5g4YNG0IIIXWHi4iIgEqlws6dO1G2bFlZ8y1ZsgS9evWCiYkJcuTIoXbFWqVSaXUx2I8X9v0UXVjYl7KXI0eOoFKlSjAw0L1OOra2trhw4QLc3d3h6emJxYsXw8/PD9HR0ShatCjevHkjd0T6TikpKdi7dy9Gjx6NiIgIrf1f072/8ixQp04d6WsvLy/cuHEDL1++lJpl5WBgYIDevXtLYwp0QcmSJREaGgpbW1uUKFHis8+NnFdedX0qTQB4/PgxXr58CV9fXxgbG3+yTzPpLmNj40xX4L5165a0IKucoqOjMXPmTOl/SOHChdG/f39Zu1np8lStAPDrr78iKCgIw4cP/2wxoQ0Zp9zV5el36dt96txCpVLBxMQEXl5e6Ny58xevtP8oiYmJCA0NVTs3AtIuAqempqot86Bt3t7eCA8Ph7u7O8qVK4epU6fCyMgIixYtgoeHh2y5AODFixcYM2YMDh06lOl08S9fvpQpWZpnz55JwysKFCigE59TQNoY49WrV2PTpk149+4dGjdujEmTJmnt8bNlYZMZuQfIAWknARcvXtSZ/tWNGzeWWhbkHuT7OdevX8fatWsBpBWIb9++hYWFBcaPH4/GjRujd+/esmV78eIFWrVqhUOHDkGlUiEyMhIeHh7o1q0bbG1tMW3aNNmy0bdp1KgRxo8fjw0bNgBIOymJjY3FsGHDNMafaVtwcDAaNWqE4sWLSyuFh4WFoUiRIti5cydq1aolWzZzc3P07NlTtsf/nPfv36N169ayFzUZffjwAXXr1sWCBQuQL18+ueNQFhgzZgx+//131KtXT2qlPHPmDPbt24c+ffrgzp076N27N5KTk9GjRw+t5xs+fDgmT56ssT29K7Wchc2oUaOQmJgIABg/fjwaNGiAKlWqSD1s5NSxY0dERUWhW7ducHJy0pmLlYmJiejXrx9WrlwpFVv6+voICAjAnDlzYGZmJkuuESNGYN26dXj48CFq1aqFWbNmoXHjxlrPky27ojVt2vSLV0/atWunsTjaj7ZhwwaMGDECAwcORKlSpTSuaMq1mF1KSgrCwsLg4+MDGxsbWTJ8Ts6cOXHo0CEUKlQIhQsXxuTJk9GoUSOEh4ejUqVK0qBNOQQEBODp06dYvHgxChUqJHVfCg4OxqBBg3D16lXZstG3efXqFVq0aIFz587h9evXcHZ2xuPHj1GhQgXs2bNH1haIEiVKoE6dOhonJ8OHD0dISIjsY1l01cCBA+Hg4ICRI0fKHUWNg4MDTpw4wcImm2jevDlq1aqlMRB/4cKFCAkJwebNmzFnzhwsWrQIly9f1no+U1NTXL9+XWOR65iYGBQpUkQqLHSF3D1s0llaWuL48eM6t2juTz/9hAMHDmDu3LnSha7jx48jMDAQtWrVkm1B9UqVKqF9+/Zo1aoV7O3tZckAZNPCpnPnzti2bRtsbGxQqlQpAGldqeLi4lC7dm2Eh4cjJiYGoaGh0h+FNuhyv2oTExNcv3490xmO5NakSRPUr18fPXr0wJAhQ7B9+3Z07twZW7Zsga2tLQ4cOCBbtpw5cyI4OBjFihVTG5dx+/Zt+Pj4yFp00fcJCwtDeHg4EhISULJkSdSsWVPuSDAxMcHly5c1ToRv3boFHx8fjv/5hMDAQKxcuRLFihWDj4+PxuQBck08MnDgQBgbG2d6FZ2Ux8LCApcuXYKXl5fa9qioKBQvXhwJCQmIjo6Gj4+PLEVEzpw5sWbNGo3xxQcOHEC7du3w9OlTrWf6WFRUFKKjo+Hr6wtTU1Od6M5dpkwZzJkzRyem7M7I3t4emzZtQrVq1dS2Hzp0CK1atcKzZ8/kCaYjsmVXtJw5c6Jdu3aYO3euVEykpqaif//+sLS0xLp169CrVy8MGzYMx48f11ouXV67wNvbG7dv39bJwkZXp9IE0pqEM2tmffnyJScQUKhKlSpJFzzi4uLkDfP/OTg44NKlSxqFzaVLl+Do6ChTKt13+fJllChRAgA0ZsOU86QpOTkZS5cuxYEDBzJtvZf7/xp9Gzs7O+zcuRMDBw5U275z506pG3xiYqK0DIW2NW7cGAMGDMDWrVulMXlRUVEYPHiw7DPw6XJ37r/++gvDhw/HmDFj4O3trXFhxMrKSpZcb968yXRtLkdHR52YbOHatWuZzmCrrb+1bNli4+DggLCwMI01T27duoWKFSvi+fPnuHz5MqpUqSLLiUtmL7pKpULDhg21niXdvn37MGLECEyYMCHTD1ptv4Fnz56Nnj17wsTEBLGxsXBxcZH96k1m/P39UapUKUyYMAGWlpaIiIiAq6sr2rRpg9TUVGzatEnuiPSVpkyZAjc3N7Ru3RoA0KpVK2zevBk5c+bEnj17ZO2OMH78eMyYMQPDhw9HxYoVAaS1LE2ZMgWDBg3C6NGjZctG305Xpzyn7/P333+jd+/e8Pf3l8bYnD17Fnv27MGCBQvQrVs3TJs2DWfOnJFl3MirV69Qt25dnDt3TlpP5P79+6hSpQq2bNkiaxd0Xe7OHRkZiXbt2ml09ZV7/bAaNWogR44cWLlyJUxMTAAAb9++RadOnfDy5UvZerHoymKr2bKwsbW1xYoVKzSqwx07dqBTp074559/EBkZibJly+Kff/7RWi5dedEzk7GbXMYCQq43sIGBAR4+fAhHR0fo6+vj0aNHOnll+urVq6hevbo07XSjRo1w9epVvHz5EmFhYTq3MCB9mru7O1avXo2KFSti//79aNWqFdavX48NGzYgNjYWISEhsmUTQmDmzJmYNm0aHj58CABwdnbG0KFDERgYKGvRHxcXh02bNiE6OhpDhw6FnZ0dLly4ACcnJ+TOnVu2XBnpYjcXyl7CwsIwd+5ctVmq+vXrJ12IkJsQAvv370d4eDhMTU3h4+MDX19fuWPpdHfusmXLwsDAAP3798908oCqVavKkuvy5cuoW7cukpKSpAtu4eHhMDY2RkhICIoUKSJLroYNG0JfXx+LFy/OdLHVKlWqaCVHtuyK1rFjR3Tr1g0jR45EmTJlAKRdPZk4cSICAgIApM3rru0X/+MVdk+fPo2XL1/qxAq7urRKPZB20rZ582b4+/tDCIH79+9/chxB3rx5tZwuzYcPHxAYGIidO3di//79sLS0REJCApo1a4Y+ffogV65csuSi7/P48WNpjaldu3ahVatWqF27Ntzc3FCuXDlZs6lUKgwcOBADBw6UVsKWq1tLRhEREahZsyasra0RExODHj16wM7ODlu2bEFsbCxWrlwpaz5d7eby6tUrpKSkaMzW+fLlSxgYGMjWxYW+X8YurLpIpVKhdu3aqF27ttxR1Ohyd+4rV67g4sWLWp9o6kuKFi2KyMhItWn227Zti/bt28PU1FS2XCdPnsTBgwdhb28PPT096OnpoXLlypg0aRICAwO1tthqtixsZsyYAScnJ0ydOhVPnjwBADg5OWHgwIEYNmwYAKB27dpaXwPl4xddX19flhc9M3JdefiUUaNGoV+/fujbty9UKpVUoGYkd3OwoaEhIiIiYGtri19//VWWDJR1bG1tce/ePbi4uGDfvn347bffAKT9ncm9YOKdO3eQnJyMfPnyqRU0kZGRMDQ01JjtSFsGDRqEzp07Y+rUqWq5/P390a5dO1kyZTRw4EAYGhoiNjYWhQoVkra3bt0agwYNkq2wadOmDRo2bIiff/5ZbfuGDRuwY8cO7NmzR5Zc9O+9e/dOY2yBHIVqxu7cs2fP/uy+gYGBWkqlqUqVKli5ciUmTJgAIK0AS01NxdSpUz/bZVMbSpcujXv37ulcYTNp0iQ4OTlpTB2+dOlSPHv2TDrP1baUlBTpc8De3h4PHz5EgQIF4OrqKrVkaoXI5l69eiVevXoldwwhhBA2Njbi9u3bQgghPDw8xMGDB4UQQkRFRQlTU1M5o4mlS5eKDRs2aGzfsGGDWL58uQyJhIiPjxeXL18WKpVKhIaGikuXLmV6k9OAAQPEsGHDZM1AWaNPnz7C1dVV1KxZU+TIkUO8fv1aCCHE2rVrRYkSJWTN5uvrm+n7cNWqVaJq1araD/T/WVlZiaioKCGEEBYWFiI6OloIIURMTIwwNjaWLVc6Jycn6X9ExnzR0dHC3Nxctly2trbi2rVrGtuvX78u7OzsZEhE/0ZiYqLo06ePcHBwEHp6eho3Obi5uYnnz59LX3/q5u7uLku+dFeuXBGOjo6ibt26wsjISLRo0UIUKlRIODk5Sf9b5LJhwwZRuHBhsWzZMnHu3DkRHh6udpOLq6urCAsL09h+6tQp4ebmJkOiNJUrVxZbt24VQgjRtm1bUbduXXH8+HEREBAgihQporUc2bLFJiNdatLX5RV2J02ahIULF2psd3R0RM+ePdGpUyetZ7K0tIS3tzeWLVuGSpUqyd4snRnObpR9zJgxA25ubrh37x6mTp0KCwsLAMCjR480rqxr28WLFzPt5lK+fHn07dtXhkRpjI2NER8fr7H91q1bOrEKtq52c0lKSkJycrLG9g8fPuDt27cyJKJ/Y+jQoTh06BDmz5+Pjh07Yt68eXjw4AEWLlwo25TeGWdhzfi1+Ghsr5x0vTt3+kQyXbt2lbalj4+Ws7fI48ePM31uHBwc8OjRI61miYiIgLe3N/T09DBq1ChpVjY5F1vNtoXNpk2bpEG/HzcLy7WYnS6vsBsbG5vpVM+urq6IjY2VIdH/VK9eHc+ePZNmczlz5gzWrFmDwoULy77i+ZUrV1CyZEkAaSdzGenCBwd9PUNDQwwZMkRj+8dTuMpBpVJJY2sySh+rIZdGjRph/Pjx2LBhA4C0nLGxsRg2bBiaN28uW650utrNpWzZsli0aBHmzJmjtn3BggXS2mukHDt37sTKlStRrVo1dOnSBVWqVIGXlxdcXV2xevVqtG/fXu6IWLJkCWbMmIHIyEgAQL58+TBgwAB0795dtky63p1bV5focHFxQVhYmMY5W1hYGJydnbWapUSJEtLkTr1798bZs2cBAF5eXrhx44Y8i61qrW1Ii2bNmiUsLCxE3759hZGRkfjpp59EzZo1hbW1tRg5cqTc8dS8ePFCpKamyh1DuLi4iO3bt2ts37Ztm8idO7cMif6ncuXKYuXKlUIIIR49eiQsLS1FhQoVhL29vQgKCpI1G5E2NGjQQLRs2VIkJydL25KTk0Xz5s1F3bp1ZcsVFxcnatasKWxsbIS+vr5wcXERhoaGwtfXVyQkJMiWK93ly5d1spvL8ePHhYmJiahSpYoYN26cGDdunKhSpYowMTERR48elS0XfR9zc3Nx9+5dIYQQuXPnFqdPnxZCCHH79m1ZuzymGz16tDA3NxfDhw8X27dvF9u3bxfDhw8XFhYWYvTo0bJm09Xu3O/fvxceHh6ZdhmV25QpU0SOHDnE0qVLRUxMjIiJiRFLliwROXLkEBMnTtRqFjs7O3Hq1CkhhBAqlUo8ffpUq4+fmWzZYvPXX39h0aJFaNu2LZYvX45ffvkFHh4eGDNmDF6+fCl3PDUfz4ojl7Zt2yIwMBCWlpbSFJBHjhxB//790aZNG1mzXblyRVobYMOGDShatCjCwsIQEhKCXr16YcyYMbLmI/rRpkyZAl9fXxQoUECaMvPYsWOIj4+Xdc0Ta2tr7N+/H8ePH0dERAQSEhJQsmRJ1KxZU7ZMGXl7e+PWrVuYO3euTnVzqVSpEk6ePIk//vgDGzZskKbfXbJkicYirKT7PDw8cOfOHeTNmxcFCxbEhg0bULZsWezcuVPWNWLSzZ8/H3///Tfatm0rbWvUqBF8fHzQr18/jB8/XrZsutqd29DQ8JMzscpt6NChePHiBX7++WepR5KJiQmGDRuGESNGaDVL8+bNUbVqVeTKlQsqlQqlS5eGvr5+pvvevn1bK5my5To2ZmZmuH79OlxdXeHo6Ij9+/ejWLFiiIyMRPny5fHixQu5I+qc9+/fo2PHjti4cSMMDNLq3dTUVAQEBGDBggUwMjKSLZuFhQWuXLkCNzc3NGrUCJUqVcKwYcMQGxuLAgUKsE86/Sc8fPgQc+fOVVuHom/fvjpzcYTov2rGjBnQ19dHYGAgDhw4gIYNG0IIgQ8fPmD69Ono37+/rPlsbGxw9uxZjaL51q1bKFu2rCwLlafT5cVqJ06ciFu3bmHx4sXSeZEuSUhIwPXr12Fqaop8+fLJNm5w3759iIqKQmBgIMaPH//JpQi09T7IloWNh4cHNm/ejBIlSqB06dLo0aMHfvrpJ4SEhKBNmzY612qjSyIjI3Hp0iWYmpqiaNGicHV1lTsSypUrBz8/P9SvXx+1a9fGqVOnUKxYMZw6dQotWrTA/fv35Y5ICpeSkoKwsDD4+PjoxBVWJTl79iwOHTqEp0+fIjU1Ve0+uSfP2LdvHywsLFC5cmUAwLx58/D333+jcOHCmDdvHmxtbWXJdeHCBRgaGqJo0aIAgO3bt2PZsmUoXLgwxo0bJ+uFJPr37t69i/Pnz8PLyws+Pj5yx0G/fv1gaGio8X4cMmQI3r59i3nz5smUTLc1bdoUoaGhsLCwQNGiRTVak7Zs2SJTMt3UpUsXzJ49W/Y11rJlYdO9e3e4uLhg7NixmDdvHoYOHYpKlSrh3LlzaNasGZYsWSJ3RJ2XkpKCy5cvw9XVVbYP/3SHDx9G06ZNER8fj06dOmHp0qUAgJEjR+LGjRv850JZwsTEBNevX890Eg3K3MSJEzFq1CgUKFBAY2Vuua+2AmkL2U2ZMgX+/v64fPkySpcujcGDB+PQoUMoWLAgli1bJkuuMmXKYPjw4WjevDlu376NwoULo1mzZjh79izq16+PmTNnypKLsqd+/fph5cqVcHFxQfny5QEAp0+fRmxsLAICAmBoaCjtK/fFCF3SpUuXz94v1/8P+rxsWdikpqYiNTVVajpcv349wsLCkC9fPvTq1UvtTUxpBgwYgKJFi6Jbt25ISUlB1apVceLECZiZmWHXrl2oVq2arPlSUlIQHx+vVmTFxMTAzMwMjo6OMiaj7KJ06dKYMmUKatSoIXcUxXBycsKUKVPQuXNnuaNkKmM31nHjxuHKlSvYtGkTLly4AH9/fzx+/FiWXNbW1rhw4QI8PT0xZcoUHDx4EMHBwQgLC0ObNm1w7949WXLR99PllsuvnQFQFy5GEP1butdpMAvo6enh/fv3uHDhAp4+fQpTU1NpMOu+ffvQsGFDmRPqnk2bNqFDhw4A0qauvH37Nm7cuIFVq1bh119/RVhYmKz59PX1NVqO5FptnbKn3377DUOGDMGECRMyHcSqS2ti6Qo9Pb1M19fRFUZGRtK6CgcOHEBAQACAtElbMlt/R1uEENLJ74EDB9CgQQMAadO4Pn/+XLZc9H2+1HIpt0OHDskdQdGePXuGmzdvAgAKFCigE2t00adlyxabffv2oWPHjplOEiDnokq6zMTEBFFRUciTJw969uwJMzMzzJw5E3fu3EGxYsW0fhJQsmRJhIaGwtbWFiVKlPjsh4Nc6xJR9qKnpyd9nfHvTci8GJsumzp1Kh4+fKizXacaNWqE9+/fo1KlSpgwYQLu3LmD3LlzIyQkBH379tVYe0pbqlevDhcXF9SsWRPdunXDtWvX4OXlhSNHjqBTp06IiYmRJRd9H11vuaTvk5iYKHXjS78Qoa+vj4CAAMyZMyfTxX9JftmyxaZfv35o1aoVxowZAycnJ7njKIKTkxOuXbuGXLlyYd++fZg/fz4A4M2bN5+cuu9Haty4sTTDR+PGjXXiqhdlb7p+VTM5ORmHDx9GdHQ02rVrB0tLSzx8+BBWVlawsLCQJdOQIUNQv359eHp6onDhwhrdfOUe/zZ37lz8/PPP2LRpE+bPn4/cuXMDAPbu3Yu6devKlmvmzJlo3749tm3bhl9//RVeXl4A0lrOK1asKFsu+j663nJJ32fQoEE4cuQIdu7cKb2+x48fR2BgIAYPHiydJ5FuyZYtNlZWVrh48SI8PT3ljqIY48aNw8yZM5ErVy68efMGt27dgrGxMZYuXYq///4bJ0+elDsi0X/W3bt3UbduXcTGxiIpKQm3bt2Ch4cH+vfvj6SkJCxYsECWXH379sXixYvh5+en0QUH4ODab/Xu3Tvo6+tzHKjC6HrLJX0fe3t7bNq0SWOM8aFDh9CqVSs8e/ZMnmD0WdmyxaZFixY4fPgwC5tvMG7cOHh7e+PevXto2bKl1Fqir6+P4cOHy5rNw8MDZ8+eRY4cOdS2x8XFoWTJklpb9Imyv2PHjmHhwoW4ffs2Nm7ciNy5c2PVqlVwd3eXpgyWQ//+/VG6dGmEh4ervQ+aNm2KHj16yJZrxYoV2Lx5M+rXry9bho/Fx8dL46G+1IVW7nFT586dw/Xr1wEAhQoVQunSpWXNQ99H11su6fu8efMm014/jo6O0tg90j3ZsrCZO3cuWrZsiWPHjqFo0aIa/2QCAwNlSqbbWrRoobGtU6dOMiRRFxMTk+n4hqSkJK5hQ1lm8+bN6NixI9q3b48LFy4gKSkJAPDq1StMnDgRe/bskS3bsWPHcOLECY31Tdzc3PDgwQOZUqUNwte1C0i2trZ49OgRHB0dYWNjk2k3VrnHTd2/fx9t27ZFWFiYtG5SXFwcKlasiHXr1iFPnjyy5KLvExgYiEOHDsHPzw85cuRg1+lsokKFChg7dixWrlwJExMTAMDbt28RFBSEChUqyJyOPiVbFjZr165FSEgITExMcPjwYY0ZSljYZC40NBQzZsxQu4I4YMAAaUY5bduxY4f0dXBwMKytraXvU1JSEBoayjVHKMv89ttvWLBgAQICArBu3Tppe6VKlfDbb7/JmCxtCvvMTsLv378v62Jo48aNw9ixY7Fs2TKdGUh78OBB2NnZAdDdcVPdu3fHhw8fcP36dRQoUAAAcPPmTXTp0gXdu3fHvn37ZE5I30IXWy7p35s5cybq1q2LPHnyoFixYgCA8PBwmJiYIDg4WOZ09CnZcoxNzpw5ERgYiOHDh6vNdESf9tdff6F///5o0aKFdCXi1KlT2LRpE2bMmIE+ffpoPVP6a6dSqfDxn6mhoSHc3Nwwbdo0aapUon/DzMwM165dg5ubGywtLREeHg4PDw9pAcV3797Jlq1169awtrbGokWLYGlpiYiICDg4OKBx48bImzevbGNZSpQogejoaAgh4ObmptE6LveMhbGxsXBxcdG4gi6EwL1795A3b15ZcpmamuLEiRMoUaKE2vbz58+jSpUq7OaiMK6urggODkbBggXljkJZ7M2bN1i9ejVu3LgBIO2Cb/v27WFqaipzMvqUbNli8/79e7Ru3ZpFzTeYOHEiZsyYgb59+0rbAgMDUalSJUycOFGWwiZ9ekV3d3ecPXsW9vb2Ws9A/x05c+ZEVFSUxvpIx48fh4eHhzyh/r9p06ahTp06UoHVrl07REZGwt7eHmvXrpUtV5MmTWR77K/h7u4udUvL6OXLl3B3d5etK5qLiws+fPigsT0lJQXOzs4yJKJ/QxdbLun7ZFxqYvz48RgyZIis4xjp22XLFpuBAwfCwcEBI0eOlDuKYlhYWODSpUvStKPpIiMjUaJECSQkJMiUjEg7Jk2ahP/7v//D0qVLUatWLezZswd3797FwIEDMXr0aPTr10/WfMnJyVi3bh0iIiKQkJCAkiVL8srhF+jp6eHJkycaC+rdvXsXhQsXRmJioiy5tm/fjokTJ2LevHnShAHnzp1Dv379MGzYMJ0vGEmdrrdc0tczNTVFZGQk8uTJA319/UwvjJBuy5YtNikpKZg6dSqCg4Ph4+Oj8U9m+vTpMiXTXY0aNcLWrVsxdOhQte3bt2/Xia5eiYmJOHLkCGJjY/H+/Xu1+zhmirLC8OHDkZqaiho1auDNmzfw9fWFsbExhgwZIntRAwAGBgbo0KGD3DEydf78eWlsXpEiRTS6WGnboEGDAKR1Yx09erTaVfSUlBScPn0axYsX12omW1tbtS5xiYmJKFeuHAwM0j6Gk5OTYWBggK5du7KwURi+XtlH8eLF0aVLF1SuXBlCCPz555+fXCdszJgxWk5HXyNbttj4+fl98j6VSoWDBw9qMY3umj17tvR1fHw8/vzzT1SqVEltjE1YWBgGDx6MUaNGyRUTFy9ehL+/P968eYPExETY2dnh+fPnMDMzg6OjI6d7piz1/v17REVFISEhAYULF5Zt8cuPRUZG4tChQ3j69KnUTTOdXB+wT58+RZs2bXD48GG12b38/Pywbt06jZYSbUn/DDhy5AgqVKigNpuckZER3NzcMGTIEOTLl09rmVasWPHV++rCbJRE/0U3b97E2LFjER0djQsXLqBw4cLSxYeMVCoVW+J0VLYsbOjrfO2MYiqVStbioVq1asifPz8WLFgAa2trhIeHw9DQEB06dED//v3RrFkz2bIRacPff/+N3r17w97eHjlz5tSY6VGuD9jWrVvj9u3bWLlyJQoVKgQAuHbtGjp16gQvLy9Zx/8AQJcuXTB79mxZZ44jImXS09PD48eP2RVNYVjYkM6zsbHB6dOnUaBAAdjY2ODkyZMoVKgQTp8+jU6dOkmzlRD9G+/evcOcOXM+2Soi59U5V1dX/Pzzzxg2bJhsGTJjbW2NAwcOoEyZMmrbz5w5g9q1ayMuLk6eYAA+fPgAU1NTXLp0Cd7e3rLlyExsbOxn75drtjYiIqXLlmNsKHsxNDSUZrhzdHREbGwsChUqBGtra9y7d0/mdJRddOvWDSEhIWjRogXKli2rU4vs/fPPP2jZsqXcMTSkpqZqjGEE0t6zHxeG2mZoaIi8efPKNvPZ57i5uX3270sXMxP9F+liF2D6PLbYEACga9eun71/6dKlWkqiqXbt2ujcuTPatWuHHj16ICIiAoGBgVi1ahX++ecfnD59WrZslH1YW1tjz549qFSpktxRNHTr1g1lypRBr1695I6ipnHjxoiLi8PatWulaYofPHiA9u3bw9bWFlu3bpU135IlS7BlyxasWrVKWrRTF4SHh6t9/+HDB1y8eBHTp0/H77//zu61RDpAV7sA0+exsCEAQNOmTdW+//DhA65cuYK4uDhUr14dW7ZskSlZ2jSor1+/hp+fH54+fYqAgACcOHEC+fPnx+LFi7U+uxFlT4ULF8a6devg4+MjdxQNkyZNwvTp01G/fn0ULVpUo5VErpkB7927h0aNGuHq1atwcXGRtnl7e2PHjh3IkyePLLnSlShRAlFRUfjw4QNcXV1hbm6udr+unZjs3r0bf/zxBw4fPix3FPpKHz58QMGCBbFr1y5pnBllD7raBZg+j4UNfVJqaip69+4NT09P/PLLL7LlePv2LYQQ0pStMTEx2Lp1KwoXLow6derIlouyl71792L27NlYsGABXF1d5Y6j5nMTfcg9uYcQAgcOHFBbmbtmzZqy5ckoKCjos/ePHTtWS0m+TlRUFIoVKybb+jr0fXLnzo0DBw6wsMlmrKyscOnSJdkXaKZvw8KGPuvmzZuoVq0aHj16JFuG2rVro1mzZujVqxfi4uJQsGBBGBoa4vnz55g+fTp69+4tWzbKPp49e4ZWrVrh6NGjMDMz02gVefnypUzJKLuJj49X+14IgUePHmHcuHG4ceMGLl26JE8w+i4TJ07ErVu3sHjx4kynBiZl0tUuwPR5fAfSZ0VHRyM5OVnWDBcuXMCMGTMAAJs2bYKTkxMuXryIzZs3Y8yYMSxsKEu0bdsWDx48wMSJE+Hk5KRTkwfostDQUISGhmY6uFbOsXnp4uLisGnTJkRHR2Po0KGws7PDhQsX4OTkhNy5c8uSycbGRuPvSwgBFxcXrFu3TpZM9P3Onj2L0NBQhISEoGjRohpdHuXsyk3fz8vLC6NHj8apU6d0qgswfR4LGwLwv5W606VfQdy9e7fsi8W9efNGWociJCQEzZo1g56eHsqXL4+7d+/Kmo2yjxMnTuDkyZMoVqyY3FEApL0nJ0yYAHNzc43358emT5+upVTqgoKCMH78eJQuXRq5cuXSuWIwIiICNWvWhLW1NWJiYtCjRw/Y2dlhy5YtiI2NxcqVK2XJdejQIbXv9fT04ODgAC8vL17xVyAbGxs0b95c7hiUxRYtWgQLCwscOXIER44cUbtPpVKxsNFR/A9KAICLFy+qfZ/+QTtt2rQvzpj2o3l5eWHbtm1o2rQpgoODMXDgQABpq55bWVnJmo2yj4IFC+Lt27dyx5BcvHgRHz58kL7WRQsWLMDy5cvRsWNHuaNkatCgQejcuTOmTp2qtkinv78/2rVrJ1uuqlWryvbYlPWWLVsmdwT6Ae7cuSN3BPoOHGNDANJaRYQQUhN6TEwMtm3bhkKFCsk+QH/Tpk1o164dUlJSUKNGDYSEhABImynq6NGj2Lt3r6z5KHsICQlBUFAQfv/990y7HbCI1pQjRw6cOXMGnp6eckfJlLW1NS5cuABPT09YWloiPDwcHh4euHv3LgoUKIB3797JkmvFihWwt7dH/fr1AQC//PILFi1ahMKFC2Pt2rU6N3kF0X/F17aUq1QqTJs2TYvJ6GuxsCEAuj9A//Hjx3j06BGKFSsmLdZ55swZWFlZoWDBgrJmo+wh/e8qs7EPKpVK1kUTV65ciTJlymjMuvTu3Tts2LABAQEBsuQaNmwYLCwsMHr0aFke/0scHR0RHByMEiVKqBU2+/fvR9euXWVb4LdAgQKYP38+qlevjpMnT6JGjRqYOXMmdu3aBQMDA47JUBh3d/fPdsOUc9ZC+jZ+fn7YunUrbGxs4Ofn98n9VCoVDh48qMVk9LVY2BAAwN7eHkeOHEGRIkWwePFizJkzR22A/vXr1+WOSPRDfdyH+mNydh/S09ODubk5li9frtaX/8mTJ3B2dtZq0ZXxKmZqaipWrFgBHx8f+Pj4aLRyyTX2J1337t3x4sULbNiwAXZ2doiIiIC+vj6aNGkCX19fzJw5U5ZcZmZmuHHjBvLmzYthw4bh0aNHWLlyJa5evYpq1arh2bNnsuSi7zNr1iy179MXXN23bx+GDh2K4cOHy5SM6L+HY2wIAAfoE+n6uIegoCB07NgRly9fxrhx42TL8fF4n/QFcq9cuaK2XRcmEpg2bRpatGgBR0dHvH37FlWrVsXjx49RoUIF/P7777LlsrCwwIsXL5A3b16EhIRIxaKJiYlOjfOir9O/f/9Mt8+bNw/nzp3Tchqi/za22BAAwMfHB927d0fTpk3h7e2Nffv2oUKFCjh//jzq/7/27j2u5vvxA/jrnNRKpfsK001UrJIR3TZja5goNF+lUmGZuZVLs422fV3WNzHf2BbG2Chrl68JfX27uGQUnVWikqKvCAmp3Dp9fn/06Gx9w2+ZnU9Hr+fj0eNRn8+pz2tnj3Je5/O+vPkmqqqqxI5I9Je7efMmNm/erLhD2b9/f4SGhkJPT0/UXFKpFFVVVSgrK4Ovry/c3d2xfft21NbWKv2OjSo6cuQI8vPzUVdXh4EDB4q+gWhAQACKiorg7OyMnTt3oqKiAkZGRti9ezeWLFnSpiSSaiorK8OAAQPa7FtERH8dqdgBqGNYunQpFixYAEtLSwwZMgSurq4Amu/eODs7i5yO6K934sQJ9O7dG2vWrEFNTQ1qamoQFxeH3r17Izc3V9RsLXc/hg4diuPHj6O0tBRubm44f/68qLk6upY5NB4eHnjnnXewaNEi0UsN0PxOvqurK65du4bvv/8eRkZGAICTJ09i8uTJIqejpyU5ORmGhoZixyDqVHjHhhQ4QZ86M09PT9jY2GDjxo2KvUQaGxsxbdo0lJWV4dChQ6Jla7lj8/zzzwNoHjoaEBCAtLQ01NfX847NI6ipqcHDwwNTpkzBxIkTYWBgIHYkegY5Ozu3GnopCAKqqqpw7do1bNiwATNmzBAxHVHnwmJDRARAS0sLMpmsTYk/ffo0Bg0ahIaGBpGSNc+vWbhwIbp27drq+LJly3Do0KE2Gz5SM5lMhh07diAxMRHXrl3DyJEjMWXKFHh7e+O5554TOx49Iz766KNWX7fsAzds2DC+KUikZCw2REQATE1NsX37dnh5ebU6npqaiqCgIFy5ckWkZPRnCYKAzMxM7NixA99//z2ampowfvx4fPXVV2JHIyKip4jFhogIwJw5c/Djjz8iNjYWbm5uAICsrCwsXLgQEyZMEG1p4N87ffo0KioqcP/+fcUxiUQCb29vEVOpltzcXISFhSE/P59D+Oipkcvl+Omnn1otPDJ27FioqamJnIyoc+Fyz0REAGJjYyGRSBAUFITGxkYAgLq6OmbOnIlVq1aJmq1lNbSCggJIJBK0vB/VMq6fL9Af7+LFi9ixYwd27NiBU6dOwdXVFevXrxc7Fj0jSktLMXr0aFRWVsLW1hYAsHLlSvTq1QspKSno3bu3yAmJOg/esSEi+p2GhgacO3cOANC7d+8281rE4O3tDTU1NWzatAlWVlbIzs7G9evXERkZidjYWHh6eoodsUP68ssvsWPHDmRlZcHOzg4BAQHw9/eHhYWF2NHQ2NiIzMxMnDt3Dv7+/tDV1cWlS5fQrVs36OjoiB2P2mH06NEQBAHffvutYhW069evY8qUKZBKpUhJSRE5IVHnwWJDRAQgNDQUn332mWKj2hb19fWYPXu2qPMxjI2NkZ6eDkdHR+jp6SE7Oxu2trZIT09HZGRkm00zqVmvXr0wefJkBAQEwMnJSew4ChcuXMDIkSNRUVGBe/fuoaSkBNbW1pg7dy7u3buHL774QuyI1A7a2to4duwYHBwcWh3Py8uDu7s76urqREpG1PlwHxsiIgBff/31Q3d9v3PnDrZt2yZCot/I5XJF4TI2NsalS5cAABYWFiguLhYzWodWUVGBmJiYDlVqgOad6gcNGoQbN25AS0tLcdzX1xdpaWkiJqMn8dxzz+H27dttjtfV1UFDQ0OERESdF+fYEFGnVltbC0EQIAgCbt++DU1NTcU5uVyOvXv3KvaPEcuLL76IvLw8WFlZYciQIYiJiYGGhgYSEhJgbW0taraOJj8//w8/1tHR8S9M8miHDx/G0aNH27zotbS0RGVlpSiZ6MmNGTMGM2bMwObNm+Hi4gIAOH78OMLDwzF27FiR0xF1Liw2RNSp6evrQyKRQCKRoG/fvm3OSySSNvtUKNsHH3yA+vp6AMDHH3+MMWPGwNPTE0ZGRkhKShI1W0czYMCAhy6w8DBiLbrQ1NT00GtfvHixzVBI6vjWrVuH4OBguLq6Ql1dHUDzHKqxY8fis88+EzkdUefCOTZE1KkdPHgQgiBg+PDh+P777xWTfwFAQ0MDFhYW6NGjh4gJH66mpgYGBgaPfeHeGV24cEHxuUwmw4IFC7Bw4UK4uroCAH755ResXr0aMTEx8PHxESXjpEmToKenh4SEBOjq6iI/Px8mJiYYN24czM3NsWXLFlFy0Z9z9uxZFBUVAQDs7e1hY2MjciKizofFhogIzS+Izc3NWRSeIS4uLoiOjsbo0aNbHd+7dy8+/PBDnDx5UpRcFy9exBtvvAFBEHD27FkMGjQIZ8+ehbGxMQ4dOiT60EciIlXFYkNEBGD//v3Q0dGBh4cHAGD9+vXYuHEj+vXrh/Xr18PAwEC0bL6+vg8tXBKJBJqamrCxsYG/v79iDw1qpqWlhdzcXNjb27c6fubMGQwcOPChi0UoS2NjIxITE5Gfn4+6ujoMHDgQAQEBrRYTINUgCAKSk5ORkZGBq1evoqmpqdX5H374QaRkRJ0PV0UjIgKwcOFC1NbWAgAKCgoQERGB0aNHo7y8HBEREaJm09PTQ3p6OnJzcxXzgWQyGdLT09HY2IikpCQ4OTkhKytL1Jwdjb29PVauXIn79+8rjt2/fx8rV65sU3aUrUuXLpgyZQpiYmKwYcMGTJs2jaVGRc2bNw+BgYEoLy+Hjo4O9PT0Wn0QkfLwjg0REQAdHR2cOnUKlpaWiI6OxqlTp5CcnIzc3FyMHj0aVVVVomWLiopCbW0t4uPjIZU2vx/V1NSEuXPnQldXF8uXL0d4eDgKCwtx5MgR0XJ2NNnZ2fD29oYgCIoV0FpWTduzZ49iBSsxnD179pHv8C9dulSkVPQkDA0N8c0337QZ8khEysdiQ0SE5hcnR44cQb9+/eDh4YGgoCDMmDED58+fR79+/dDQ0CBaNhMTE2RlZbVZta2kpARubm6orq5GQUEBPD09cfPmTXFCdlD19fX49ttvW03q9vf3h7a2tmiZNm7ciJkzZ8LY2BhmZmathhlKJBLk5uaKlo3az8rKCvv27YOdnZ3YUYg6PS73TEQEwMPDAxEREXB3d0d2drZiGeWSkhK88MILomZrbGxEUVFRm2JTVFSkWDZYU1OTCx88hLa2Njw8PGBubq4YktayCaZYe4z8/e9/x/Lly7F48WJRrk9PV3R0ND766CN89dVXHE5IJDIWGyIiAPHx8XjnnXeQnJyMzz//HD179gQA7Nu3DyNHjhQ1W2BgIMLCwrBkyRIMHjwYAJCTk4MVK1YgKCgIQPOy1f379xczZodTVlYGX19fFBQUKPa2+X35E2sfmxs3bsDPz0+Ua9PT99Zbb2Hnzp14/vnnYWlpqdjLpgXvwBEpD4eiERF1cHK5HKtWrUJ8fDyuXLkCADA1NcXs2bOxePFiqKmpoaKiAlKpVPS7Sx2Jt7c31NTUsGnTJlhZWeH48eOoqalBZGQkYmNj4enpKUqusLAwDB48GOHh4aJcn56ut956CxkZGZg4cSJMTU3b3DldtmyZSMmIOh8WGyIiABUVFY89b25urqQkj9eyclu3bt1ETtLxGRsbIz09HY6OjtDT00N2djZsbW2Rnp6OyMhIyGQyUXKtXLkScXFxePPNN+Hg4NDmHf45c+aIkouejLa2NlJTUxVLxROReDgUjYgIgKWl5WPnqIg1bOl/sdD8cXK5HLq6ugCaS86lS5dga2sLCwsLFBcXi5YrISEBOjo6OHjwIA4ePNjqnEQiYbFRMb169eLvJVEHwWJDRAS0eff+wYMHkMlkiIuLw/Lly0VK9Zvk5GTs2rULFRUVrfZlATiG/1FefPFF5OXlwcrKCkOGDEFMTAw0NDSQkJAAa2tr0XKVl5eLdm16+lavXo1Fixbhiy++gKWlpdhxiDo1DkUjInqMlJQU/OMf/0BmZqZoGdatW4f3338fU6dORUJCAkJCQnDu3Dnk5ORg1qxZHaJ4dUSpqamor6/H+PHjUVpaijFjxqCkpARGRkZISkrC8OHDxY5IzwADAwM0NDSgsbERXbt2bTO0sKamRqRkRJ0Piw0R0WOUlpbCyckJ9fX1omWws7PDsmXLMHnyZOjq6iIvLw/W1tZYunQpampqEB8fL1o2VVNTUwMDAwOlL40dERGBTz75BNra2oiIiHjsY+Pi4pSUip6Gr7/++rHng4ODlZSEiDgUjYgIv03KbyEIAi5fvozo6Gj06dNHpFTNKioq4ObmBgDQ0tLC7du3ATQvAz106FAWm3YwNDQU5boymQwPHjxQfE7PDhYXoo6DxYaICIC+vn6bd/EFQUCvXr2QmJgoUqpmZmZmqKmpgYWFBczNzXHs2DE4OTmhvLwcvOmuGjIyMh76OT1b7t6922YOHBcWIFIeFhsiIgDp6emtio1UKoWJiQlsbGzQpYu4fyqHDx+O3bt3w9nZGSEhIZg/fz6Sk5Nx4sQJjB8/XtRs1H7btm3D4MGDYW9v3+r43bt3sWvXLsWmq6Qa6uvrsXjxYuzatQvXr19vc76jrKhI1Blwjg0RUQfX1NSEpqYmRcFKTEzE0aNH0adPH7z99tvQ0NAQOSG1h1Qqhba2NrZu3YoJEyYojl+5cgU9evTgC2EVM2vWLGRkZOCTTz5BYGAg1q9fj8rKSnz55ZdYtWoVAgICxI5I1Gmw2BARoXnTRFNTU4SGhrY6/tVXX+HatWtYvHixSMnoWSOVShEbG4sPPvgAixYtQnR0NAAWG1Vlbm6Obdu2YdiwYejWrRtyc3NhY2OD7du3Y+fOndi7d6/YEYk6DRYbIiI0b9C5Y8cOxST9FsePH8ff/vY30fceuXv3LvLz83H16lU0NTW1Ojd27FiRUtGTkEqlqKqqQllZGXx9feHu7o7t27ejtraWxUYF6ejo4PTp0zA3N8cLL7yAH374AS4uLigvL4eDgwPq6urEjkjUaXCODRERgKqqKnTv3r3NcRMTE1y+fFmERL/Zv38/goKCUF1d3eacRCLhC2EV0zKXa+jQoTh+/DjGjh0LNzc3fPHFFyInoydhbW2N8vJymJubw87ODrt27YKLiwt+/vln6Ovrix2PqFORih2AiKgj6NWrF7Kystocz8rKQo8ePURI9JvZs2fDz88Ply9fVsy3aflgqVE9vx8oYW5ujqNHj8LS0hKvv/66iKnoSYWEhCAvLw8AEBUVhfXr10NTUxPz58/HwoULRU5H1Lnwjg0REYDp06dj3rx5ePDggWJH+rS0NCxatAiRkZGiZrty5QoiIiJgamoqag56OpYtWwYdHR3F1127dsWPP/6IZcuW4dChQyImoycxf/58xeevvfYaioqKcPLkSdjY2MDR0VHEZESdD+fYEBGh+V30qKgorFu3TrEPhaamJhYvXoylS5eKmi00NBTu7u4ICwsTNQcREVFHxmJDRPQ7dXV1OHPmDLS0tNCnTx8899xzYkdCQ0MD/Pz8YGJiAgcHB6irq7c6P2fOHJGS0Z9x+vRpVFRUtNrQUSKRwNvbW8RU9EesW7fuDz+Wv59EysNiQ0TUwW3evBnh4eHQ1NSEkZFRq41EJRIJysrKRExH7dWyGlpBQQEkEolizk3L/1fOm+r4rKys/tDj+PtJpFwsNkREHZyZmRnmzJmDqKgoSKVc80XVeXt7Q01NDZs2bYKVlRWys7Nx/fp1REZGIjY2Fp6enmJHJCJSSSw2REQdnKGhIXJyctC7d2+xo9BTYGxsjPT0dDg6OkJPTw/Z2dmwtbVFeno6IiMjIZPJxI5IRKSSuCoaEVEHFxwcjKSkJCxZskTsKPQUyOVy6OrqAmguOZcuXYKtrS0sLCxQXFwscjpqr4iIiIcel0gk0NTUhI2NDcaNGwdDQ0MlJyPqfFhsiIg6OLlcjpiYGKSmpsLR0bHN4gFxcXEiJaMn8eKLLyIvLw9WVlYYMmQIYmJioKGhgYSEBFhbW4sdj9pJJpMhNzcXcrkctra2AICSkhKoqanBzs4OGzZsQGRkJI4cOYJ+/fqJnJbo2cahaEREHdyrr776yHMSiQTp6elKTEN/VmpqKurr6zF+/HiUlpZizJgxKCkpgZGREZKSkhT7KJFqWLt2LQ4fPowtW7agW7duAIBbt25h2rRp8PDwwPTp0+Hv7487d+4gNTVV5LREzzYWGyIiIpHV1NTAwMCg1Yp3pBp69uyJAwcOtLkbU1hYCC8vL1RWViI3NxdeXl6orq4WKSVR58DldYiIiERmaGjIUqOibt26hatXr7Y5fu3aNdTW1gIA9PX1W+1XRER/Dc6xISIiUiJfX9+HlpjfTzb39/dXzNegjm3cuHEIDQ3F6tWrMXjwYABATk4OFixYAB8fHwBAdnY2+vbtK2JKos6BQ9GIiIiUaOrUqfjpp5+gr6+Pl156CQCQm5uLmzdvwsvLC3l5eTh//jzS0tLg7u4uclr6/9TV1WH+/PnYtm0bGhsbAQBdunRBcHAw1qxZA21tbfz6668AgAEDBogXlKgTYLEhIiJSoqioKNTW1iI+Pl6x4WpTUxPmzp0LXV1dLF++HOHh4SgsLMSRI0dETkt/VF1dHcrKygAA1tbW0NHRETkRUefDYkNERKREJiYmyMrKajM0qaSkBG5ubqiurkZBQQE8PT1x8+ZNcUISEakgLh5ARESkRI2NjSgqKmpzvKioCHK5HACgqanJxQSIiNqJiwcQEREpUWBgIMLCwrBkyZJWk81XrFiBoKAgAMDBgwfRv39/MWMSEakcDkUjIiJSIrlcjlWrViE+Ph5XrlwBAJiammL27NlYvHgx1NTUUFFRAalUihdeeEHktEREqoPFhoiISCQt+5y07FhPRERPjsWGiIiIiIhUHufYEBERKVlycjJ27dqFioqKNjvS5+bmipSKiEi1cVU0IiIiJVq3bh1CQkJgamoKmUwGFxcXGBkZoaysDKNGjRI7HhGRyuJQNCIiIiWys7PDsmXLMHnyZOjq6iIvLw/W1tZYunQpampqEB8fL3ZEIiKVxDs2RERESlRRUQE3NzcAgJaWFm7fvg2geRnonTt3ihmNiEilsdgQEREpkZmZGWpqagAA5ubmOHbsGACgvLwcHERBRPTkWGyIiIiUaPjw4di9ezcAICQkBPPnz8frr7+OSZMmwdfXV+R0RESqi3NsiIiIlKipqQlNTU3o0qV5YdLExEQcPXoUffr0wdtvvw0NDQ2RExIRqSYWGyIiIiIiUnncx4aIiEjJ7t69i/z8fFy9ehVNTU2tzo0dO1akVEREqo3FhoiISIn279+PoKAgVFdXtzknkUggl8tFSEVEpPq4eAAREZESzZ49G35+frh8+bJivk3LB0sNEdGT4xwbIiIiJerWrRtkMhl69+4tdhQiomcK79gQEREp0cSJE5GZmSl2DCKiZw7v2BARESlRQ0MD/Pz8YGJiAgcHB6irq7c6P2fOHJGSERGpNhYbIiIiJdq8eTPCw8OhqakJIyMjSCQSxTmJRIKysjIR0xERqS4WGyIiIiUyMzPDnDlzEBUVBamUI8KJiJ4W/kUlIiJSovv372PSpEksNURETxn/qhIRESlRcHAwkpKSxI5BRPTM4QadRERESiSXyxETE4PU1FQ4Ojq2WTwgLi5OpGRERKqNc2yIiIiU6NVXX33kOYlEgvT0dCWmISJ6drDYEBERERGRyuMcGyIiIiIiUnksNkREREREpPJYbIiIiIiISOWx2BARERERkcpjsSEiIiIiIpXHYkNERH8JS0tLrF27VuwYT9358+chkUjw66+/ih2FiIh+h8WGiIj+X1u3boW+vr7YMYiIiB6JxYaIiOgh7t+/L3YEIiJqBxYbIqJO4Pbt2wgICIC2tja6d++ONWvWYNiwYZg3bx4A4N69e1iwYAF69uwJbW1tDBkyBJmZmQCAzMxMhISE4NatW5BIJJBIJIiOjm53hk2bNkFfXx9paWkAgFOnTmHUqFHQ0dGBqakpAgMDUV1dDQDYtm0bjIyMcO/evVY/w8fHB4GBgbh16xbU1NRw4sQJAEBTUxMMDQ0xdOhQxWO/+eYb9OrVS/F1QUEBhg8fDi0tLRgZGWHGjBmoq6tTnJ86dSp8fHywfPly9OjRA7a2tgCA7OxsODs7Q1NTE4MGDYJMJmuV6caNGwgICICJiQm0tLTQp08fbNmypd3PDxER/TksNkREnUBERASysrKwe/duHDhwAIcPH0Zubq7i/LvvvotffvkFiYmJyM/Ph5+fH0aOHImzZ8/Czc0Na9euRbdu3XD58mVcvnwZCxYsaNf1Y2JiEBUVhX//+98YMWIEbt68ieHDh8PZ2RknTpzA/v37ceXKFbz11lsAAD8/P8jlcuzevVvxM65evYqUlBSEhoZCT08PAwYMUJSvgoICSCQSyGQyRVk5ePAgXnnlFQBAfX093njjDRgYGCAnJwffffcd/vOf/+Ddd99tlTMtLQ3FxcU4cOAA9uzZg7q6OowZMwb9+vXDyZMnER0d3ea//cMPP8Tp06exb98+nDlzBp9//jmMjY3b9fwQEdFTIBAR0TOttrZWUFdXF7777jvFsZs3bwpdu3YV5s6dK1y4cEFQU1MTKisrW33fiBEjhPfee08QBEHYsmWLoKen167rWlhYCGvWrBEWLVokdO/eXTh16pTi3CeffCJ4eXm1evx///tfAYBQXFwsCIIgzJw5Uxg1apTi/OrVqwVra2uhqalJEARBiIiIEN58801BEARh7dq1wqRJkwQnJydh3759giAIgo2NjZCQkCAIgiAkJCQIBgYGQl1dneLnpaSkCFKpVKiqqhIEQRCCg4MFU1NT4d69e4rHfPnll4KRkZFw584dxbHPP/9cACDIZDJBEATB29tbCAkJaddzQ0RET18XsYsVERH9tcrKyvDgwQO4uLgojunp6SmGWhUUFEAul6Nv376tvu/evXswMjL6U9devXo16uvrceLECVhbWyuO5+XlISMjAzo6Om2+59y5c+jbty+mT5+OwYMHo7KyEj179sTWrVsxdepUSCQSAMArr7yCzZs3Qy6X4+DBg/Dy8oKZmRkyMzPh6OiI0tJSDBs2DABw5swZODk5QVtbW3Edd3d3NDU1obi4GKampgAABwcHaGhoKB5z5swZODo6QlNTU3HM1dW1Vd6ZM2diwoQJyM3NhZeXF3x8fODm5vannjciImo/Fhsiok6urq4OampqOHnyJNTU1Fqde1jxaA9PT0+kpKRg165diIqKanVNb29vfPrpp22+p3v37gAAZ2dnODk5Ydu2bfDy8kJhYSFSUlIUj3v55Zdx+/Zt5Obm4tChQ1ixYgXMzMywatUqODk5oUePHujTp0+78v6++PxRo0aNwoULF7B3714cOHAAI0aMwKxZsxAbG9vun0VERE+Oc2yIiJ5x1tbWUFdXR05OjuLYrVu3UFJSAqC5QMjlcly9ehU2NjatPszMzAAAGhoakMvl7b62i4sL9u3bhxUrVrR6oT9w4EAUFhbC0tKyzTV/Xy6mTZuGrVu3YsuWLXjttddaLQagr68PR0dHxMfHQ11dHXZ2dnj55Zchk8mwZ88exfwaALC3t0deXh7q6+sVx7KysiCVShV3rh7G3t4e+fn5uHv3ruLYsWPH2jzOxMQEwcHB+Oabb7B27VokJCS0+7kiIqI/h8WGiOgZp6uri+DgYCxcuBAZGRkoLCxEWFgYpFIpJBIJ+vbti4CAAAQFBeGHH35AeXk5srOzsXLlSsUdEktLS9TV1SEtLQ3V1dVoaGj4w9d3c3PD3r178dFHHyk27Jw1axZqamowefJk5OTk4Ny5c0hNTUVISEirAuXv74+LFy9i48aNCA0NbfOzhw0bhm+//VZRYgwNDWFvb4+kpKRWxSYgIACampoIDg7GqVOnkJGRgdmzZyMwMFAxDO1h/P39IZFIMH36dJw+fRp79+5tcydm6dKl+Ne//oXS0lIUFhZiz549sLe3/8PPDxERPR0sNkREnUBcXBxcXV0xZswYvPbaa3B3d4e9vb1i7siWLVsQFBSEyMhI2NrawsfHBzk5OTA3NwfQXE7Cw8MxadIkmJiYICYmpl3X9/DwQEpKCj744AP885//RI8ePZCVlQW5XA4vLy84ODhg3rx50NfXh1T62z9Nenp6mDBhAnR0dODj49Pm577yyiuQy+WKuTRAc9n532Ndu3ZFamoqampqMHjwYEycOBEjRoxAfHz8Y3Pr6Ojg559/RkFBAZydnfH++++3GT6noaGB9957D46Ojnj55ZehpqaGxMTEdj0/RET050kEQRDEDkFERMpVX1+Pnj17YvXq1QgLCxM7zmONGDEC/fv3x7p168SOQkREHRgXDyAi6gRkMhmKiorg4uKCW7du4eOPPwYAjBs3TuRkj3bjxg1kZmYiMzMTGzZsEDsOERF1cCw2RESdRGxsLIqLi6GhoYGXXnoJhw8ffuKNJA8fPoxRo0Y98nzLJpl/hrOzM27cuIFPP/30sRP8iYiIAA5FIyKiJ3Dnzh1UVlY+8ryNjY0S0xAREbHYEBERERHRM4CrohERERERkcpjsSEiIiIiIpXHYkNERERERCqPxYaIiIiIiFQeiw0REREREak8FhsiIiIiIlJ5LDZERERERKTy/g94YGoG1COYmwAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 1000x500 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Eg: Count the number of messages that contain a specific keyword\n",
+        "\n",
+        "keywords_to_count = augmented_messages_df.explode(\"get_keywords\").groupby(\"get_keywords\").size().sort_values(ascending=False)\n",
+        "\n",
+        "keywords_to_count.head(20).plot(kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Bonus: Use the previous results of the job\n",
+        "\n",
+        "This PoC was cool, but all the Job execution are independent. \n",
+        "\n",
+        "Let's say that you want to **use the previous results of the job** as context for the current message. For example, to anchor the LLM with the current keywords found.\n",
+        "\n",
+        "There are multiple ways to do it. \n",
+        "\n",
+        "### With phospho\n",
+        "\n",
+        "With phospho, one cool way is to set a `job` argument to the job function. At runtime, `job` is then a reference to the current lab.Job and contains all results so far."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "async def get_keywords_previous_results(\n",
+        "    message: lab.Message,\n",
+        "    job: lab.Job = None, # Add the job as an argument\n",
+        "    model: str=\"openai:gpt-3.5-turbo\",\n",
+        ") -> lab.JobResult:\n",
+        "    \"\"\"\n",
+        "    This function uses OpenAI GPT to extract keywords from a given message.\n",
+        "\n",
+        "    It also uses the previous results of the job to provide context to the LLM.\n",
+        "    The job argument is used to access the previous results.\n",
+        "    \"\"\"\n",
+        "    provider, model_name = lab.get_provider_and_model(model)\n",
+        "    openai_client = lab.get_async_client(provider)\n",
+        "\n",
+        "    # Using the reference to the job, we can access the results of the other jobs\n",
+        "    # to use them as context for the current job\n",
+        "    previous_keywords = []\n",
+        "    if job:\n",
+        "        # Get the previous results\n",
+        "        previous_job_results = job.results.values()\n",
+        "        # Let's flatten the list of lists of keywords\n",
+        "        previous_keywords = [keyword for result in previous_job_results for keyword in result.value]\n",
+        "\n",
+        "    prompt = \"You are an annotator reading Amazon product reviews. Your job is to label \\\n",
+        "    each review with topics that describe important topics covered in the review, relevant \\\n",
+        "    to the e-commerce domain. Do not include generic topics such as 'good', 'bad', 'interesting', etc.\"\n",
+        "    \n",
+        "    # If there are previous results, we add them to the prompt\n",
+        "    if len(previous_keywords) > 0:\n",
+        "        prompt += f\"\"\"\n",
+        "        So far, you've reviewed {len(previous_job_results)} reviews, and the keywords you've found are:\n",
+        "        {\", \".join(previous_keywords)}\n",
+        "\n",
+        "        If possible, reuse the existing topics to label the current review. Do not add \n",
+        "        variations of the same topics.\"\"\"\n",
+        "\n",
+        "    prompt = f\"\"\"The review is: \n",
+        "    {message.content}\n",
+        "\n",
+        "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
+        "    Keywords:\"\"\"\n",
+        "\n",
+        "    response = await openai_client.chat.completions.create(\n",
+        "        model=\"gpt-3.5-turbo\",\n",
+        "        messages=[\n",
+        "            {\n",
+        "                \"role\": \"system\",\n",
+        "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
+        "            },\n",
+        "            {\"role\": \"user\", \"content\": prompt},\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "    response = response.choices[0].message.content\n",
+        "    keywords = re.findall(r\"- (.*)\", response)\n",
+        "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
+        "    return lab.JobResult(\n",
+        "        value=keywords,\n",
+        "        result_type=lab.ResultType.list,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's run this job. \n",
+        "\n",
+        "Note that we are still running the jobs in parallel! This means that the existing results won't always be available at the start. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 38,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "No job_config provided. Running with empty config\n",
+            "100%|██████████| 100/100 [00:10<00:00,  9.52it/s]\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of different keywords extracted: 552\n"
+          ]
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJLCAYAAAA1hAPqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACauklEQVR4nOzdeViN+f8/8Ocp2nctRNqsUfax7wZlzzKI7GYMIstgxhZGlrEzjLFmGIOxjGWEELKT7FT2JXuobNX790e/7m/HyTo59333eT6u61zqPrdznp1T97lf93vTCCEEiIiIiIiIVMxA7gBERERERET/FQsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiAgC4ubmhadOmcseQ1d69e6HRaLB3797//Fhdu3aFm5vbf36cjyH3e+fm5oauXbvK9vxERAALGyL6gGXLlkGj0UCj0eDAgQM69wsh4OLiAo1G88VOrO7cuYOxY8fi1KlTX+TxidTg/PnzGDt2LK5duyZ3lByjtL/tbdu2YezYsXLHIKLPxMKGiD6KiYkJVq1apbM9MjISt27dgrGx8Rd77jt37iAkJEQxJz9EH+P333/HpUuXcuzxzp8/j5CQkFxX2Cjpb3vbtm0ICQmROwYRfSYWNkT0Ufz8/LB27VqkpqZqbV+1ahUqVKiA/Pnzy5SM6OMJIfDixQu9PFfevHm/aMFPRETaWNgQ0Ufp0KEDHj16hJ07d0rbXr9+jXXr1qFjx47Z/p/k5GQMHjwYLi4uMDY2RvHixfHLL79ACKG1386dO1GjRg3Y2NjAwsICxYsXx48//gggY8xDpUqVAADdunWTusUtW7bsvXlv376NHj16wNnZGcbGxnB3d0efPn3w+vVraZ8rV66gbdu2sLOzg5mZGapUqYKtW7dqPU7mmIs1a9YgJCQEBQsWhKWlJdq0aYOnT5/i1atXGDhwIBwdHWFhYYFu3brh1atXWo+h0WjQr18/rF27Fl5eXjA1NUXVqlVx5swZAMBvv/2GIkWKwMTEBHXq1Mn2ivzatWtRoUIFmJqawt7eHp06dcLt27e19unatSssLCxw+/ZttGzZEhYWFnBwcMCQIUOQlpb23tfrXZYvX448efJg6NCh0rYjR46gcePGsLa2hpmZGWrXro2oqCjp/j179kCj0WDDhg06j7dq1SpoNBocOnQI//zzDzQaDU6fPi3d//fff0Oj0cDf31/r/5UsWRLffPON9H1qairGjx8PT09PGBsbw83NDT/++KPOa5859iQ8PBwVK1aEqakpfvvtNwDArVu30LJlS5ibm8PR0RHBwcE6/x8AYmNj0bp1a+TPnx8mJiYoVKgQ2rdvj6dPn773tXt7jM21a9eg0Wjwyy+/YOHChVL2SpUq4dixY+99rGXLlqFt27YAgLp160p/B2+PBTpw4AC++uormJiYwMPDA2FhYTqPlZiYiIEDB0p/l0WKFMHkyZORnp7+3gxARmE4YcIEFCpUCGZmZqhbty7OnTuns9/jx48xZMgQeHt7w8LCAlZWVvD19UVMTIy0z4f+tvfv34+2bduicOHCMDY2houLC4KDg3UK04SEBHTr1g2FChWCsbExChQogBYtWuj8Hf3777+oWbMmzM3NYWlpiSZNmmhl79q1K+bNmwcAUhaNRvPB14SIFEQQEb3H0qVLBQBx7NgxUa1aNdG5c2fpvo0bNwoDAwNx+/Zt4erqKpo0aSLdl56eLurVqyc0Go3o2bOnmDt3rmjWrJkAIAYOHCjtd/bsWWFkZCQqVqwoZs2aJRYsWCCGDBkiatWqJYQQIiEhQYwbN04AEL179xYrVqwQK1asEPHx8e/MfPv2beHs7CzMzMzEwIEDxYIFC8SoUaNEyZIlxZMnT6THdXJyEpaWluKnn34S06dPF2XKlBEGBgZi/fr10mPt2bNHABBly5YVVatWFbNnzxZBQUFCo9GI9u3bi44dOwpfX18xb9480blzZwFAhISEaOUBIHx8fISLi4uYNGmSmDRpkrC2thaFCxcWc+fOFV5eXmLatGli5MiRwsjISNStWzfb96BSpUpixowZYvjw4cLU1FS4ublJP48QQnTp0kWYmJiIUqVKie7du4v58+eL1q1bCwDi119//eB7/fZ7+NtvvwmNRiN++uknaVtERIQwMjISVatWFdOmTRMzZswQPj4+wsjISBw5ckR6711cXETr1q11nsPPz094enoKIYR49OiR0Gg0Ys6cOdL9AwYMEAYGBsLBwUHadv/+fQFAzJ07V+tnBSDatGkj5s2bJwIDAwUA0bJlS52fqUiRIsLW1lYMHz5cLFiwQOzZs0ekpKSIYsWKCRMTE/HDDz+ImTNnigoVKggfHx8BQOzZs0cIIcSrV6+Eu7u7cHZ2FhMmTBCLFi0SISEholKlSuLatWvvfT27dOkiXF1dpe+vXr0qAIhy5cqJIkWKiMmTJ4spU6YIe3t7UahQIfH69et3PlZ8fLwICgoSAMSPP/4o/R0kJCRIP2fx4sWFk5OT+PHHH8XcuXNF+fLlhUajEWfPnpUeJzk5Wfj4+Ih8+fKJH3/8USxYsEAEBgYKjUYjBgwY8N6fRwghRo4cKQAIPz8/MXfuXNG9e3fh7Ows7O3tRZcuXaT9jh07Jjw9PcXw4cPFb7/9JsaNGycKFiworK2txe3bt4UQH/7b7t+/v/Dz8xMTJ04Uv/32m+jRo4cwNDQUbdq00cpUrVo1YW1tLUaOHCkWLVokJk6cKOrWrSsiIyOlfcLCwoRGoxGNGzcWc+bMEZMnTxZubm7CxsZGXL16VQghxMGDB8XXX38tAEhZVqxY8cHXhIiUg4UNEb1X1sJm7ty5wtLSUqSkpAghhGjbtq10Ev72SfHGjRsFADFhwgStx2vTpo3QaDQiLi5OCCHEjBkzBADx4MGDd2Y4duyYACCWLl36UZkDAwOFgYGBOHbsmM596enpQgghBg4cKACI/fv3S/c9f/5cuLu7Czc3N5GWliaE+L/CpnTp0lonnh06dBAajUb4+vpqPX7VqlW1TmaFyChsjI2NpRMoITKKBgAif/784tmzZ9L2ESNGCADSvq9fvxaOjo6idOnS4sWLF9J+W7ZsEQDE6NGjpW2ZJ/vjxo3Tev5y5cqJChUqvO8lE0Jov4ezZs0SGo1GjB8/Xuu1K1q0qGjUqJH0OgohREpKinB3dxdff/211s9hbGwsEhMTpW33798XefLkEWPGjJG2lSpVSrRr1076vnz58qJt27YCgLhw4YIQQoj169cLACImJkYIIcSpU6cEANGzZ0+t/EOGDBEAxO7du7V+JgBi+/btWvvOnDlTABBr1qyRtiUnJ4siRYpoFTbR0dECgFi7du0HX7+3vauwyZcvn3j8+LG0fdOmTQKA2Lx583sfb+3atVrZssr8Offt2ydtu3//vjA2NhaDBw+Wto0fP16Ym5uLy5cva/3/4cOHC0NDQ3Hjxo13Pv/9+/eFkZGRaNKkidb7/+OPPwoAWoXNy5cvpb+hrD+/sbGx1u/n+/62M48zWYWGhgqNRiOuX78uhBDiyZMnAoCYOnXqO3M/f/5c2NjYiF69emltT0hIENbW1lrb+/btK3jNl0i92BWNiD5au3bt8OLFC2zZsgXPnz/Hli1b3tkNbdu2bTA0NERQUJDW9sGDB0MIgX///RcAYGNjAwDYtGnTR3WF+ZD09HRs3LgRzZo1Q8WKFXXuz+xasm3bNnz11VeoUaOGdJ+FhQV69+6Na9eu4fz581r/LzAwEHnz5pW+r1y5MoQQ6N69u9Z+lStXxs2bN3XGItWvX1+rW1LlypUBAK1bt4alpaXO9itXrgAAjh8/jvv37+P777+HiYmJtF+TJk1QokQJna5zAPDdd99pfV+zZk3p8T7GlClTMGDAAEyePBkjR46Utp86dQqxsbHo2LEjHj16hIcPH+Lhw4dITk5G/fr1sW/fPuk9DAwMxKtXr7Bu3Trp///1119ITU1Fp06dtLLt378fAPD8+XPExMSgd+/esLe3l7bv378fNjY2KF26NICM9w4ABg0apJV78ODBAKDzmri7u6NRo0Za27Zt24YCBQqgTZs20jYzMzP07t1baz9ra2sAQHh4OFJSUj7q9fuQb775Bra2ttL3NWvWBIBPeo+y4+XlJT0WADg4OKB48eJaj7t27VrUrFkTtra20vv38OFDNGjQAGlpadi3b987H3/Xrl14/fo1+vfvr9VFa+DAgTr7Ghsbw8Ag4xQjLS0Njx49krqZnjx58qN+HlNTU+nr5ORkPHz4ENWqVYMQAtHR0dI+RkZG2Lt3L548eZLt4+zcuROJiYno0KGD1s9saGiIypUrY8+ePR+Vh4iUj4UNEX00BwcHNGjQAKtWrcL69euRlpamdWKY1fXr1+Hs7Kx10g5kjJXIvB/IOMmrXr06evbsCScnJ7Rv3x5r1qz57CLnwYMHePbsmXQS/C7Xr19H8eLFdba/nS9T4cKFtb7PPOF1cXHR2Z6enq4z/uJT/j8A6SQtM0d2WUuUKKGT08TEBA4ODlrbbG1t33nS97bIyEgMGzYMw4YN0xpXA2SMNQGALl26wMHBQeu2aNEivHr1Svq5S5QogUqVKmHlypXS/1+5ciWqVKmCIkWKSNtq1qyJu3fvIi4uDgcPHoRGo0HVqlW1Cp79+/ejevXq0ony9evXYWBgoPU4AJA/f37Y2NjovCbu7u46P+f169dRpEgRnTEUb7/O7u7uGDRoEBYtWgR7e3s0atQI8+bN++D4mvd5+3chs8j52PfoYx8387GzPm5sbCy2b9+u8/41aNAAAHD//v13Pn7m61q0aFGt7Q4ODlqFGpBxgWHGjBkoWrQojI2NYW9vDwcHB5w+ffqjX7sbN26ga9eusLOzk8aL1a5dGwCkxzA2NsbkyZPx77//wsnJCbVq1cKUKVOQkJCg9TMDQL169XR+7h07drz3ZyYidckjdwAiUpeOHTuiV69eSEhIgK+vr9Ti8rlMTU2xb98+7NmzB1u3bsX27dvx119/oV69etixYwcMDQ1zJvh/9K4c79ou3pog4b/+/4/1X1+vUqVKITExEStWrMC3336rVRRkFptTp05F2bJls/3/FhYW0teBgYEYMGAAbt26hVevXuHw4cOYO3eu1v6ZLWb79u3DlStXUL58eZibm6NmzZqYPXs2kpKSEB0djZ9//lnnuT52YHfWK/+fY9q0aejatSs2bdqEHTt2ICgoCKGhoTh8+DAKFSr0yY+X0+/5pzxueno6vv76a/zwww/Z7lusWLH/lCHTxIkTMWrUKHTv3h3jx4+HnZ0dDAwMMHDgwI+6aJGWloavv/4ajx8/xrBhw1CiRAmYm5vj9u3b6Nq1q9ZjDBw4EM2aNcPGjRsRHh6OUaNGITQ0FLt370a5cuWkfVesWJHt7I158vBUiCi34F8zEX2SVq1a4dtvv8Xhw4fx119/vXM/V1dX7Nq1C8+fP9dqtbl48aJ0fyYDAwPUr18f9evXx/Tp0zFx4kT89NNP2LNnDxo0aPBJMxM5ODjAysoKZ8+efe9+rq6u2a4xkl0+OWXmuHTpEurVq6d136VLl3I8p729PdatW4caNWqgfv36OHDgAJydnQEAnp6eAAArKyvpCv/7tG/fHoMGDcKff/6JFy9eIG/evFozmwEZrQyFCxfG/v37ceXKFakrVa1atTBo0CCsXbsWaWlpqFWrlvR/XF1dkZ6ejtjYWKmFDQDu3buHxMTEj3pNXF1dcfbsWQghtH6/3rXujLe3N7y9vTFy5EgcPHgQ1atXx4IFCzBhwoQPPldOyYkZujw9PZGUlPRR79/bMl/X2NhYeHh4SNsfPHig09q0bt061K1bF4sXL9banpiYCHt7e+n7d/1MZ86cweXLl7F8+XIEBgZK27POypiVp6cnBg8ejMGDByM2NhZly5bFtGnT8Mcff0i/t46Ojh/8uTkLGpG6sSsaEX0SCwsLzJ8/H2PHjkWzZs3euZ+fnx/S0tJ0rtDPmDEDGo0Gvr6+ADKmhX1bZmtA5tS75ubmADJOij7EwMAALVu2xObNm3H8+HGd+zOvXvv5+eHo0aM4dOiQdF9ycjIWLlwINzc3eHl5ffC59KFixYpwdHTEggULtKYi/vfff3HhwgU0adIkx5+zUKFC2LVrF168eIGvv/4ajx49AgBUqFABnp6e+OWXX5CUlKTz/x48eKD1vb29PXx9ffHHH39g5cqVaNy4sdZJbaaaNWti9+7dOHr0qFTYlC1bFpaWlpg0aRJMTU1RoUIFaX8/Pz8AwMyZM7UeZ/r06QDwUa+Jn58f7ty5ozUGKCUlBQsXLtTa79mzZzrjpby9vWFgYJDt1NBf0qf8HbxLu3btcOjQIYSHh+vcl5iYqPOzZtWgQQPkzZsXc+bM0WoFevt9ADJaj95ugVq7dq3OFOXv+pkyW5+yPoYQArNmzdLaLyUlBS9fvtTa5unpCUtLS+n9adSoEaysrDBx4kS8efNGJ2vW39uceI2JSD5ssSGiT9alS5cP7tOsWTPUrVsXP/30E65du4YyZcpgx44d2LRpEwYOHChdRR03bhz27duHJk2awNXVFffv38evv/6KQoUKSd2UPD09YWNjgwULFsDS0hLm5uaoXLlytmMngIxuMDt27EDt2rXRu3dvlCxZEnfv3sXatWtx4MAB2NjYYPjw4fjzzz/h6+uLoKAg2NnZYfny5bh69Sr+/vtvaTyH3PLmzYvJkyejW7duqF27Njp06IB79+5h1qxZcHNzQ3Bw8Bd53iJFimDHjh2oU6cOGjVqhN27d8PKygqLFi2Cr68vSpUqhW7duqFgwYK4ffs29uzZAysrK2zevFnrcQIDA6VxWOPHj8/2uWrWrImVK1dCo9FI77mhoSGqVauG8PBw1KlTB0ZGRtL+ZcqUQZcuXbBw4UIkJiaidu3aOHr0KJYvX46WLVuibt26H/z5evXqhblz5yIwMBAnTpxAgQIFsGLFCpiZmWntt3v3bvTr1w9t27ZFsWLFkJqaihUrVsDQ0BCtW7f+pNf0vypbtiwMDQ0xefJkPH36FMbGxqhXrx4cHR0/+jGGDh2Kf/75B02bNkXXrl1RoUIFJCcn48yZM1i3bh2uXbuWbfEJQFoTKTQ0FE2bNoWfnx+io6Px77//6vyfpk2bYty4cejWrRuqVauGM2fOYOXKlVotPcC7/7ZLlCgBT09PDBkyBLdv34aVlRX+/vtvnZahy5cvo379+mjXrh28vLyQJ08ebNiwAffu3UP79u0BZLQwzp8/H507d0b58uXRvn17ODg44MaNG9i6dSuqV68uXYDJLKCDgoLQqFEjGBoaSo9DRCogy1xsRKQaWad7fp+3p3sWImOa1eDgYOHs7Czy5s0rihYtKqZOnao1VWxERIRo0aKFcHZ2FkZGRsLZ2Vl06NBBZzraTZs2CS8vL5EnT56Pmvr5+vXrIjAwUDg4OAhjY2Ph4eEh+vbtK169eiXtEx8fL9q0aSNsbGyEiYmJ+Oqrr8SWLVu0Hidzuue3p/t91+syZswYnemrAYi+fftq7Zc59e/b09S+6/n++usvUa5cOWFsbCzs7OxEQECAuHXrltY+Xbp0Eebm5jqvRWamD8nuPTxy5IiwtLQUtWrVkqbfjY6OFv7+/iJfvnzC2NhYuLq6inbt2omIiAidx3z16pWwtbUV1tbWWtNVZ3Xu3DkBQJQsWVJr+4QJEwQAMWrUKJ3/8+bNGxESEiLc3d1F3rx5hYuLixgxYoR4+fLlB3+mTNevXxfNmzcXZmZmwt7eXgwYMEBs375da0rlK1euiO7duwtPT09hYmIi7OzsRN26dcWuXbuyfxGzeNd0z9lNTQxAaxrsd/n999+Fh4eHMDQ01Mr5rp+zdu3aonbt2lrbnj9/LkaMGCGKFCkijIyMhL29vahWrZr45Zdf3ruWjhBCpKWliZCQEFGgQAFhamoq6tSpI86ePStcXV11pnsePHiwtF/16tXFoUOHss3zrr/t8+fPiwYNGggLCwthb28vevXqJWJiYrT2efjwoejbt68oUaKEMDc3F9bW1qJy5cpa03hn2rNnj2jUqJGwtrYWJiYmwtPTU3Tt2lUcP35c2ic1NVX0799fODg4CI1Gw6mfiVRGI8R/HK1IRET0DqmpqXB2dkazZs10xlsQERHlJGX0tSAiolxp48aNePDggdYAcCIioi+BLTZERJTjjhw5gtOnT2P8+PGwt7f/6EUZiYiIPhdbbIiIKMfNnz8fffr0gaOjI8LCwuSOQ0RE/wPYYkNERERERKrHFhsiIiIiIlI9FjZERERERKR6ilugMz09HXfu3IGlpSU0Go3ccYiIiIiISCZCCDx//hzOzs4fXDxbcYXNnTt34OLiIncMIiIiIiJSiJs3b6JQoULv3UdxhY2lpSWAjPBWVlYypyEiIiIiIrk8e/YMLi4uUo3wPoorbDK7n1lZWbGwISIiIiKijxqiwskDiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6eeQO8F+4Dd+aY491bVKTHHssIiIiIiLSL7bYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPU+qbAJDQ1FpUqVYGlpCUdHR7Rs2RKXLl3S2qdOnTrQaDRat++++y5HQxMREREREWX1SYVNZGQk+vbti8OHD2Pnzp148+YNGjZsiOTkZK39evXqhbt370q3KVOm5GhoIiIiIiKirPJ8ys7bt2/X+n7ZsmVwdHTEiRMnUKtWLWm7mZkZ8ufPnzMJiYiIiIiIPuA/jbF5+vQpAMDOzk5r+8qVK2Fvb4/SpUtjxIgRSElJ+S9PQ0RERERE9F6f1GKTVXp6OgYOHIjq1aujdOnS0vaOHTvC1dUVzs7OOH36NIYNG4ZLly5h/fr12T7Oq1ev8OrVK+n7Z8+efW4kIiIiIiL6H/XZhU3fvn1x9uxZHDhwQGt77969pa+9vb1RoEAB1K9fH/Hx8fD09NR5nNDQUISEhHxuDCIiIiIios/ritavXz9s2bIFe/bsQaFChd67b+XKlQEAcXFx2d4/YsQIPH36VLrdvHnzcyIREREREdH/sE9qsRFCoH///tiwYQP27t0Ld3f3D/6fU6dOAQAKFCiQ7f3GxsYwNjb+lBhERERERERaPqmw6du3L1atWoVNmzbB0tISCQkJAABra2uYmpoiPj4eq1atgp+fH/Lly4fTp08jODgYtWrVgo+Pzxf5AYiIiIiIiD6psJk/fz6AjEU4s1q6dCm6du0KIyMj7Nq1CzNnzkRycjJcXFzQunVrjBw5MscCExERERERve2Tu6K9j4uLCyIjI/9TICIiIiIiok/1n9axISIiIiIiUgIWNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqfVJhExoaikqVKsHS0hKOjo5o2bIlLl26pLXPy5cv0bdvX+TLlw8WFhZo3bo17t27l6OhiYiIiIiIsvqkwiYyMhJ9+/bF4cOHsXPnTrx58wYNGzZEcnKytE9wcDA2b96MtWvXIjIyEnfu3IG/v3+OByciIiIiIsqU51N23r59u9b3y5Ytg6OjI06cOIFatWrh6dOnWLx4MVatWoV69eoBAJYuXYqSJUvi8OHDqFKlSs4lJyIiIiIi+v/+0xibp0+fAgDs7OwAACdOnMCbN2/QoEEDaZ8SJUqgcOHCOHToULaP8erVKzx79kzrRkRERERE9Ck+u7BJT0/HwIEDUb16dZQuXRoAkJCQACMjI9jY2Gjt6+TkhISEhGwfJzQ0FNbW1tLNxcXlcyMREREREdH/qM8ubPr27YuzZ89i9erV/ynAiBEj8PTpU+l28+bN//R4RERERET0v+eTxthk6tevH7Zs2YJ9+/ahUKFC0vb8+fPj9evXSExM1Gq1uXfvHvLnz5/tYxkbG8PY2PhzYhAREREREQH4xBYbIQT69euHDRs2YPfu3XB3d9e6v0KFCsibNy8iIiKkbZcuXcKNGzdQtWrVnElMRERERET0lk9qsenbty9WrVqFTZs2wdLSUho3Y21tDVNTU1hbW6NHjx4YNGgQ7OzsYGVlhf79+6Nq1aqcEY2IiIiIiL6YTyps5s+fDwCoU6eO1valS5eia9euAIAZM2bAwMAArVu3xqtXr9CoUSP8+uuvORKWiIiIiIgoO59U2AghPriPiYkJ5s2bh3nz5n12KCIiIiIiok/xn9axISIiIiIiUgIWNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1Prmw2bdvH5o1awZnZ2doNBps3LhR6/6uXbtCo9Fo3Ro3bpxTeYmIiIiIiHR8cmGTnJyMMmXKYN68ee/cp3Hjxrh79650+/PPP/9TSCIiIiIiovfJ86n/wdfXF76+vu/dx9jYGPnz5//sUERERERERJ/ii4yx2bt3LxwdHVG8eHH06dMHjx49+hJPQ0REREREBOAzWmw+pHHjxvD394e7uzvi4+Px448/wtfXF4cOHYKhoaHO/q9evcKrV6+k7589e5bTkYiIiIiIKJfL8cKmffv20tfe3t7w8fGBp6cn9u7di/r16+vsHxoaipCQkJyOQURERERE/0O++HTPHh4esLe3R1xcXLb3jxgxAk+fPpVuN2/e/NKRiIiIiIgol8nxFpu33bp1C48ePUKBAgWyvd/Y2BjGxsZfOgYREREREeVin1zYJCUlabW+XL16FadOnYKdnR3s7OwQEhKC1q1bI3/+/IiPj8cPP/yAIkWKoFGjRjkanIiIiIiIKNMnFzbHjx9H3bp1pe8HDRoEAOjSpQvmz5+P06dPY/ny5UhMTISzszMaNmyI8ePHs1WGiIiIiIi+mE8ubOrUqQMhxDvvDw8P/0+BiIiIiIiIPtUXnzyAiIiIiIjoS2NhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkennkDpBbuQ3fmmOPdW1Skxx7LCIiIiKi3IgtNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESql0fuAKR/bsO35thjXZvUJMceKydzATmbjYiIiIiUjS02RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKqXR+4ARGrgNnxrjj3WtUlNcuyxAGVnIyIiItIXttgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6n1yYbNv3z40a9YMzs7O0Gg02Lhxo9b9QgiMHj0aBQoUgKmpKRo0aIDY2NicyktERERERKTjkwub5ORklClTBvPmzcv2/ilTpmD27NlYsGABjhw5AnNzczRq1AgvX778z2GJiIiIiIiyk+dT/4Ovry98fX2zvU8IgZkzZ2LkyJFo0aIFACAsLAxOTk7YuHEj2rdv/9/SEhERERERZSNHx9hcvXoVCQkJaNCggbTN2toalStXxqFDh7L9P69evcKzZ8+0bkRERERERJ/ik1ts3ichIQEA4OTkpLXdyclJuu9toaGhCAkJyckYRKQQbsO35thjXZvUJMcei4iIiHIf2WdFGzFiBJ4+fSrdbt68KXckIiIiIiJSmRwtbPLnzw8AuHfvntb2e/fuSfe9zdjYGFZWVlo3IiIiIiKiT5GjhY27uzvy58+PiIgIaduzZ89w5MgRVK1aNSefioiIiIiISPLJY2ySkpIQFxcnfX/16lWcOnUKdnZ2KFy4MAYOHIgJEyagaNGicHd3x6hRo+Ds7IyWLVvmZG4iIiIiIiLJJxc2x48fR926daXvBw0aBADo0qULli1bhh9++AHJycno3bs3EhMTUaNGDWzfvh0mJiY5l5qIiIiIiCiLTy5s6tSpAyHEO+/XaDQYN24cxo0b95+CERERERERfSzZZ0UjIiIiIiL6r1jYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUL4/cAYiI9M1t+NYcfbxrk5rk6OMRERHRp2OLDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPXyyB2AiIj+j9vwrTn2WNcmNcmxxwKUnY2IiIgtNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlK9HC9sxo4dC41Go3UrUaJETj8NERERERGRJM+XeNBSpUph165d//ckeb7I0xAREREREQH4QoVNnjx5kD9//i/x0ERERERERDq+yBib2NhYODs7w8PDAwEBAbhx48aXeBoiIiIiIiIAX6DFpnLlyli2bBmKFy+Ou3fvIiQkBDVr1sTZs2dhaWmps/+rV6/w6tUr6ftnz57ldCQiIiIiIsrlcryw8fX1lb728fFB5cqV4erqijVr1qBHjx46+4eGhiIkJCSnYxAR0f8Qt+Fbc+yxrk1qkmOPlZO5AOVmy8lcgLKzEZFyffHpnm1sbFCsWDHExcVle/+IESPw9OlT6Xbz5s0vHYmIiIiIiHKZL17YJCUlIT4+HgUKFMj2fmNjY1hZWWndiIiIiIiIPkWOFzZDhgxBZGQkrl27hoMHD6JVq1YwNDREhw4dcvqpiIiIiIiIAHyBMTa3bt1Chw4d8OjRIzg4OKBGjRo4fPgwHBwccvqpiIiIiIiIAHyBwmb16tU5/ZBERERERETv9cXH2BAREREREX1pLGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSvRxfoJOIiIgot3IbvjXHHuvapCY59lg5mQtQbraczAUw2+dQ8u8aW2yIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLVY2FDRERERESqx8KGiIiIiIhUj4UNERERERGpHgsbIiIiIiJSPRY2RERERESkeixsiIiIiIhI9VjYEBERERGR6rGwISIiIiIi1WNhQ0REREREqsfChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkREREREpHosbIiIiIiISPVY2BARERERkeqxsCEiIiIiItVjYUNERERERKrHwoaIiIiIiFSPhQ0REREREakeCxsiIiIiIlI9FjZERERERKR6LGyIiIiIiEj1WNgQEREREZHqsbAhIiIiIiLV+2KFzbx58+Dm5gYTExNUrlwZR48e/VJPRURERERE/+O+SGHz119/YdCgQRgzZgxOnjyJMmXKoFGjRrh///6XeDoiIiIiIvof90UKm+nTp6NXr17o1q0bvLy8sGDBApiZmWHJkiVf4umIiIiIiOh/XJ6cfsDXr1/jxIkTGDFihLTNwMAADRo0wKFDh3T2f/XqFV69eiV9//TpUwDAs2fPPvhc6a9SciAxPvr5PgWzfbqczAUoN9v/yvsJKDcbf9c+D7N9Ov6ufR5m+3T8Xfs8zPbp9P27lnm/EOKDj6URH7PXJ7hz5w4KFiyIgwcPomrVqtL2H374AZGRkThy5IjW/mPHjkVISEhORiAiIiIiolzk5s2bKFSo0Hv3yfEWm081YsQIDBo0SPo+PT0djx8/Rr58+aDRaP7z4z979gwuLi64efMmrKys/vPj5RSl5gKY7XMpNZtScwHM9rmUmk2puQBm+1xKzabUXACzfS6lZlNqLuB/J5sQAs+fP4ezs/MH983xwsbe3h6Ghoa4d++e1vZ79+4hf/78OvsbGxvD2NhYa5uNjU1Ox4KVlZXi3nRAubkAZvtcSs2m1FwAs30upWZTai6A2T6XUrMpNRfAbJ9LqdmUmgv438hmbW39Ufvl+OQBRkZGqFChAiIiIqRt6enpiIiI0OqaRkRERERElFO+SFe0QYMGoUuXLqhYsSK++uorzJw5E8nJyejWrduXeDoiIiIiIvof90UKm2+++QYPHjzA6NGjkZCQgLJly2L79u1wcnL6Ek/3XsbGxhgzZoxOdze5KTUXwGyfS6nZlJoLYLbPpdRsSs0FMNvnUmo2peYCmO1zKTWbUnMBzJadHJ8VjYiIiIiISN++yAKdRERERERE+sTChoiIiIiIVI+FDRERERERqR4LGyIiIiIiUj0WNkRERERE9J/Ex8dj5MiR6NChA+7fvw8A+Pfff3Hu3Dm9ZWBhQ5SD0tLScOrUKTx58kTWHPXq1UNiYqLO9mfPnqFevXr6D0Qko9evX+PSpUtITU2VOwoA4OTJkzhz5oz0/aZNm9CyZUv8+OOPeP36tYzJKLd7+fKl3BEktra2sLOz07nly5cPBQsWRO3atbF06VK5Y9JHioyMhLe3N44cOYL169cjKSkJABATE4MxY8boLUeune45NTUVe/fuRXx8PDp27AhLS0vcuXMHVlZWsLCwkC1XbGws9uzZg/v37yM9PV3rvtGjR8uUCti9ezeqVasGExMT2TK8z4oVK7BgwQJcvXoVhw4dgqurK2bOnAl3d3e0aNFCtlwDBw6Et7c3evTogbS0NNSuXRsHDx6EmZkZtmzZgjp16siSy8DAAAkJCXB0dNTafv/+fRQsWBBv3ryRJRf9N0o9rr3t2bNn2L17N4oXL46SJUvKliMlJQX9+/fH8uXLAQCXL1+Gh4cH+vfvj4IFC2L48OGy5KpUqRKGDx+O1q1b48qVKyhVqhRatWqFY8eOoUmTJpg5c6YsubJKT09HXFxctp9VtWrVkikVfY709HT8/PPPWLBgAe7duyf9HYwaNQpubm7o0aOHLLlmzJiBn3/+Gb6+vvjqq68AAEePHsX27dsRHByMq1evYsWKFZgzZw569eql12z//PNPtts1Gg1MTExQpEgRuLu76zXTuyjleFu1alW0bdsWgwYNgqWlJWJiYuDh4YGjR4/C398ft27d0k8QkQtdu3ZNlChRQpiZmQlDQ0MRHx8vhBAiKChIfPvtt7LlWrhwoTA0NBROTk6iTJkyomzZstKtXLlysuUSQghzc3NhbGwsatSoIUaOHCl27twpUlJSZM2U6ddffxX29vZiwoQJwtTUVHo/ly5dKurUqSNrtoIFC4pjx44JIYTYsGGDcHZ2FpcuXRIjR44U1apV03uemJgYERMTIzQajdizZ4/0fUxMjDh58qSYOHGicHV11XuurFq2bClatWqlc/P39xcdO3YUo0ePFhcvXpQt3759+0RAQICoUqWKuHXrlhBCiLCwMLF//37ZMgmh3OOaEEK0bdtWzJkzRwghREpKiihatKjImzevyJMnj1i3bp1suYKCgkSFChXE/v37hbm5ufSabdy4UZQtW1a2XFZWViIuLk4IIcSkSZNEw4YNhRBCHDhwQBQqVEi2XJkOHTok3N3dhYGBgdBoNFo3AwMDueOJsLAwUa1aNVGgQAFx7do1IYQQM2bMEBs3bpQ115MnT0R4eLhYsWKFWL58udZNTiEhIcLDw0P88ccfWp+hq1evFlWqVJEtl7+/v5g/f77O9gULFgh/f38hhBCzZ88WpUuX1nc06Xc9u9//zH9r1aolHj9+rPdsSj3empubiytXrgghhLCwsJB+z65evSqMjY31liNXFjYtWrQQnTp1Eq9evdJ6cffs2SOKFCkiW67ChQuLSZMmyfb87/P69Wtx4MAB8fPPP4uGDRsKCwsLYWRkJKpVqyZ++uknWbOVLFlSbNiwQQih/cdy5swZkS9fPhmTCWFsbCxu3rwphBCiV69eYsCAAUIIIa5cuSIsLS31nifzgJvdAVmj0QgzMzOxePFivefKqkuXLsLa2lq4uroKf39/4e/vL9zc3ISNjY1o166dKF68uDA2NhYHDhzQe7Z169YJU1NT0bNnT2FsbCz9rs2ZM0f4+vrqPU9WSj2uCSGEk5OTOHXqlBBCiJUrV4oiRYqI5ORk8euvv8paQBQuXFgcOnRICKF97IiNjZXl7zOTpaWluHz5shBCiAYNGoiZM2cKIYS4fv26MDExkS1XpjJlyoi2bduK8+fPiydPnojExEStm5yUeqHrn3/+EZaWlkKj0Qhra2thY2Mj3WxtbWXLJYQQnp6eYteuXUII7b+DCxcuCBsbG9lymZubi9jYWJ3tsbGxwtzcXAghRFxcnDAzM9N3NLFr1y5RuXJlsWvXLvHs2TPx7NkzsWvXLlG1alWxdetWceDAAVGqVCnRvXt3vWdT6vG2YMGCIioqSgih/Xu2fv164eHhobccubKwsbOzk674vl01mpqaypbL0tJSyqJ0Z8+eFV26dBF58uSR/QqdiYmJdFUu6/t5+fJl2U8CChcuLMLDw0VqaqpwcXERW7ZsEUJkvH5yfGBcu3ZNXL16VWg0GnHs2DFx7do16Xbnzh2Rmpqq90xvGzZsmOjTp49IS0uTtqWlpYl+/fqJESNGiPT0dNG7d29RvXp1vWcrW7asdHU16+/ayZMnhZOTk97zZKXU45oQGX+jN27cEEII0blzZzFs2DAhRMaJeuYJihyynvhmfc1OnTolrKysZMtVt25dERgYKMLCwkTevHmlk7u9e/fK3qIqhBBmZmbZnnAqgVIvdBUtWlQMGDBAJCcny5bhXd71GXru3DlZ/z5dXFzE9OnTdbZPnz5duLi4CCEyeiHIcewtVaqUdJKe1YEDB4SXl5cQQoidO3dKOfVJqcfbwYMHixo1aoi7d+8KS0tLERsbKw4cOCA8PDzE2LFj9ZYjj346vOlXeno60tLSdLbfunULlpaWMiTK0LZtW+zYsQPfffedbBne5fLly9i7dy/27t2LyMhIvHr1CjVr1sQvv/wi2ziRTO7u7jh16hRcXV21tm/fvl3W/qQA0K1bN7Rr1w4FChSARqNBgwYNAABHjhxBiRIl9J4n8zV6u0+8kixevBhRUVEwMPi/uUsMDAzQv39/VKtWDRMnTkS/fv1Qs2ZNvWe7dOlStuMHrK2ts52MQZ+UelwDABcXFxw6dAh2dnbYvn07Vq9eDQB48uSJrOP2KlasiK1bt6J///4AMvrHA8CiRYtQtWpV2XLNnDkTAQEB2LhxI3766ScUKVIEALBu3TpUq1ZNtlyZKleujLi4OCmXkly9ehXlypXT2W5sbIzk5GQZEmW4ffs2goKCYGZmJluGd/Hy8sL+/ft1PkPXrVuX7WupL6NGjUKfPn2wZ88eaYzNsWPHsG3bNixYsAAAsHPnTtSuXVvv2eLj42FlZaWz3crKCleuXAEAFC1aFA8fPtR3NMUebydOnIi+ffvCxcUFaWlp8PLyQlpaGjp27IiRI0fqLUeuLGwaNmyImTNnYuHChQAyPsySkpIwZswY+Pn5yZarSJEiGDVqFA4fPgxvb2/kzZtX6/6goCCZkgElSpSAg4MDBgwYgOHDh8Pb21s6CZDboEGD0LdvX7x8+RJCCBw9ehR//vknQkNDsWjRIlmzjR07FqVLl8bNmzfRtm1bGBsbAwAMDQ1lG5icSakTVaSmpuLixYsoVqyY1vaLFy9KJ+4mJiay/P7lz58fcXFxcHNz09p+4MABeHh46D1PVko9rgEZk2gEBATAwsICrq6u0sWQffv2wdvbW7ZcEydOhK+vL86fP4/U1FTMmjUL58+fx8GDBxEZGSlbLh8fH61Z0TJNnToVhoaGMiTS1r9/fwwePBgJCQnZflb5+PjIlEy5F7oaNWqE48ePy36cyM7o0aPRpUsX3L59G+np6Vi/fj0uXbqEsLAwbNmyRbZcvXr1gpeXF+bOnYv169cDAIoXL47IyEipwB88eLAs2SpUqIChQ4ciLCwMDg4OAIAHDx7ghx9+QKVKlQBkfMa6uLjoPVvW423hwoUVc7w1MjLC77//jlGjRuHs2bNISkpCuXLlULRoUf0G0VvbkB7dvHlTeHl5iZIlS4o8efKIKlWqiHz58onixYuLe/fuyZbLzc3tnTd3d3fZcgkhxIABA0S5cuWEsbGxqFq1qhgxYoQIDw9XTLP6H3/8IYoUKSKNFSlYsKBYtGiR3LG0vHjxQu4IEiVPVNG/f39hb28vpk+fLvbv3y/2798vpk+fLuzt7UVQUJAQQojff/9dlq5oEydOFF5eXuLw4cPC0tJS7N+/X/zxxx/CwcFBzJ49W+95slLqcS3T8ePHxfr168Xz58+lbVu2bJFlrFRWcXFxomfPnqJSpUqiZMmSIiAgQJw+fVrWTJmOHTsmwsLCRFhYmDQJiRJkNz4v66BpOf3++++iYMGCYvXq1cLc3Fz8+eefYsKECdLXclm0aJEoXLiwGDNmjFi3bp3YtGmT1k1u+/btEw0aNBAODg7C1NRUVK9eXYSHh8sdS7EuXrwoihcvLoyMjISnp6fw9PQURkZGokSJEuLSpUtCiIwJg8LCwmTJd+zYMUUeb5UgV0/3vHr1apw+fRpJSUkoX748AgICYGpqKnc0RUtMTMT+/fsRGRmJyMhInDt3DuXKlUNUVJTc0QBkTN+alJSkM42xXNLS0jBx4kTFTaPp6uqK77//HsOGDZPl+d8nLS0NkyZNwty5c3Hv3j0AgJOTE/r3749hw4bB0NAQN27cgIGBAQoVKqTXbEIITJw4EaGhoUhJSQGQ0cVlyJAhGD9+vF6zZIfHtdzh1q1b6NChA6KiomBjYwMg49hbrVo1rF69Wu+/92+7fv36e+9/u7VE31auXImxY8ciPj4eAODs7IyQkBDZjrcAtLrWvk2j0WTbjZSUPa14eno6duzYgcuXLwPIaE36+uuv3/te69Pr169x9epVeHp6Ik8e+TtgpaWlYdmyZYiIiMj2/dy9e7decuTawkbpMl92pXT3yvTo0SNERkZiz5492Lt3L86fPw9bW1tZ+pFmunr1KlJTU3WaM2NjY5E3b16dbkP6NG7cOCxfvhzjxo1Dr169cPbsWXh4eOCvv/7CzJkzcejQIVlyWVlZ4dSpU4rsFpHVs2fPACDbvsxyev36NeLi4pCUlAQvLy9FrBHz8uVLxa4zBWScrP/zzz+4ceOGziKT06dP11uOzN+pjyHX713jxo2RmJiI5cuXo3jx4gAyxnd169YNVlZW2L59uyy51EZpF7qUysPDA8eOHUO+fPm0ticmJqJ8+fLSmBF9O3z4MDp27Ijr16/j7VNRFoPvptT1ufr164dly5ahSZMm0rjjrGbMmKGXHLm2sFHq+IKwsDBMnToVsbGxAIBixYph6NCh6Ny5s2yZgIzxPVkLmVq1aqF27dqoU6eO7ONtateuje7du6NLly5a2//44w8sWrQIe/fulScYMsZN/fbbb6hfv77WglQXL15E1apV8eTJE1ly9ejRA5UqVVLkRBX0eaysrNCqVSt06tQJ9evXV8xVQwCIiIhA8+bNpd/90qVL49q1axBCoHz58nq7UgdkXDn/0PFKCCHriZOpqSkOHjyoM3D7xIkTqFmzptRaKKf4+HjMnDkTFy5cAJAxAH3AgAHw9PSUNZeSL3Qp1bsWbL537x4KFy6MV69eyZKrbNmyKFasGEJCQrI9Eba2tpYlV6aIiIh3tj4sWbJEplTAgAEDEBUVhZkzZ6Jx48Y4ffo0PDw8sGnTJowdOxbR0dGy5LK3t0dYWJjsYz7lb7v6An7//Xf06dMH9vb2yJ8/v9Yfi0ajka2wmT59OkaNGoV+/fqhevXqADIGJX/33Xd4+PAhgoODZckFAHfv3kXv3r1Rp04dlC5dWrYc2YmOjpZer6yqVKmCfv36yZDo/9y+fTvbmYPS09Px5s0bGRJlUPJEFffu3cOQIUOkD4y3r63o+2TT39//o/fNHOAqh+XLl2PVqlVo0aIFrK2t8c0336BTp06oWLGibJkyjRgxAkOGDEFISAgsLS3x999/w9HREQEBAWjcuLFes+zZs0evz/c5XFxcsj0+pKWlwdnZWYZE2sLDw9G8eXOULVtWOvZGRUWhVKlS2Lx5M77++mvZsnXt2hXdu3fXKWyOHDki+4WuyMhI/PLLL1rF4NChQ2WZ4REA/vnnH+nr8PBwrUIhLS0NERERshaCsbGxWLdunSJn3wsJCcG4ceNQsWLFbIsuOW3cuBF//fUXqlSpopWrVKlSUvdMORgZGSnivcyVLTZKHV/g7u6OkJAQBAYGam1fvnw5xo4di6tXr8qUTNmsra2xd+/ebK9u1qlTB8+fP5cpWcbMKcHBwejUqZNWi824ceOwc+dO7N+/X5Zc7u7u77xPo9HI1vUAAHx9fXHjxg3069cv2w+MFi1a6DVPt27dPnrfpUuXfsEkH+f58+dYt24d/vzzT+zevRseHh7o1KmTrC3RlpaWOHXqFDw9PWFra4sDBw6gVKlSiImJQYsWLXDt2jXZsinRpk2bMHHiRMybN08qTI8fPy6NM2vZsqWs+cqVK4dGjRph0qRJWtuHDx+OHTt24OTJkzIly2i5PHnypM4JVFxcHCpWrCjbtOx//PEHunXrBn9/f61icMOGDVi2bBk6duyo90yZrboajUbnAlJm69a0adPQtGlTvWcDgHr16uGHH37Q+8WPj1GgQAFMmTJF9t402TEzM5O6vWc974iJiUGtWrXw9OlTWXJNmzYNV65cwdy5c+UtBGWYsOCLU+pCmMbGxtkuenb58mVhbGwsQyJtYWFholq1aqJAgQLSYl4zZswQGzdulDVX06ZNRdu2bbUWl0xNTRWtW7cWjRs3ljGZEBs3bhTW1tZi0qRJwszMTEydOlX07NlTGBkZiR07dsiaTaksLCxEdHS03DFyhXPnzomyZcvKPlOVk5OTOH/+vBAiYwHFzFmgTp06JeuCcUII8fjxYzF16lTRvXt30b17d/HLL7+IR48eyZrJxsZGGBkZCQMDA2FkZKT1ta2trdZNDsbGxuLy5cs62y9duiT7Z5WVlZU4efKkzvbjx48LCwsLGRJlKFGiRLaLTU6bNk2UKFFChkT/x83NTTx48EDWDNlZv3698PLyEkuXLhXHjx8XMTExWjc52dnZibi4OFkzvEvNmjWlWTotLCzElStXhBBC9OvXTzRq1Ei2XC1bthTW1tbC3d1dNG3aVLRq1Urrpi+5siuaUhfCLFKkCNasWYMff/xRa/tff/2l/3m+3zJ//nyMHj0aAwcOxM8//yx1B7KxscHMmTP1fhU9q0mTJqF27dooXry41KS/f/9+PHv2TK9997PTokULbN68GePGjYO5uTlGjx6N8uXLy95dI5PSZk0BMrrhCIU2FI8ZMwbdu3eXfdan93n58iX++ecfrFq1Ctu3b4eTkxOGDh0qa6YqVargwIEDKFmyJPz8/DB48GCcOXMG69evR5UqVWTLtW/fPjRr1gzW1tZSy8js2bMxbtw4bN68WbZZl2bOnCnL834sBwcHnDp1Sudz6dSpU7IP1K9VqxZCQ0Px559/Smv+pKWlITQ0FDVq1JAt15UrV9CsWTOd7c2bN9f5zNc3pfYGad26NQCge/fu0rbM1iW5Jw/o2bMnVq1ahVGjRsmW4V2Uuj6XjY0NWrVqJdvzZ8qVXdFCQ0Mxffp0NGnSRFHjC/7++2988803aNCggVZTdUREBNasWSPrL4SXlxcmTpyIli1bajVtnj17FnXq1JF1VjQAuHPnDubOnYuYmBiYmprCx8cH/fr1g52dnay5lEqps6YAwI4dOzBt2jT89ttvihvoW7ZsWZw9exa1a9dGjx490Lp1a2nRVbmFh4dj1apV2LhxI/LkyYM2bdogICBA9ilRgYyTuqSkJPj4+CA5ORmDBw/GwYMHUbRoUUyfPl22QtHb2xtVq1bF/PnztU6Cv//+exw8eDDbRTIpY7bHGTNmYPjw4dJCiVFRUZg8eTIGDRok68ne+fPnUatWLdjY2GR7oUuuMaJFihTB0KFD8e2332ptX7BgAaZNmyZNGKQvs2fPRu/evWFiYoLZs2e/d1+5zomUPK34gAEDEBYWBh8fH/j4+OicR+pzpsfsxMfHY9KkSYiJiZGm/h82bJisC3QqRa4sbJQ8vuDEiROYMWOGNLiwZMmSGDx4sM74EX0zNTXFxYsX4erqqlXYxMbGwsfHBy9evJAl15s3b9C4cWMsWLBA9lYtNVHqrCkAYGtri5SUFKSmpsLMzEznA+Px48cyJcsQHR2NpUuX4s8//0Rqairat2+P7t27S6tNy8XMzAxNmzZFQEAA/Pz8dF430mVqaopTp05JUypnunTpEsqWLavX49qzZ8+k6aU/NCW13NOfCyEwc+ZMTJs2DXfu3AGQsVbM0KFDERQUJPtAaiVe6Jo/fz4GDhyI7t27axWDy5Ytw6xZs3QKni/N3d0dx48fR758+RR9TqRUdevWfed9Go1G9t4i9G65srChT+fl5YXQ0FC0aNFCq7CZM2cOli5dKutgUQcHB+nqrxLY2tp+9Ae7XCfprq6u0qwpWd/PuLg4lC9f/pPW+shpma1I7/L2tN5yefPmDTZv3oylS5ciPDwcJUqUQI8ePdC1a1dZpiF9/vw5LC0t9f68HysxMRHr1q1DfHw8hg4dCjs7O5w8eRJOTk4oWLCgLJmqV6+OoUOH6gzG37hxIyZNmoTDhw/rLYuhoSHu3r0LR0fHd05JrYQuOG/LnJxFyb97SrFhwwZMmzZN68Ll0KFDZe3KrTT//PMPfH19kTdvXq1Z27LTvHlzPaVSn7S0NGzYsEFrBr4WLVrovct5+fLlERERAVtbW5QrV+6950b6Oo9URqf7XEwtV+kGDRqEvn374uXLlxBC4OjRo/jzzz8RGhqKRYsWyZYLADp16oTFixfrzNAjF6X3jweABw8eZNsXPjk5WfarrUopXD5ECIE3b97g9evXEELA1tYWc+fOxahRo/D777/jm2++0WseS0tLpKWlYePGjTofZpndrORy+vRpNGjQANbW1rh27Rp69eoFOzs7rF+/Hjdu3EBYWJhes2QKCgrCgAEDEBcXJ431OXz4MObNm6f348nu3bulFoWlS5fCxcVF531LT0/HjRs39JrrQ5RQ0Jw+fRqlS5eGgYGB1vubHR8fHz2l0tWqVStFjDH4kLS0NJw5cwaurq6wtbXV63O3bNlSWlPnfbP/Ka3AV5Jz586hefPmSEhIkFqjJ0+eDAcHB2zevFmv3TFbtGghdddu0aKF7OcXQC5qsRk0aBDGjx8Pc3NzDBo06L376rNvpJqu0q1cuRJjx46V5kF3dnZGSEgIevToIWuu/v37IywsDEWLFkWFChVgbm6udb/cfV2VqFatWmjbti369+8PS0tLnD59Gu7u7ujfvz9iY2P1vrK5Wgp8IKO7aGZXNGNjYwQGBqJnz57S9LJz5szBhAkTcO/ePb3miouLg5+fH27fvq21Wr2Liwu2bt0q68KJDRo0QPny5TFlyhStFsKDBw+iY8eOep3uOfM4+6GPNjmPuVk/F7J69OgRHB0dZcmlxCuvmbIuMPm+91cJn6NKNHDgQHh7e6NHjx5IS0tDrVq1cOjQIZiZmWHLli2oU6eO3BEVwd/fH8uWLYOVldUH1zeTc02zqlWrwsHBAcuXL5cK0ydPnqBr16548OABDh48KFs2Jcg1LTbR0dHSgmdyjh94W9ardEpfOC4gIAABAQFISUlBUlKS7LPfZDp79izKly8PIGMQfFZyXx3Ytm0bDA0N0ahRI63tO3bsQFpaGnx9fWXJpbRZU2xtbaUTORsbG8UW+N7e3rh48SIaNmyIxYsXo1mzZjpX1Tt06IABAwboPVtQUBA8PT1x+PBh6Zjy6NEjdOrUCUFBQdi6daveM2U6duwYfvvtN53tBQsWREJCgl6zKHUGqKwyf9fflpSUBBMTExkSKfPKa6arV6/CwcFB+lop7OzscPnyZdjb23+wi7KcYwfXrVuHTp06AQA2b96Ma9eu4eLFi1ixYgV++uknREVFyZZNSaytraX3UI7uxh/r1KlTOH78uFZrm62tLX7++WdZx4J2794dtWvX1umV8ezZMwwcOBBLlizRS45c02KjBjdu3ICLi4vOwU8IgZs3b6Jw4cIyJaPP5ePjg0mTJsHPz09r+/bt2zFs2DDExMTIlExZs6ZERkaievXqyJMnzwcLq9q1a+spla7x48eje/fuso0JeR9zc3McPnxY5/2LiYlB9erVkZSUJFMywNHREeHh4ShXrpxWi83OnTvRvXt33Lx5U7ZsSpLZm2DWrFno1asXzMzMpPvS0tJw5MgRGBoa8kTzHd68eYNvv/0Wo0aNeu+AeH1Zvnw52rdvD2NjYyxbtuy9hY2cXXBNTEwQFxeHQoUKoXfv3jAzM8PMmTNx9epVlClTRtYxlxEREToTKg0cOBANGjSQLZPSlSlTBjNmzEC9evW0tu/evRsDBgyQbbZHAwMDmJqaokePHpg5c6a0QOy9e/fg7Oyst4uWuabFJquwsDBUqlQJJUuW1Nr+8uVLrFmzBoGBgbLkcnd3z7b7wePHj+Hu7q73K9VK7nqQnbi4OMTHx6NWrVowNTV951VPfYqNjYWXl5fO9hIlSiAuLk6GRP/H09MTv//+u6wZMmUtVuQsXD4kcyzN2168eIGpU6di9OjRMqTKYGxsLA3kziopKQlGRkYyJPo/zZs3x7hx47BmzRoAGS2pN27cwLBhw6S1KuR0/vx53LhxA69fv9baru/ByZm9CYQQOHPmjNb7ZmRkhDJlymDIkCF6zZQdDw8PHDt2DPny5dPanpiYiPLly8s2i1bevHnx999/K2ZtkazFSteuXeUL8gFOTk44f/48ChQogO3bt2P+/PkAMpYFkHN83q+//ooBAwagTZs2Uiv44cOH4efnhxkzZqBv376yZVOy0NBQBAUFYezYsVpjB8eNG4fJkydrFar67tq9detW9OzZExcuXMCaNWv0PoYLyKUtNgYGBjA3N8eyZcu0PlT1XTVml+vevXtSk3qm69evw8vLC8nJyXrNExISgqFDh8LMzAxjx459b5EwZswYPSbT9ujRI7Rr1w579uyBRqNBbGwsPDw80L17d9ja2mLatGmyZcufPz9WrVqlc+Vk165d6NixI+7fvy9LLqX14f/QgN+s5Bz8q7TXLavAwECcPHkSixcvxldffQUAOHLkCHr16oUKFSpg2bJlsmV7+vQp2rRpg+PHj+P58+dwdnZGQkICqlatim3btumMi9OXK1euoFWrVjhz5ozWuIzMY51c72e3bt0wa9Ys2ceTvUvWMS1Z3bt3Dy4uLjoFoj516dIFZcuWRXBwsGwZsqPkY8fYsWMxc+ZMFChQACkpKbh8+TKMjY2xZMkS/P777zh06JAsuQoVKoThw4ejX79+WtvnzZuHiRMn4vbt27LkAjJ+14cMGYKIiAjcv39fZ0yXnO9nZksI8H/HsrePbXJ07c48bhgaGqJ169a4ffs2/vnnH9jZ2bHFJieEhISgc+fOOHPmDMaOHStrlszuBxqNBqNGjcq2+0HZsmX1nitrsSL3a/Q+wcHByJs3L27cuKHVCvfNN99g0KBBshY2LVq0wMCBA7FhwwZp8HZcXBwGDx4s61SV77pe8erVK1mu7pctW1ZrRen3kfMD4135YmJiZF8Mdvbs2ejSpQuqVq0qrWHz5s0btGjRQvaZ+qytrbFz504cOHAAp0+flro+yt2dZMCAAXB3d0dERATc3d1x9OhRPHr0CIMHD8Yvv/wiW66lS5fK9tzvk3X63fDwcK1xBmlpadLrKKeiRYti3LhxiIqKynYyGbkWm1TaMTersWPHonTp0rh58ybatm0rjaUyNDSUdbHmxMRENG7cWGd7w4YNMWzYMBkS/Z+uXbvixo0bGDVqFAoUKCB775CslDpeO/M1ypcvH3bt2oXvvvsOVatWxdSpU/WbI7e22CQkJEhX66pXr44VK1bg2bNnsrTYZC70FBkZiapVq+p0P3Bzc8OQIUNkXaelZ8+e6NSpkyJnR8mfPz/Cw8NRpkwZrf77V65cgY+Pj6xjC54+fYrGjRvj+PHjKFSoEADg1q1bqFmzJtavXw8bGxu95slcYTo4OBjjx4+HhYWFdF9aWhr27duHa9eu6X2CjawrTEdHR2PIkCEYOnQoqlatCgA4dOgQpk2bhilTprx3CtAvJXPg79OnT2FlZaX1IZaWloakpCR89913mDdvnt6zvS0uLk6rP3rmbG2ky97eHrt374aPjw+sra1x9OhRFC9eHLt378bgwYMVNdGMEmReCc5u1rG8efPCzc0N06ZNQ9OmTeWIB0B5C3Ar9ZirBh07dkS5cuUwdOhQre2//PILjh8/jtWrV8uULGOa8/3798ty0VmtsmvpnT59OoYNG4b09HS22PwXmSclVapUwZEjR9C8eXNUq1YNCxYskCVPZnWt5O4HDx48QOPGjeHg4ID27dujU6dOKFOmjNyxAGSsvZK1lSvT48ePpStPcrG2tsbBgwexc+dOrVWwa9WqJUueGTNmAMi4erhgwQKt/tOZRbQcfweurq7S123btsXs2bO1Jlzw8fGBi4sLRo0aJUthM3PmTAgh0L17d4SEhGhdqc583TKLMH360NT1Wa/c6Xva88wTuo8h11X0tLQ0aR0We3t73LlzB8WLF4erqysuXbokSyYlS09PB5BRPBw7dgz29vYyJ9KVdVa0t7vfyEGpx9y3KXGQvpeXF37++Wfs3btXOr4ePnwYUVFRGDx4sNYxRt/HEBcXlw9OGa9PaljLac+ePTo9GwYNGgQfHx+9ToiSq1tsMqvGlJQUBAQEICIiAsnJyYqY5z5zliAXFxeZk/yfJ0+eYO3atVi1ahX279+PEiVKICAgAB07doSbm5tsufz8/FChQgWMHz9eWpPF1dUV7du3R3p6OtatWydbNqWqW7cu1q9fL8vAvQ8xNTXFyZMndSb3uHDhAsqXL48XL17IlEx79jYlyGzt/RCNRoPdu3d/4TTa3r5y/uDBA6SkpEitlImJiTAzM4Ojo6Nsg81r1qyJwYMHo2XLlujYsSOePHmCkSNHYuHChThx4gTOnj0rSy76bxYvXowZM2YgNjYWQEb3tIEDB6Jnz56yZVLyMTfrIP2sBcS6detkHaT/sd0a5WiJ27FjB6ZNm4bffvtN1vOfTFzL6ePlysIm66D4rMaMGYN9+/bJ1j8xNTUVISEhmD17ttR9ysLCAv3798eYMWOkfvNKcOvWLfz5559YsmQJYmNjkZqaKluWs2fPon79+ihfvjx2796N5s2b49y5c3j8+DGioqL0vjDh7Nmz0bt3b5iYmHzwqrVcV6qVrHz58ihdujQWLVokdct8/fo1evbsibNnz8o6A9/JkyeRN29eaUrlTZs2YenSpfDy8sLYsWNl7yuvVKtWrcKvv/6KxYsXay0e2qtXL3z77bcICAiQJVd4eDiSk5Ph7++PuLg4NG3aFJcvX0a+fPnw119/6Uz6Qf8nOTkZkZGR2c4mJ+dxbfTo0Zg+fTr69++v1ZV17ty5CA4Oxrhx42TLplRKHqSvVLa2tkhJSUFqairMzMx0zs/0vS7R9evXUbhwYWg0Gq2u3dnJ2kNC327duoV//vkn2+OGvnoV5MrCRqn69OmD9evXY9y4cVoH5LFjx6Jly5bSFIxye/PmDbZu3Yo//vgDW7duhZ2dnewHvqdPn2Lu3Llaa7L07dsXBQoU0HsWd3d3HD9+HPny5VNcf+9MaWlpWLZsmTSjS2YXk0z6vrqf1dGjR9GsWTMIIaQm89OnT0Oj0WDz5s3SjF9yqFSpEoYPH47WrVvjypUr8PLygr+/P44dO4YmTZrIPkhfqTw9PbFu3TqUK1dOa/uJEyfQpk0bRS2q+Pjx4w8upvi/Ljo6Gn5+fkhJSUFycjLs7Ozw8OFD2VvgAMDBwQGzZ89Ghw4dtLb/+eef6N+/Px4+fChTMmWc1GXHwsICp06d0hmPFxsbi3Llysk6TjWTEroVZrV8+fL33i/nukRKFRERgebNm8PDwwMXL15E6dKlce3aNQghpAvT+pCrC5vs1i7QaDRo1qyZLHmsra2xevVqndXot23bhg4dOuDp06ey5Mq0Z88erFq1Cn///TfS09Ph7++PgIAA1KtXTzEHG/o4/fr1w7Jly9CkSZNsZ3TJ7Bcul+TkZKxcuRIXL14EkNHfu2PHjrJNC5zJ2toaJ0+ehKenJyZPnozdu3cjPDwcUVFRaN++PReafAczMzNERkbqrHp99OhR1KlTBykpKbLkWrp0Kdq3bw9TU1NZnl+t6tSpg2LFimHBggWwtrZGTEwM8ubNi06dOmHAgAHw9/eXLZuNjQ2OHTumM9nO5cuX8dVXXyExMVGWXEo5qcuOkgfpK7FbodKFhobCyckJ3bt319q+ZMkSPHjwQLYZ5b766iv4+voiJCREmujJ0dERAQEBaNy4Mfr06aOfICIXio+PFz4+PkKj0QgDAwOh0Wikrw0MDGTL5eDgIM6fP6+z/fz588Le3l6GRP/H2dlZmJiYiJYtW4q1a9eKly9fyprnbS9evBBHjhwRmzdvFps2bdK6ySkkJEQkJyfrbE9JSREhISEyJMqQL18+sXXrVtmeX60sLS3F5cuXhRBCNGjQQMycOVMIIcT169eFiYmJnNEUrWnTpqJcuXLixIkT0rbjx4+L8uXLi2bNmsmWy9HRUVhaWoru3buLqKgo2XKojbW1tbh48aL0debn1uHDh0Xx4sXljCb69esngoODdbYPHjxYfP/99zIkylCpUiUxevRoIYQQFhYWIj4+Xjx//lw0b95c/Prrr3rPM2vWLOk2fvx4YW1tLfz8/MT48ePF+PHjRZMmTYSNjY0YP3683rNlGjVqlDA3NxfDhw+XPs+HDx8uLCwsxKhRo2TLlSkuLk789NNPon379uLevXtCCCG2bdsmzp49K2suV1fXbI9nhw8fFm5ubjIkymBhYSHi4uKEEELY2NhIr9OpU6eEq6ur3nLkysKmadOmokWLFuLBgwfCwsJCnD9/Xuzfv1989dVXYt++fbLlCgkJER06dNAqGl6+fCkCAgLE2LFjZcslhBALFy4UT548kTXDu/z777/CwcFBKlCz3uQsVIUQwsDAQDrgZfXw4UNZsxUoUEBcunRJtuf/GOfOnRP//vuvogrVunXrisDAQBEWFiby5s0rYmNjhRBC7N27V68HZrW5f/++8PX1FRqNRhgZGQkjIyOh0WiEr6+vSEhIkC3XmzdvxPr160Xz5s1F3rx5RfHixcWkSZPE3bt3ZcukBvb29lKBX7RoUbF9+3YhhBAXLlwQZmZmckYT/fr1E1ZWVqJUqVKiR48eokePHqJ06dLCyspKKnoyb/qklJO6TG5ubh91c3d313u2TPb29mLVqlU621etWiXy5csnQ6L/s3fvXmFqaioaNGggjIyMRHx8vBBCiNDQUNG6dWtZsxkbG4srV67obI+PjxfGxsYyJMrg5OQkXQQpWbKk9Hl+6tQpYW5urrccypj6J4cdOnQIu3fvhr29PQwMDGBgYIAaNWogNDQUQUFBss0nHx0djYiICBQqVEiaSjkmJgavX79G/fr1tZr3169fr9dsvXr1ApCxRkZ8fDxq1aoFU1PTj1pQ8Uvr378/2rZti9GjR8PJyUnWLG971+sj94KOgwcPxqxZszB37lzZ37+3KXU1eCBj2ueAgABs3LgRP/30k9Qnfd26dahWrZpsuZTOwcEB27ZtQ2xsrDSdbIkSJVCsWDFZc+XJkwetWrVCq1atcO/ePfzxxx9Yvnw5Ro0ahcaNG6NHjx5o1qyZ1kreBJQrV07q7lW7dm2MHj0aDx8+xIoVK1C6dGlZs509exbly5cHAMTHxwPImMrb3t5ea5Y7fR/3zM3NpW7vBQoUQHx8PEqVKgUAsoz7UdK4tnd58+YNKlasqLO9QoUKsk5YBADDhw/HhAkTMGjQIGnKeACoV68e5s6dK2OyjNl0o6KidMb4RkVFwdnZWaZUGUusHDhwACVLloSfnx8GDx6MM2fOYP369ahSpYrecuTKwkapaxfY2NigdevWWtuUMt3zo0eP0K5dO+zZswcajQaxsbHw8PBAjx49YGtri2nTpsmW7d69exg0aJCiiprMwccajQbFihV754KOcjlw4AD27NmDf//9F6VKldKZ0UXfhXNWSl0NHsiY///MmTM626dOnaq1PgVlrE8wfvx4mJubZ7vezt69e6Wv5Rw4ncnJyQk1atTA5cuXcfnyZZw5cwZdunSBra0tli5dqsjFieUyceJEPH/+HADw888/IzAwEH369EHRokWxZMkSWbMpddV1pZzUvc/r169x9epVeHp6KmJK+86dO2P+/Pk6x4eFCxfKNpNipjNnzmDVqlU62x0dHWWdoALIuBA9cOBAvHnzRprZMSIiAj/88AMGDx4sW67p06dLE1GEhIQgKSkJf/31F4oWLarXzwD5f7O/gNKlSyMmJgbu7u6oXLkypkyZAiMjIyxcuBAeHh6y5Vq6dKlsz/0hwcHByJs3L27cuKG1vsg333yDQYMGyVrYtGnTBnv37tX7tM7vo9QFHTPZ2NigVatWsj3/+yi1RTVTYmIi1q1bh/j4eAwdOhR2dnY4f/48nJycULBgQVmzKUl0dDTevHkjff0ucrcY3rt3DytWrMDSpUtx5coVtGzZElu2bEGDBg2QnJyMcePGoUuXLh+cQvV/Sdar6I6Ojti+fbuMadRBKSd12UlJSUH//v2lmb4uX74MDw8P9O/fHwULFsTw4cNly7Z48WLs2LFDKv6OHDmCGzduIDAwUOuCib5fQxsbG9y9e1enVSQ6Olr2z4GhQ4fi0aNH+P7776VWQhMTEwwbNgwjRoyQLVfW82tzc3PZFqbNlbOice2CT5c/f36Eh4ejTJky0mwWHh4euHLlCnx8fGSdDjIlJQVt27aFg4MDvL29dVof5FpTITU1FStXrkS9evUU0/KmBra2tjh58iTc3d3h6emJRYsWoW7duoiPj4e3t7dsM2gBGdNO169fHzY2Nrh27RouXboEDw8PjBw5Ejdu3EBYWJhs2ejTNWvWDOHh4ShWrBh69uyJwMBAnS6i9+/fR/78+XWmRCf6WGlpaYiKioKPj4+0QK2SDBgwAFFRUZg5cyYaN26M06dPw8PDA5s2bcLYsWNlu5ik5AWIhwwZgiNHjmDt2rUoVqwYTp48iXv37iEwMBCBgYEYM2aMXvNkJykpCRcuXICpqSmKFi0KY2NjuSMpQq5ssWnUqJH0dZEiRXDx4kXZ1i4oX748IiIiYGtri3Llyr33+eVcmDA5OVlnQVMgY80Huf9Y/vzzT+zYsQMmJibYu3ev1muo0WhkK2zy5MmDPn36SGMKlOjBgwdS98vixYvDwcFB5kTKbVEFMrpXdevWDVOmTNHqV+3n54eOHTvKmIw+h6OjIyIjI9/beurg4KCK8Qj69OjRI4wePRp79uzJdh0sfS9OqHSGhoZo2LAhLly4oMjCZuPGjfjrr79QpUoVrc/PUqVKSeOU5KDUboVARnfMvn37wsXFBWlpafDy8kJaWho6duyIkSNHyh0PAJCQkIDHjx+jVq1aMDY2ln1M9LvOsTUaDUxMTFCkSBF07doV3bp1+6I5cmVhkx25BnK3aNFCKgxatmwpS4aPUbNmTYSFhWH8+PEAMn4R09PTMWXKlI++qvKl/PTTTwgJCcHw4cMVN8j3q6++QnR0tKwr/WYnOTkZ/fv3R1hYmHRSYmhoiMDAQMyZMyfbIlZfRo4cieTkZADAuHHj0LRpU9SsWVNqUZXTsWPH8Ntvv+lsL1iwIBISEmRIRP/F4sWLP7iPRqNR3N+v3Dp37oy4uDj06NEDTk5OsncnVIPSpUvjypUr7120WS4PHjyAo6Ojzvbk5GTFvLe3bt0CABQqVEjmJBmMjIzw+++/Y9SoUTh79iySkpJQrlw5nfWT5KDUMdGjR4/Gzz//DF9fX2mh7aNHj2L79u3o27cvrl69ij59+iA1NVWasOqL0Nv8a3rUsmVL0apVK52bv7+/6Nixoxg9erQ0R7++pKamisjISMVOqXz27Fnh6OgoGjduLIyMjESbNm1EyZIlhZOTkzSFpVxsbW1lz/Auf/31l/Dw8BBz5swRBw8eFDExMVo3ufTu3Vt4eHiIbdu2iadPn4qnT5+KrVu3Ck9PT/Hdd9/JlutdHj16JNLT0+WOIRwcHMTJkyeFEP+3FoUQQuzYsUMUKlRIzmj0mfbu3SuaNm0qPD09haenp2jWrJms0/6rgYWFhTh16pTcMVTl33//FWXLlhWbN28Wd+7ckY67mTc51axZU8yePVsIkfHeZk4V3K9fP9GoUSPZcqWlpYmQkBBhZWUlrTNobW0txo0bJ9LS0mTLpXSdO3cWjRo1Ejdv3tT6nNq+fbvw8vKSLZe/v7+YP3++zvYFCxYIf39/IYQQs2fPFqVLl/6iOXLlGJuuXbti48aNsLGxQYUKFQBkdPNKTExEw4YNERMTg2vXriEiIgLVq1fXWy4TExNcuHBBcVd03rx5g8aNGyM0NBQ7d+5ETEwMkpKSUL58efTt2xcFChSQNV9wcDAcHBzw448/ypojO+9rQdJoNLJNXWxvb49169bpzPS0Z88etGvXDg8ePJAlV1ZKnFq8Z8+eePToEdasWQM7OzucPn0ahoaGaNmyJWrVqoWZM2fKmo8+zR9//IFu3brB399fOtZHRUVhw4YNWLZsGbsXvkOlSpUwZ84cxczmpQZZPwuyHscyj2tyTmN/4MAB+Pr6olOnTli2bBm+/fZbnD9/HgcPHkRkZKR0nqRvI0aMwOLFixESEiL9fR44cABjx45Fr1698PPPP+s1T3azO76LnBNCKHVMtIWFBU6dOiUtk5ApLi4OZcuWRVJSEuLj4+Hj4yP12vgScmVXtPz586Njx46YO3eudLBJT0/HgAEDYGlpidWrV+O7777DsGHDcODAAb3lUmpTdd68eXH69GnY2trip59+kjuOjrS0NEyZMgXh4eHw8fHRmTxAzgOMUvvmp6SkZDs9tqOjo6yD8wHlNqMDwLRp09CmTRs4OjrixYsXqF27NhISElC1alW9f8jSf/fzzz9jypQpCA4OlrYFBQVh+vTpGD9+PAubd/j1118xfPhwjB49GqVLl9Y55lpZWcmUTLmUPF6kRo0aiImJQWhoKLy9vbFjxw6UL18ehw4dgre3t2y5li9fjkWLFqF58+bSNh8fHxQsWBDff/+93o+5b0+icPLkSaSmpqJ48eIAMmaTMzQ0lK0QzKTUMdF2dnbYvHmz1vEWADZv3iwNB0lOTtYav/ol5MoWGwcHB0RFReksDnf58mVUq1YNDx8+xJkzZ1CzZk0kJibqLdf27dsxYsQIjB8/HhUqVIC5ubnW/XJ+WAQHB8PY2BiTJk2SLcO7vG+MjxyzpWTn/PnzuHHjhjT1IpCRrVmzZrLkqV+/PvLly4ewsDCYmJgAAF68eIEuXbrg8ePH2LVrlyy5ACAwMBD379/HokWLULJkSelqU3h4OAYNGoRz587Jli1TVFSUVstlgwYN5I5En8HY2Bjnzp3L9gpi6dKl8fLlS5mSKVtsbCw6duyoM6GNElof6NMFBgaibt26qFWrlqKWTTAxMcHp06d1ztUuXbqEsmXL4sWLFzIly7hgunfvXixfvhy2trYAgCdPnqBbt26oWbOmrOvF+Pn5oUKFChg/fjwsLS1x+vRpuLq6on379khPT8e6detkyfX777+jT58+8PPzk8bYHDt2DNu2bcOCBQvQo0cPTJs2DUePHv2i42lzZYtNamoqLl68qPPHcvHiRemAbGJiovduL35+fgCA5s2bK66pOjU1FUuWLMGuXbuyLbrkbBVR8pWwK1euoFWrVjhz5gw0Gg0yrxNkvr9yvaeZ03oWKlQIZcqUAQDExMTA2NgYO3bskCVTph07diA8PFxnkGjRokVlWUvEzs4Oly9fhr29Pbp3745Zs2ahevXqeu2mSl+Gi4sLIiIidAqbXbt2cYr29wgICEDevHmxatUqTh7wHqdPn0bp0qVhYGCA06dPv3dfHx8fPaXSZWRkhNDQUPTs2RPOzs6oXbs26tSpg9q1a8s6GL5MmTKYO3cuZs+erbV97ty50ueWXKZNm4YdO3ZIRQ2QMevXhAkT0LBhQ1kLm6lTp6JevXo4fvw4Xr9+jR9++AHnzp3D48ePERUVJVuuXr16wcvLC3PnzpUWAS9evDgiIyNRrVo1ANDL65YrC5vOnTujR48e+PHHH1GpUiUAGVXjxIkTERgYCACIjIxEqVKl9JpLySfoZ8+eRfny5QFktGxlxQ+1dxswYADc3d0REREBd3d3HDlyBI8fP8bgwYPxyy+/yJbL29sbsbGxWLlyJS5evAgA6NChAwICAmBqaipbLkB5zeivX7/Gs2fPYG9vj+XLl2Py5MlfvKmc9GPw4MEICgrCqVOnpA/WqKgoLFu2DLNmzZI5nXKdPXsW0dHRUhccyl7ZsmWRkJAAR0dHlC1bVuviVlZyX7hctGgRAOD27dvYt28fIiMjMW3aNHz77bcoUKCANCOZvk2ZMgVNmjTBrl27pCnZDx06hJs3b2Lbtm2yZMr07NmzbMeiPnjwAM+fP5chUYY3b94gKCgImzdvxs6dO2FpaYmkpCT4+/srYky0Ei4K5srCZsaMGXBycsKUKVNw7949AICTkxOCg4MxbNgwAEDDhg3RuHFjveaqXbu2Xp/vUyi56Hr58iXmzJnzzjUV5Fz/59ChQ9i9ezfs7e1hYGAAQ0ND1KhRA6GhoQgKCpJt4bPQ0FA4OTnpTKm4ZMkSPHjwQPo7kIPSphavWrUqWrZsiQoVKkAIgaCgoHcWf0uWLNFzOvov+vTpg/z582PatGlYs2YNAKBkyZL466+/0KJFC5nTKVfFihVx8+ZNFjYfcPXqVWltMKWOt8zK1tYW+fLlg62tLWxsbJAnTx5Z1zarXbs2Ll++jHnz5kkX4Pz9/fH999/D2dlZtlwA0KpVK3Tr1g3Tpk2TulUdOXIEQ4cOhb+/v2y5lD4mOtPLly+1uuYD+htukSvH2GT17NkzAMoY7Lh06VJYWFigbdu2WtvXrl2LlJQUdOnSRaZkyhYQEIAdO3agTZs22XaLkHMFYFtbW5w8eRLu7u7w9PTEokWLULduXcTHx8Pb21u2gfpubm5YtWqVdJU605EjR9C+fXtZP4TPnTuHevXqoXz58ti9ezeaN2+u1Yyu7z7g9+7dw4wZMxAfH4/169ejUaNG72w52rBhg16zEclh7dq1GDt2LIYOHQpvb2+dyQPk7FZFn+7HH3/E3r17ER0djZIlS0pd0WrVqqXV1Yr+T0pKCoYMGYIlS5bgzZs3ADIW5e7RowemTp2q011fn5Q6JjolJQU//PAD1qxZg0ePHuncr69Wy1xf2ChJsWLF8Ntvv+lclY6MjETv3r2lFeJJm7W1NbZt2yZ782Z2MgcRtmzZEh07dsSTJ08wcuRILFy4ECdOnMDZs2dlyfWuqcWvXLkCLy8v2QZNK31qcXd3dxw/fhz58uWTNQeRnLKbxj6zm5Xc3aqU7NKlS5gzZw4uXLgAIKN1sH///rK3fBkYGMDBwQHBwcHw9/fXGX8sp8TERBw9ejTb3hiZQwf0LS0tDVFRUfD29oaRkRHi4+MBAJ6enrIWNJkyF98uWrSoosZE9+3bF3v27MH48ePRuXNnzJs3D7dv38Zvv/2GSZMmISAgQC85cmVXNABYt24d1qxZozNTFSBf16UbN25kO9Wzq6srbty4IUMidShYsKBixzyMHDlSmo993LhxaNq0KWrWrIl8+fJ90Vk/PsTFxQVRUVE6v29RUVGyNvErvRldDd1J6P2yTgZha2v73jGCFhYWKFWqFCZPnsxWiCz4d/Dp/v77b7Rv3x4VK1aUxoscPnwYpUuXxurVq9G6dWvZskVHRyMyMhJ79+7FtGnTYGRkJLXa1KlTR7ZCZ/PmzQgICEBSUhKsrKy0/lY1Go1shY2hoSEaNmwoXRxU2rFBqWOiN2/ejLCwMNSpU0eaPa5IkSJwdXXFypUr9VbY5MoWm9mzZ+Onn35C165dsXDhQnTr1g3x8fE4duwY+vbtK9t6FIULF8bcuXO15mwHgE2bNqFv376yDeBTun///RezZ8/GggUL4OrqKnecD3r8+PEHT6i+tClTpmDKlCnS7CkAEBERgR9++AGDBw/GiBEjZMumtGb02bNno3fv3jAxMdGZnedtQUFBekpFn2v58uVo3749jI2NsXz58vfu++rVK2zbtg03b97EiRMn9JRQ2d68eYMSJUpgy5YtKFmypNxxVMPT0xMBAQEYN26c1vYxY8bgjz/+kK76K0FMTAxmzJiBlStXIj09XbYWuGLFisHPzw8TJ07MdkIZOVWsWBGTJ09G/fr15Y6iGhYWFjh//jwKFy6MQoUKYf369fjqq69w9epVeHt7623h0FzZYvPrr79i4cKF6NChA5YtW4YffvgBHh4eGD16NB4/fixbrg4dOiAoKAiWlpaoVasWgIxuaAMGDED79u1ly6V0FStWxMuXL+Hh4QEzMzOd/t5yvqfZyVyISk5Dhw7Fo0eP8P3330stliYmJhg2bJisRQ2gvKnFZ8yYgYCAAJiYmGDGjBnv3E+j0bCwUYGsYxU/Ztyir6+v7AvuKUnevHm5vs9nuHv3brYtDJ06dcLUqVNlSPR/hBCIjo7G3r17sXfvXhw4cADPnj2Dj4+PrJMa3b59G0FBQYoragBgwoQJGDJkiCLXHVQqDw8PXL16FYULF0aJEiWwZs0afPXVV9i8eTNsbGz0liNXttiYmZnhwoULcHV1haOjI3bu3IkyZcogNjYWVapUyXZQkz68fv0anTt3xtq1a5EnT0ZNmZ6ejsDAQCxYsABGRkay5FK6Bg0a4MaNG+jRo0e2kwdw0oV3S0pKwoULF2BqaoqiRYvKuipxJjUsuEq5y+vXr7Ptw1+4cGGZEinbxIkTcfnyZSxatEj6rKL38/PzQ9u2bdGtWzet7UuXLsXq1asRHh4uU7KMSW6SkpJQpkwZqQtazZo19XqymR1/f3+0b98e7dq1kzVHdrKOM1PauoNKNWPGDBgaGiIoKAi7du1Cs2bNIITAmzdvMH36dAwYMEAvOXJlYePh4YG///4b5cqVQ8WKFdGrVy98++232LFjB9q3by/7Ff7Y2FicOnUKpqam8Pb2VkX3KjmZmZnh0KFDsi/YRbnToEGDPmo/jUaDadOmfeE0lJMuX76MHj164ODBg1rbeXLyfq1atUJERAQsLCzg7e2tc7U6c/E9+j8LFizA6NGj0a5dO1SpUgVAxhibtWvXIiQkRGts49vd0b+0rVu3ombNmopoZfjnn3+krx88eIBx48ahW7du2c6+p+/XKavIyMj33q/k5TuU4vr16zhx4gSKFCmi13FKubKw6dmzJ1xcXDBmzBjMmzcPQ4cORfXq1XH8+HH4+/tj8eLFckcEkDHzxpkzZ+Dq6sopF9+jfPny+PXXX6UPC6Kc9LFr57A1SX2qV6+OPHnyYPjw4ShQoIBOay8vlmTv7VaHty1dulRPSdQju5nksvO/XlDzdaIvLVcWNunp6UhPT5ea0P/66y9ERUWhaNGi+O6773SuCujLwIED4e3tjR49eiAtLQ21a9fGwYMHYWZmhi1btqBOnTqy5FK6HTt2ICQkBD///HO2V3WUcBWKiJTH3NwcJ06cQIkSJeSOQkQqlJKSku3sukqbKU0pjh079s7F1PU1fjZXFjZAxqqnp0+f1nlxNRoNmjVrJkumQoUKYePGjahYsSI2btyI77//Hnv37sWKFSuwe/duREVFyZJL6TKv8Lx9tZXdSYjofSpVqoQZM2agRo0ackdRpQcPHkjrqxUvXlzWVerVKDExUfZxLGqjlNfswYMH6NatG/79999s7+d5h66JEydi5MiRKF68uM54aH32eMiVowK3b9+Ozp07ZztJgJwnwg8fPkT+/PkBANu2bUO7du1QrFgxdO/eHbNmzZIlkxrs2bNH7ghEpEKTJ0/GDz/8gIkTJ7K19xMkJydLiwBmXhg0NDREYGAg5syZo8hZrOQ2efJkuLm54ZtvvgEAtG3bFn///TcKFCiAbdu2sdtjNpT8mg0cOBCJiYk4cuQI6tSpgw0bNuDevXuYMGECx1q+w6xZs7BkyRJ07dpV3iAiFypSpIj4/vvvRUJCgtxRtBQuXFiEh4eL1NRU4eLiIrZs2SKEEOLs2bPCxsZG5nRERLmLRqORbgYGBtIt83vKXu/evYWHh4fYtm2bePr0qXj69KnYunWr8PT0FN99953c8RTJzc1NREVFCSGE2LFjh7CxsRHh4eGiR48e4uuvv5Y5nTIp+TXLnz+/OHLkiBBCCEtLS3Hp0iUhhBCbNm0S1atXlzOaYuXPn19cvnxZ7hgiV7bY3Lt3D4MGDYKTk5PcUbR069YN7dq1kwaxNmjQAABw5MgR9gH/gMTERCxevBgXLlwAAJQqVQrdu3eHtbW1zMmISKnY2vt5/v77b6xbt05r3Kefnx9MTU3Rrl07zJ8/X75wCpWQkAAXFxcAwJYtW9CuXTs0bNgQbm5uqFy5sszplEnJr1lycjIcHR0BZEyX/eDBAxQrVgze3t44efKkrNmUKjg4GPPmzcPMmTNlzfFx01OoTJs2bbB37165Y+gYO3YsFi1ahN69eyMqKkpaU8TQ0BDDhw+XOZ1yHT9+HJ6enpgxYwYeP36Mx48fY/r06fD09OQBhojeqXbt2jAwMMDvv/+O4cOHo0iRIqhduzZu3LgBQ0NDueMpVkpKSrYXBh0dHZGSkiJDIuWztbXFzZs3AWR0h8+8cCmE4HiMd1Dya1a8eHFpfFmZMmXw22+/4fbt21iwYAEKFCggazalGjJkCC5dugRPT080a9YM/v7+Wjd9yZUtNnPnzkXbtm2xf//+bPtVy7l6eJs2bXS2cYHJ9wsODkbz5s3x+++/SzPdpaamomfPnhg4cCD27dsnc0IiUqK///4bnTt3RkBAAKKjo/Hq1SsAwNOnTzFx4kRs27ZN5oTKVLVqVYwZMwZhYWEwMTEBALx48QIhISGoWrWqzOmUyd/fHx07dkTRokXx6NEj+Pr6AgCio6NRpEgRmdMpk5JfswEDBuDu3bsAgDFjxqBx48b4448/YGRkhOXLl8uaTamCgoKwZ88e1K1bF/ny5dOZ8ElfcuWsaIsXL8Z3330HExMTnRdXo9HgypUrsmWLiIjAjBkzpC5VJUuWxMCBA6UrFaTL1NQU0dHROt31zp8/j4oVK/IKIhFlq1y5cggODkZgYCAsLS0RExMDDw8PREdHw9fXFwkJCXJHVKQzZ86gcePGePXqlTSAOyYmBiYmJggPD0epUqVkTqg8b968waxZs3Dz5k107doV5cqVA5CxGrulpSV69uwpc0LlUdNrlpKSgosXL6Jw4cKwt7eXO44iWVpaYvXq1WjSpImsOXJlYZM/f34EBQVh+PDhH70YlD78+uuvGDBgANq0aSNd9Tp8+DDWrVuHGTNmoG/fvjInVCYnJyesWLECDRs21NoeHh6OwMBA3Lt3T6ZkRKRkZmZmOH/+PNzc3LQKmytXrsDLywsvX76UO6JipaSkYOXKlbh48SKAjItwAQEBMDU1lTkZ0Zc3aNCgbLdrNBqYmJigSJEiaNGiBezs7PScTLlcXV0RHh4u+5jxXFnY2NnZ4dixY/D09JQ7ipZChQph+PDh6Nevn9b2efPmYeLEibh9+7ZMyZQtKCgIGzZswC+//IJq1aoBAKKiojB06FC0bt1a9oFqRKRMHh4eWLhwIRo0aKBV2ISFhWHSpEk4f/683BEVo3z58oiIiICtrS3GjRuHIUOGcFrnTxQbG/vOxQlHjx4tUyr6HHXr1sXJkyeRlpaG4sWLAwAuX74MQ0NDlChRApcuXYJGo8GBAwfg5eUlc1plWLp0KbZv346lS5fKeuzIlYVNcHAwHBwc8OOPP8odRYuFhQVOnTql03c0NjYW5cqVQ1JSkkzJlO3169cYOnQoFixYgNTUVABA3rx50adPH0yaNEmahIGIKKvQ0FD88ccfWLJkCb7++mts27YN169fR3BwMEaNGoX+/fvLHVExTE1NERsbi0KFCsHQ0BB3796VZoWiD/v999/Rp08f2NvbI3/+/Dpd4DnRjbrMnDkT+/fvx9KlS6X1rp4+fYqePXuiRo0a6NWrFzp27IgXL14gPDxc5rTKUK5cOcTHx0MIATc3N53x7fr6G8iVhU1QUBDCwsJQpkwZ+Pj46Ly406dPlyVXx44dUa5cOQwdOlRr+y+//ILjx49j9erVsuRSi5SUFMTHxwMAPD09eTWRiN5LCIGJEyciNDRUGotnbGyMIUOGYPz48TKnU5aqVavCwsICNWrUQEhICIYMGQILC4ts92Xrgy5XV1d8//33GDZsmNxRKAcULFgQO3fu1GmNOXfuHBo2bIjbt2/j5MmTaNiwIR4+fChTSmUJCQl57/1jxozRS45cWdjUrVv3nfdpNBrs3r1bb1lmz54tff3s2TP88ssvqF69utYYm6ioKAwePBgjR47UWy41efr0KdLS0nT6sj5+/Bh58uTh6uFE9F6vX79GXFwckpKS4OXl9c4T9v9lly5dwpgxYxAfH4+TJ0/Cy8tLmoUyK7Y+ZM/KygqnTp2Ch4eH3FEoB1hYWGDLli1aazkBwN69e9GsWTM8f/4cV65cQdmyZfHs2TN5QlK2cmVhoyTu7u4ftZ/cs7Upma+vL5o1a4bvv/9ea/uCBQvwzz//cMpWIqIcZGBggISEBHZF+wQ9evRApUqV8N1338kdRVUSExOxbt06xMfHY+jQobCzs8PJkyfh5OSEggULypYrICAAhw4dwrRp01CpUiUAwLFjxzBkyBBUq1YNK1aswOrVq6UeN6QcLGxI8ezs7BAVFYWSJUtqbb948SKqV6+OR48eyZSMiIgoYzzX9OnT0aRJE8Wtn6dUp0+fRoMGDWBtbY1r167h0qVL8PDwwMiRI3Hjxg2EhYXJli0pKQnBwcEICwuTxvbmyZMHXbp0wYwZM2Bubo5Tp04BAMqWLStbTtLFwoYUz9zcHIcPH4a3t7fW9jNnzqBy5cpcx4aIKIdxhq9P877eGeyRkb0GDRqgfPnymDJlitashQcPHkTHjh1x7do1uSMiKSlJeu88PDzYjVUFWNjoUffu3d97/5IlS/SURF3q1q2L0qVLY86cOVrb+/bti9OnT2P//v0yJSMiyn04wxfpg7W1NU6ePAlPT0+twub69esoXrw415miz6I7MpC+mCdPnmh9/+bNG5w9exaJiYmoV6+eTKmUb8KECWjQoAFiYmJQv359AEBERASOHTuGHTt2yJyOiCh3mTBhAn7++WfO8PUBgwYNwvjx42Fubv7OBR2BjGJw2rRpekymDsbGxtkOvL98+TIcHBxkSESf682bNyhRogS2bNmiM2xA31jY6NGGDRt0tqWnp6NPnz6KW0xUSapXr45Dhw5h6tSpWLNmDUxNTeHj44PFixejaNGicscjIspVnjx5grZt28odQ/Gio6Px5s0b6et3ydriRf+nefPmGDduHNasWQMg43W6ceMGhg0bhtatW8ucjj5F3rx5FdPCxq5oCnDp0iXUqVMHd+/elTsKERH9j+MMX6QPT58+RZs2bXD8+HE8f/4czs7OSEhIQNWqVbFt2zaYm5vLHZE+wcSJE3H58mUsWrQo26ni9YUtNgoQHx8vzbpB79ekSRMsWrQIBQoUkDsKEVGuVKRIEYwaNUqatIUzfNGXYG1tjZ07d+LAgQM4ffo0kpKSUL58eTRo0EDuaPQZjh07hoiICOzYsQPe3t46hen69ev1koMtNnr0dh9cIQTu3r2LrVu3okuXLpg7d65MydQj6wBDIiLKeZzhi4g+Vbdu3d57/9KlS/WSg4WNHtWtW1frewMDAzg4OKBevXro3r27rE13asHChoiIKHeIiIhAREREttOKc6ZY+hw8k9ajrVu3QgghNc9du3YNGzduhKurK4uaj+Tq6qrTLYKIiP4bzvBF+hYSEoJx48ahYsWKKFCgACdZoBzBs2k9atmyJfz9/fHdd98hMTERVapUQd68efHw4UNMnz4dffr0kTuiYu3fvx+//fYbLC0tYWBgAABYsWIF3N3dUaNGDZnTERGpG2f4In1bsGABli1bhs6dO8sdhXKAu7v7e48P+urCysJGj06ePIkZM2YAANatWwcnJydER0fj77//xujRo1nYvMPff/+Nzp07IyAgANHR0Xj16hWAjBlVJk6ciG3btsmckIhI3fbs2ZPt10RfyuvXr1GtWjW5Y1AOGThwoNb3b968QXR0NLZv346hQ4fqLQfH2OiRmZkZLl68iMKFC6Ndu3YoVaoUxowZg5s3b6J48eJISUmRO6IilStXDsHBwQgMDNQaYxMdHQ1fX18kJCTIHZGIiIg+wbBhw2BhYYFRo0bJHYW+oHnz5uH48eN6mzyALTZ6VKRIEWzcuBGtWrVCeHg4goODAQD379+HlZWVzOmU69KlS6hVq5bOdmtrayQmJuo/EBEREf0nL1++xMKFC7Fr1y74+PjojJ+dPn26TMkoJ/n6+mLEiBEsbHKj0aNHo2PHjggODkb9+vVRtWpVAMCOHTtQrlw5mdMpV/78+REXFwc3Nzet7QcOHODsaERERCp0+vRplC1bFgBw9uxZrfs4liv3WLduHezs7PT2fCxs9KhNmzaoUaMG7t69izJlykjb69evj1atWsmYTNl69eqFAQMGYMmSJdBoNLhz5w4OHTqEIUOGsAmbiIhIhTiWK3cpV66cVkEqhEBCQgIePHiAX3/9VW85OMaGFE8IgYkTJyI0NFQah2RsbIwhQ4Zg/PjxMqcjIiIi+t8WEhKi9X3mWo116tRBiRIl9JaDhQ2pxuvXrxEXF4ekpCR4eXnBwsJC7khERET0kfz9/bFs2TJYWVnB39//vfuuX79eT6koN2FXNFINIyMjeHl5yR2DiIiIPoO1tbXUXcna2lrmNJTT0tLSsHHjRly4cAEAUKpUKTRv3hyGhoZ6y8AWGyIiIiIi+mxxcXHw8/PD7du3Ubx4cQAZs9q6uLhg69at8PT01EsOFjZERERERPTZ/Pz8IITAypUrpVnQHj16hE6dOsHAwABbt27VSw4WNkRERET0xb09c9b7nDx58gunoZxkbm6Ow4cPw9vbW2t7TEwMqlevjqSkJL3k4BgbIiIiIvriWrZsKXcE+kKMjY3x/Plzne1JSUkwMjLSWw622BARERER0WcLDAzEyZMnsXjxYnz11VcAgCNHjqBXr16oUKECli1bppccLGyIiIiISBavX7/G/fv3kZ6errW9cOHCMiWiz5GYmIguXbpg8+bNyJs3LwAgNTUVzZs3x7Jly/Q2Cx4LGyIiIiLSq8uXL6NHjx44ePCg1nYhBDQaDdLS/l979x4V1XW2AfwZ7gOCCKGImIoEEUjlEi1tMBEUBGlqkTQ2RTQoaFdZoSpWU7pWazVZUZOlkWorxiRViTGJMZJaEaMRhhiaVhhGkasXBCIhNQZEuQgyvN8f+Tx1gnILzoT6/NZiLeecPWc/bM4f83r23qM3UTL6Ns6dO4fKykoAgK+vL7y8vIzaPwsbIiIiIjKqqVOnwsLCAmlpaXBzc+uxqUBAQICJktFwxsKGiIiIiIzKzs4OWq0WPj4+po5CQ0BEsH//fuTl5d1xauGBAweMkoO7ohERERGRUfn5+eHKlSumjkFDZPny5Xj11Vcxffp0uLq69ntb76HGJzZEREREZFS5ubn4wx/+gHXr1mHSpEnKgvNbHBwcTJSMBsPJyQl79uzBT37yE5PmYGFDREREREZlZmYGAD3+Z5+bBwxP48ePR05OjsmnFrKwISIiIiKjys/P7/V8aGiokZLQUNi9ezeOHDmCv/3tb1Cr1SbLwcKGiIiIiIgGrb29HbGxsSgoKICHh0ePqYXFxcVGycHNA4iIiIjI6K5evYo33ngDFRUVAICHH34YiYmJRvsyRxo6CQkJ0Gq1mD9/PjcPICIiIqL7R1FREaKioqBWqxEcHAwAKCwsRHt7O44ePYpHHnnExAlpIOzs7PDhhx/iscceM2kOFjZEREREZFSPP/44vLy88Nprr8HC4usJRF1dXVi8eDGqq6vx8ccfmzghDYSPjw/27dsHf39/k+ZgYUNERERERqVWq6HT6XrsolVeXo4pU6agra3NRMloMLKzs7F161Zs374dHh4eJsvBNTZEREREZFQODg6oq6vrUdh89tlnsLe3N1EqGqz58+ejra0NDz30EGxtbXtsHtDY2GiUHCxsiIiIiMionn76aSQlJWHjxo0ICQkBABQUFGDVqlWIi4szcToaqPT0dFNHAMCpaERERERkZJ2dnVi1ahW2b9+Orq4uAIClpSWSk5OxYcMGWFtbmzghDUcsbIiIiIjIJNra2nDhwgUAUKYx0fB248YNdHZ2GhxzcHAwSt8sbIiIiIiIaNBaW1vxu9/9Dvv27cNXX33V47xerzdKDjOj9EJERERERP+TnnvuOeTm5iIjIwPW1tZ4/fXXsXbtWowZMwaZmZlGy8EnNkRERERENGjf//73kZmZibCwMDg4OKC4uBheXl5488038fbbb+Pw4cNGycEnNkRERERENGiNjY3w9PQE8PV6mlvbOz/22GNG/bJVFjZERERERDRonp6euHjxIgDAx8cH+/btAwD84x//gKOjo9FycCoaEREREREN2ubNm2Fubo6lS5fio48+wuzZsyEiuHnzJl555RUsW7bMKDlY2BARERER0ZCpra2FVquFl5cX/P39jdYvCxsiIiIiIhr2LEwdgIiIiIiIhpctW7b0u+3SpUvvYZL/4hMbIiIiIiIakPHjx/ernUqlQnV19T1O8/99sbAhIiIiIqLhjts9ExERERHRsMc1NkRERERENGgrVqy443GVSgUbGxt4eXkhJiYGTk5O9zQHp6IREREREdGgTZ8+HcXFxdDr9Zg4cSIA4OzZszA3N4ePjw+qqqqgUqnwySefwM/P757l4FQ0IiIiIiIatJiYGERERODzzz+HVquFVqvFpUuXMHPmTMTFxaG+vh7Tpk1DamrqPc3BJzZERERERDRo7u7uOHbsWI+nMWVlZYiMjER9fT2Ki4sRGRmJK1eu3LMcfGJDRERERESD1tzcjMuXL/c4/uWXX+LatWsAAEdHR3R2dt7THCxsiIiIiIho0GJiYpCYmIisrCxcunQJly5dQlZWFpKSkjBnzhwAwMmTJ+Ht7X1Pc3AqGhERERERDVpLSwtSU1ORmZmJrq4uAICFhQUSEhKwefNm2NnZ4dSpUwCAwMDAe5aDhQ0REREREX1rLS0tqK6uBgB4enpixIgRRu2fhQ0REREREQ17XGNDRERERETDHgsbIiIiIiIa9ljYEBERERHRsMfChoiIiIiIhj0WNkRERuLh4YH09HRTxxhyNTU1UKlUylaew5VKpcIHH3xg6hgm9b96jxLR/YGFDRHRIOzatQuOjo6mjkFDqKGhAdHR0aaO8Z3CYo+IhhMWNkRE1C+dnZ2mjtCDiChfBvdtjR49GtbW1kNyraH2XRx7IqLvGhY2RHRfun79OuLj42FnZwc3Nzds3rwZYWFhWL58OQCgo6MDK1euhLu7O+zs7PCjH/0IGo0GAKDRaLBo0SI0NzdDpVJBpVJhzZo1A87w+uuvw9HREcePHwcAlJaWIjo6GiNGjICrqysWLFiAK1euAAAyMzPh7OyMjo4Og2vMmTMHCxYsQHNzM8zNzVFUVAQA6O7uhpOTE3784x8rbffs2YMHH3xQeX3mzBnMmDEDarUazs7O+NWvfoWWlhbl/MKFCzFnzhy8+OKLGDNmDCZOnAgAOHnyJIKCgmBjY4MpU6ZAp9MZZGpqakJ8fDxcXFygVqsxYcIE7Ny5s8/xuDWl7Z133kFISAhsbGzwgx/8APn5+UobjUYDlUqFnJwcTJ48GdbW1vjkk0/Q3d2N9evXY/z48VCr1QgICMD+/fuVsRg7diwyMjIM+tPpdDAzM0NtbS2Ank8n+hqf2++X2/8eCxcuVF5v27YNEyZMgI2NDVxdXfHUU0/1OQ63rp2SkoLly5fjgQceQFRUFIDe7xEA2L9/PyZNmqRkjoiIQGtra7/z3s7DwwMAEBsbC5VKpbw+ffo0pk+fDnt7ezg4OGDy5MnKfUdEZEosbIjovrRixQoUFBTg4MGDOHbsGE6cOIHi4mLlfEpKCj799FO88847KCkpwdy5czFr1iycO3cOISEhSE9Ph4ODAxoaGtDQ0ICVK1cOqP+XX34ZaWlpOHr0KMLDw3H16lXMmDEDQUFBKCoqwpEjR/Cf//wHv/jFLwAAc+fOhV6vx8GDB5VrXL58GdnZ2UhMTMTIkSMRGBioFF9nzpyBSqWCTqdTPozn5+cjNDQUANDa2oqoqCiMGjUKhYWFeO+99/DRRx8hJSXFIOfx48dRVVWFY8eO4dChQ2hpacFPf/pT+Pn5QavVYs2aNT1+9z/+8Y8oLy9HTk4OKioqkJGRgQceeKDfY7Nq1Sr89re/hU6nw6OPPorZs2fjq6++MmiTlpaGDRs2oKKiAv7+/li/fj0yMzOxfft2lJWVITU1FfPnz0d+fj7MzMwQFxeHvXv3GlzjrbfewtSpUzFu3LgeGfo7Pr0pKirC0qVL8fzzz6OqqgpHjhzBtGnT+v3+3bt3w8rKCgUFBdi+fXuf90hDQwPi4uKQmJiIiooKaDQaPPnkkxjs93AXFhYCAHbu3ImGhgbldXx8PMaOHYvCwkJotVqkpaXB0tJyUH0QEQ0pISK6z1y7dk0sLS3lvffeU45dvXpVbG1tZdmyZVJbWyvm5uZSX19v8L7w8HD5/e9/LyIiO3fulJEjRw6o33HjxsnmzZvlueeeEzc3NyktLVXOvfDCCxIZGWnQ/rPPPhMAUlVVJSIiycnJEh0drZzftGmTeHp6Snd3t4iIrFixQp544gkREUlPT5enn35aAgICJCcnR0REvLy8ZMeOHSIismPHDhk1apS0tLQo18vOzhYzMzP54osvREQkISFBXF1dpaOjQ2nz6quvirOzs7S3tyvHMjIyBIDodDoREZk9e7YsWrRoQGMjInLx4kUBIBs2bFCO3bx5U8aOHSsvvfSSiIjk5eUJAPnggw+UNjdu3BBbW1v55z//aXC9pKQkiYuLExERnU4nKpVKamtrRUREr9eLu7u7ZGRkKO0BSFZWVr/HJzQ0VJYtW2bQZ0xMjCQkJIiIyPvvvy8ODg5y7dq1AY9FaGioBAUFGRzr6x7RarUCQGpqau56zd7yivz3Hr3l9jG5xd7eXnbt2jXg34mI6F6zMF1JRURkGtXV1bh58yaCg4OVYyNHjlSmWp05cwZ6vR7e3t4G7+vo6ICzs/O36nvTpk1obW1FUVERPD09leOnT59GXl4eRowY0eM9Fy5cgLe3N5YsWYIf/vCHqK+vh7u7O3bt2oWFCxdCpVIBAEJDQ/HGG29Ar9cjPz8fkZGRGD16NDQaDfz9/XH+/HmEhYUBACoqKhAQEAA7Ozuln6lTp6K7uxtVVVVwdXUFAEyaNAlWVlZKm1tPSGxsbJRjjz76qEHe5ORk/PznP0dxcTEiIyMxZ84chISE9HuMbr+ehYUFpkyZgoqKCoM2U6ZMUf59/vx5tLW1YebMmQZtOjs7ERQUBAAIDAyEr68v9u7di7S0NOTn5+Py5cuYO3fuHTP0d3x6M3PmTIwbNw6enp6YNWsWZs2ahdjYWNja2vY9CAAmT55s8LqveyQyMhLh4eGYNGkSoqKiEBkZiaeeegqjRo3qV3/9tWLFCixevBhvvvkmIiIiMHfuXDz00END2gcR0WBwKhoR0Te0tLTA3NwcWq0Wp06dUn4qKirw5z//+Vtd+/HHH4der8e+fft69Dl79myD/k6dOoVz584p05eCgoIQEBCAzMxMaLValJWVGayPmDZtGq5fv47i4mJ8/PHHCAsLQ1hYGDQaDfLz8zFmzBhMmDBhQHlv/2DfX9HR0aitrUVqaio+//xzhIeHD3iq3kBy3Zpql52dbTB25eXlyjob4OspVLemo+3duxezZs36VoWqmZlZj2leN2/eVP5tb2+P4uJivP3223Bzc8Pq1asREBCAq1ev9uv63xz7vu4Rc3NzHDt2DDk5OfDz88PWrVsxceJEXLx4sV95+2vNmjUoKyvDE088gdzcXPj5+SErK2vA1yEiGmosbIjovuPp6QlLS0tlzQAANDc34+zZswC+LiD0ej0uX74MLy8vg5/Ro0cDAKysrKDX6wfcd3BwMHJycrBu3Tps3LhROf7II4+grKwMHh4ePfq8/QPu4sWLsWvXLuzcuRMREREGmwE4OjrC398ff/nLX2BpaQkfHx9MmzYNOp0Ohw4dUtbXAICvry9Onz6tLCwHgIKCApiZmSlPru7E19cXJSUluHHjhnLsX//6V492Li4uSEhIwJ49e5Ceno4dO3b0e4xuv15XVxe0Wi18fX3v2t7Pzw/W1taoq6vrMXa3j8+8efNQWloKrVaL/fv3Iz4+vtffs6/xcXFxQUNDg3Jer9ejtLTU4DoWFhaIiIjAyy+/jJKSEtTU1CA3N7ffY3G7/twjKpUKU6dOxdq1a6HT6WBlZaUUHf3J+02WlpZ3vM+9vb2RmpqKo0eP4sknn+zX5hBERPcaCxsiuu/Y29sjISEBq1atQl5eHsrKypCUlAQzMzOoVCp4e3sjPj4ezzzzDA4cOICLFy/i5MmTWL9+PbKzswF8vWNUS0sLjh8/jitXrqCtra3f/YeEhODw4cNYu3at8mWIzz77LBobGxEXF4fCwkJcuHABH374IRYtWmTwwXLevHm4dOkSXnvtNSQmJva4dlhYGN566y2liHFycoKvry/effddg8ImPj4eNjY2SEhIQGlpKfLy8vCb3/wGCxYs6HWa1bx586BSqbBkyRKUl5fj8OHDBgUaAKxevRp///vfcf78eZSVleHQoUO9Fibf9Ne//hVZWVmorKzEs88+i6ampjv+rrfY29tj5cqVSE1Nxe7du3HhwgUUFxdj69at2L17t9LOw8MDISEhSEpKgl6vx89+9rO7XrM/4zNjxgxkZ2cjOzsblZWVSE5ONngac+jQIWzZsgWnTp1CbW0tMjMz0d3d3Wvh2Ju+7pF///vfWLduHYqKilBXV4cDBw7gyy+/VMa+r7x34uHhgePHj+OLL75AU1MT2tvbkZKSAo1Gg9raWhQUFKCwsHBAf18ionvG1It8iIhM4dq1azJv3jyxtbWV0aNHyyuvvCLBwcGSlpYmIiKdnZ2yevVq8fDwEEtLS3Fzc5PY2FgpKSlRrvHrX/9anJ2dBYD86U9/6rPPby7Mzs/PFzs7O9myZYuIiJw9e1ZiY2PF0dFR1Gq1+Pj4yPLly5XNAW5ZsGCBODk5yY0bN3r0kZWVJQAMFsUvW7ZMAEhlZaVB25KSEpk+fbrY2NiIk5OTLFmyRK5fv66cT0hIkJiYmB59fPrppxIQECBWVlYSGBgo77//vsHmAS+88IL4+vqKWq0WJycniYmJkerq6j7H59bmAXv37pXg4GCxsrISPz8/yc3NVdrc2jygqanJ4L3d3d2Snp4uEydOFEtLS3FxcZGoqCjJz883aLdt2zYBIM8880yP/vGNhfJ9jU9nZ6ckJyeLk5OTfO9735P169cbLMY/ceKEhIaGyqhRo0StVou/v7+8++67fY6DyJ0X+ov0fo+Ul5dLVFSUuLi4iLW1tXh7e8vWrVv7nVek5z168OBB8fLyEgsLCxk3bpx0dHTIL3/5S3nwwQfFyspKxowZIykpKQabSRARmYpKZJD7QBIR/Q9pbW2Fu7s7Nm3ahKSkJFPH6VV4eDgefvhhbNmyxdRRhlRNTQ3Gjx8PnU6HwMBAU8chIqJhhruiEdF9SafTobKyEsHBwWhubsbzzz8PAIiJiTFxsrtramqCRqOBRqPBtm3bTB2HiIjoO4VrbIjovrVx40YEBAQo385+4sSJAX2R5O1OnDiBESNG3PVnKAQFBWHhwoV46aWXBr1Ow5TWrVt31/GJjo42dTyjqaur6/VeqaurM3VEIqJhiVPRiIiGQHt7O+rr6+963svLy4hpvpsaGxvR2Nh4x3NqtRru7u5GTmQaXV1dqKmpuet5Dw8PWFhwQgUR0UCxsCEiIiIiomGPU9GIiIiIiGjYY2FDRERERETDHgsbIiIiIiIa9ljYEBERERHRsMfChoiIiIiIhj0WNkRERERENOyxsCEiIiIiomGPhQ0REREREQ17/wfMRwFo52l4SQAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 1000x500 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Create workload\n",
+        "workload = lab.Workload(jobs=[lab.Job(job_function=get_keywords_previous_results)])\n",
+        "\n",
+        "# Run\n",
+        "await workload.async_run(\n",
+        "    messages[:100], \n",
+        "    executor_type=\"parallel\",\n",
+        "    max_parallelism=10, \n",
+        ")\n",
+        "\n",
+        "# Display results\n",
+        "results_df = workload.results_df()\n",
+        "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
+        "\n",
+        "keywords_to_count = (\n",
+        "    augmented_messages_df.explode(\"get_keywords_previous_results\")\n",
+        "    .groupby(\"get_keywords_previous_results\")\n",
+        "    .size()\n",
+        "    .sort_values(ascending=False)\n",
+        ")\n",
+        "keywords_to_count.head(20).plot(\n",
+        "    kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\"\n",
+        ")\n",
+        "\n",
+        "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords_previous_results\"].explode().nunique())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Reuse the results from another job\n",
+        "\n",
+        "Likewise, you can set a `workload` argument. This lets you also use results on other jobs to augment the result of the current one.\n",
+        "\n",
+        "Let's use this to **run the topic extraction on GPT-4 first on a subsample,** and then use GPT-3.5."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 39,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "async def get_keywords_previous_jobs(\n",
+        "    message: lab.Message,\n",
+        "    workload: lab.Workload = None, # Add the job as an argument\n",
+        "    model: str=\"openai:gpt-3.5-turbo\",\n",
+        ") -> lab.JobResult:\n",
+        "    \"\"\"\n",
+        "    This function uses OpenAI GPT to extract keywords from a given message.\n",
+        "\n",
+        "    It uses the results of the previous jobs to provide context to the current job.\n",
+        "    The workload argument is used to access the results of the previous jobs.\n",
+        "    The previous jobs are expected to be named `get_keywords`.\n",
+        "\n",
+        "    If the message.id was already processed, the previous result is returned.\n",
+        "    \"\"\"\n",
+        "    provider, model_name = lab.get_provider_and_model(model)\n",
+        "    openai_client = lab.get_async_client(provider)\n",
+        "\n",
+        "    # Using the reference to the job, we can access the results of the other jobs\n",
+        "    # to use them as context for the current job\n",
+        "    previous_keywords = []\n",
+        "    if workload:\n",
+        "        # Get the previous results of the job `get_keywords` \n",
+        "        previous_job_results = workload.jobs[\"get_keywords\"].results.values()\n",
+        "\n",
+        "        # If this message.id was already processed, we return the previous result\n",
+        "        if message.id in previous_job_results:\n",
+        "            return previous_job_results[message.id]\n",
+        "\n",
+        "        # Otherwise, let's flatten the list of lists of keywords\n",
+        "        previous_keywords = [keyword for result in previous_job_results for keyword in result.value]\n",
+        "\n",
+        "    prompt = \"You are an annotator reading Amazon product reviews. Your job is to label \\\n",
+        "    each review with topics that describe important topics covered in the review, relevant \\\n",
+        "    to the e-commerce domain. Do not include generic topics such as 'good', 'bad', 'interesting', etc.\"\n",
+        "    \n",
+        "    # If there are previous results, we add them to the prompt\n",
+        "    if len(previous_keywords) > 0:\n",
+        "        prompt += f\"\"\"\n",
+        "        So far, you've reviewed {len(previous_job_results)} reviews, and the keywords you've found are:\n",
+        "        {\", \".join(previous_keywords)}\n",
+        "\n",
+        "        If possible, reuse the existing topics to label the current review. Do not add \n",
+        "        variations of the same topics.\"\"\"\n",
+        "\n",
+        "    prompt = f\"\"\"The review is: \n",
+        "    {message.content}\n",
+        "\n",
+        "    Return a list of max 10 keywords as a bullet point list: `- keyword1\\n- keyword2\\n- keyword3`\n",
+        "    Keywords:\"\"\"\n",
+        "\n",
+        "    response = await openai_client.chat.completions.create(\n",
+        "        model=\"gpt-3.5-turbo\",\n",
+        "        messages=[\n",
+        "            {\n",
+        "                \"role\": \"system\",\n",
+        "                \"content\": \"You are a business analyst, expert in e-commerce.\",\n",
+        "            },\n",
+        "            {\"role\": \"user\", \"content\": prompt},\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "    response = response.choices[0].message.content\n",
+        "    # Parse the response to extract the keywords with regex\n",
+        "    keywords = re.findall(r\"- (.*)\", response)\n",
+        "    keywords = [keyword.strip().lower() for keyword in keywords]\n",
+        "    return lab.JobResult(\n",
+        "        value=keywords,\n",
+        "        result_type=lab.ResultType.list,\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Let's use this to run 10 expensive calls to GPT-4, and then use those keywords as grounding when calling GPT-3.5."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "No job_config provided. Running with empty config\n",
+            "100%|██████████| 100/100 [00:01<00:00, 74.78it/s]\n",
+            "100%|██████████| 100/100 [00:09<00:00, 10.41it/s]\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "{'get_keywords': None,\n",
+              " 'get_keywords_previous_jobs': JobResult(value=['computer performance', 'aging computer', 'tips for optimizing performance', 'maximumpc', 'computer parts', 'vendors', 'useful tests', 'computer maintenance', 'performance optimization', 'aging technology'], result_type=<ResultType.list: 'list'>, logs=[], metadata={}, created_at=1710887336, job_id='get_keywords_previous_jobs')}"
+            ]
+          },
+          "execution_count": 40,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# First, we run on GPT-4\n",
+        "# We create a new job config to specify the model\n",
+        "\n",
+        "\n",
+        "class GPT4Config(lab.JobConfig):\n",
+        "    model: str = \"openai:gpt-4\"\n",
+        "\n",
+        "\n",
+        "workload = lab.Workload(\n",
+        "    jobs=[\n",
+        "        # The jobs are executed sequentially, in the order they are defined\n",
+        "        lab.Job(\n",
+        "            job_function=get_keywords,\n",
+        "            config=GPT4Config(), # We specify the model\n",
+        "            sample=0.1, # We only run on 10% of the data\n",
+        "        ),\n",
+        "        lab.Job(job_function=get_keywords_previous_jobs),\n",
+        "    ]\n",
+        ")\n",
+        "results = await workload.async_run(\n",
+        "    messages[:100],\n",
+        "    executor_type=\"parallel\",\n",
+        "    max_parallelism=10,\n",
+        ")\n",
+        "results.get(\"0\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 41,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of different keywords extracted: 586\n"
+          ]
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAJeCAYAAABmn5DCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACeX0lEQVR4nOzdd1QU1/sG8GdBaYIUaaJIt6Bi77ETa+y9YfebxAr2WMGCmlijEbuCscQSjb1g7x3sAhbsBYIKKAjc3x/82LAuFgzuzJDnc86eI7Pj7sPCLvPO3PtelRBCgIiIiIiISMH0pA5ARERERET0b7GwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIgCAs7MzvvvuO6ljSOrQoUNQqVQ4dOjQv36sHj16wNnZ+V8/zueQ+mfn7OyMHj16SPb8REQACxsi+oSVK1dCpVJBpVLh2LFjWvcLIeDo6AiVSvXVDqwePXqEiRMn4tKlS1/l8YmU4Nq1a5g4cSLu3r0rdZQcI7f39s6dOzFx4kSpYxDRF2JhQ0SfxcjICGvWrNHafvjwYTx48ACGhoZf7bkfPXoEf39/2Rz8EH2OJUuW4ObNmzn2eNeuXYO/v3+uK2zk9N7euXMn/P39pY5BRF+IhQ0RfZYmTZpgw4YNSElJ0di+Zs0aVKhQAfb29hIlI/p8Qgi8efNGJ8+VN2/er1rwExGRJhY2RPRZOnXqhJiYGOzbt0+9LTk5GRs3bkTnzp2z/D8JCQkYOnQoHB0dYWhoiGLFiuGXX36BEEJjv3379uGbb76BhYUFTE1NUaxYMfz0008A0uc8VKpUCQDQs2dP9bC4lStXfjTvw4cP0bt3bzg4OMDQ0BAuLi744YcfkJycrN7n9u3baNeuHaysrGBiYoKqVatix44dGo+TMefijz/+gL+/PwoVKgQzMzO0bdsWL1++RFJSEoYMGQJbW1uYmpqiZ8+eSEpK0ngMlUqFAQMGYMOGDfD09ISxsTGqVauGy5cvAwAWLVoEd3d3GBkZoU6dOlmekd+wYQMqVKgAY2NjWFtbo2vXrnj48KHGPj169ICpqSkePnyIli1bwtTUFDY2Nhg2bBhSU1M/+np9yKpVq5AnTx4MHz5cve306dNo1KgRzM3NYWJigtq1a+P48ePq+w8ePAiVSoU///xT6/HWrFkDlUqFkydP4q+//oJKpUJ4eLj6/k2bNkGlUqF169Ya/69EiRLo0KGD+uuUlBRMmjQJbm5uMDQ0hLOzM3766Set1z5j7smePXtQsWJFGBsbY9GiRQCABw8eoGXLlsiXLx9sbW3h6+ur9f8BICIiAm3atIG9vT2MjIxQuHBhdOzYES9fvvzoa/f+HJu7d+9CpVLhl19+weLFi9XZK1WqhLNnz370sVauXIl27doBAOrWrat+H7w/F+jYsWOoXLkyjIyM4OrqiuDgYK3HiouLw5AhQ9TvS3d3d0yfPh1paWkfzQCkF4aTJ09G4cKFYWJigrp16+Lq1ata+8XGxmLYsGEoXbo0TE1NkT9/fjRu3BhhYWHqfT713j569CjatWuHIkWKwNDQEI6OjvD19dUqTJ88eYKePXuicOHCMDQ0RMGCBdGiRQut99GuXbtQs2ZN5MuXD2ZmZmjatKlG9h49emDBggUAoM6iUqk++ZoQkYwIIqKPWLFihQAgzp49K6pXry66deumvm/Lli1CT09PPHz4UDg5OYmmTZuq70tLSxP16tUTKpVK9OnTR8yfP180a9ZMABBDhgxR73flyhVhYGAgKlasKObOnSuCgoLEsGHDRK1atYQQQjx58kQEBAQIAKJfv34iJCREhISEiKioqA9mfvjwoXBwcBAmJiZiyJAhIigoSIwbN06UKFFC/P333+rHtbOzE2ZmZmLMmDFi1qxZokyZMkJPT09s3rxZ/VgHDx4UAETZsmVFtWrVxLx588SgQYOESqUSHTt2FJ07dxaNGzcWCxYsEN26dRMAhL+/v0YeAMLLy0s4OjqKadOmiWnTpglzc3NRpEgRMX/+fOHp6Slmzpwpxo4dKwwMDETdunWz/BlUqlRJzJ49W4waNUoYGxsLZ2dn9fcjhBDdu3cXRkZGomTJkqJXr15i4cKFok2bNgKA+O233z75s37/Z7ho0SKhUqnEmDFj1NtCQ0OFgYGBqFatmpg5c6aYPXu28PLyEgYGBuL06dPqn72jo6No06aN1nM0adJEuLm5CSGEiImJESqVSvz666/q+wcPHiz09PSEjY2NetuzZ88EADF//nyN7xWAaNu2rViwYIHw8fERAETLli21vid3d3dhaWkpRo0aJYKCgsTBgwdFYmKiKFq0qDAyMhIjRowQc+bMERUqVBBeXl4CgDh48KAQQoikpCTh4uIiHBwcxOTJk8XSpUuFv7+/qFSpkrh79+5HX8/u3bsLJycn9dd37twRAES5cuWEu7u7mD59upgxY4awtrYWhQsXFsnJyR98rKioKDFo0CABQPz000/q98GTJ0/U32exYsWEnZ2d+Omnn8T8+fNF+fLlhUqlEleuXFE/TkJCgvDy8hIFChQQP/30kwgKChI+Pj5CpVKJwYMHf/T7EUKIsWPHCgCiSZMmYv78+aJXr17CwcFBWFtbi+7du6v3O3v2rHBzcxOjRo0SixYtEgEBAaJQoULC3NxcPHz4UAjx6ff2wIEDRZMmTcTUqVPFokWLRO/evYW+vr5o27atRqbq1asLc3NzMXbsWLF06VIxdepUUbduXXH48GH1PsHBwUKlUolGjRqJX3/9VUyfPl04OzsLCwsLcefOHSGEECdOnBDffvutAKDOEhIS8snXhIjkg4UNEX1U5sJm/vz5wszMTCQmJgohhGjXrp36IPz9g+ItW7YIAGLy5Mkaj9e2bVuhUqlEZGSkEEKI2bNnCwDi+fPnH8xw9uxZAUCsWLHiszL7+PgIPT09cfbsWa370tLShBBCDBkyRAAQR48eVd/3+vVr4eLiIpydnUVqaqoQ4p/CplSpUhoHnp06dRIqlUo0btxY4/GrVaumcTArRHphY2hoqD6AEiK9aAAg7O3txatXr9TbR48eLQCo901OTha2traiVKlS4s2bN+r9tm/fLgCI8ePHq7dlHOwHBARoPH+5cuVEhQoVPvaSCSE0f4Zz584VKpVKTJo0SeO18/DwEA0bNlS/jkIIkZiYKFxcXMS3336r8X0YGhqKuLg49bZnz56JPHnyiAkTJqi3lSxZUrRv3179dfny5UW7du0EAHH9+nUhhBCbN28WAERYWJgQQohLly4JAKJPnz4a+YcNGyYAiAMHDmh8TwDE7t27NfadM2eOACD++OMP9baEhATh7u6uUdhcvHhRABAbNmz45Ov3vg8VNgUKFBCxsbHq7Vu3bhUAxLZt2z76eBs2bNDIllnG93nkyBH1tmfPnglDQ0MxdOhQ9bZJkyaJfPnyiVu3bmn8/1GjRgl9fX0RHR39wed/9uyZMDAwEE2bNtX4+f/0008CgEZh8/btW/V7KPP3b2hoqPH7+bH3dsbnTGaBgYFCpVKJe/fuCSGE+PvvvwUA8fPPP38w9+vXr4WFhYXo27evxvYnT54Ic3Nzje39+/cXPOdLpFwcikZEn619+/Z48+YNtm/fjtevX2P79u0fHIa2c+dO6OvrY9CgQRrbhw4dCiEEdu3aBQCwsLAAAGzduvWzhsJ8SlpaGrZs2YJmzZqhYsWKWvdnDC3ZuXMnKleujG+++UZ9n6mpKfr164e7d+/i2rVrGv/Px8cHefPmVX9dpUoVCCHQq1cvjf2qVKmC+/fva81Fql+/vsawpCpVqgAA2rRpAzMzM63tt2/fBgCcO3cOz549w48//ggjIyP1fk2bNkXx4sW1hs4BwPfff6/xdc2aNdWP9zlmzJiBwYMHY/r06Rg7dqx6+6VLlxAREYHOnTsjJiYGL168wIsXL5CQkID69evjyJEj6p+hj48PkpKSsHHjRvX/X79+PVJSUtC1a1eNbEePHgUAvH79GmFhYejXrx+sra3V248ePQoLCwuUKlUKQPrPDgD8/Pw0cg8dOhQAtF4TFxcXNGzYUGPbzp07UbBgQbRt21a9zcTEBP369dPYz9zcHACwZ88eJCYmftbr9ykdOnSApaWl+uuaNWsCQLZ+Rlnx9PRUPxYA2NjYoFixYhqPu2HDBtSsWROWlpbqn9+LFy/g7e2N1NRUHDly5IOPv3//fiQnJ2PgwIEaQ7SGDBmita+hoSH09NIPMVJTUxETE6MeZnrhwoXP+n6MjY3V/05ISMCLFy9QvXp1CCFw8eJF9T4GBgY4dOgQ/v777ywfZ9++fYiLi0OnTp00vmd9fX1UqVIFBw8e/Kw8RCR/LGyI6LPZ2NjA29sba9aswebNm5GamqpxYJjZvXv34ODgoHHQDqTPlci4H0g/yKtRowb69OkDOzs7dOzYEX/88ccXFznPnz/Hq1ev1AfBH3Lv3j0UK1ZMa/v7+TIUKVJE4+uMA15HR0et7WlpaVrzL7Lz/wGoD9IycmSVtXjx4lo5jYyMYGNjo7HN0tLygwd97zt8+DBGjhyJkSNHasyrAdLnmgBA9+7dYWNjo3FbunQpkpKS1N938eLFUalSJfz+++/q///777+jatWqcHd3V2+rWbMmHj9+jMjISJw4cQIqlQrVqlXTKHiOHj2KGjVqqA+U7927Bz09PY3HAQB7e3tYWFhovSYuLi5a3+e9e/fg7u6uNYfi/dfZxcUFfn5+WLp0KaytrdGwYUMsWLDgk/NrPub934WMIudzf0af+7gZj535cSMiIrB7926tn5+3tzcA4NmzZx98/IzX1cPDQ2O7jY2NRqEGpJ9gmD17Njw8PGBoaAhra2vY2NggPDz8s1+76Oho9OjRA1ZWVur5YrVr1wYA9WMYGhpi+vTp2LVrF+zs7FCrVi3MmDEDT5480fieAaBevXpa3/fevXs/+j0TkbLkkToAESlL586d0bdvXzx58gSNGzdWX3H5UsbGxjhy5AgOHjyIHTt2YPfu3Vi/fj3q1auHvXv3Ql9fP2eC/0sfyvGh7eK9Bgn/9v9/rn/7epUsWRJxcXEICQnB//73P42iIKPY/Pnnn1G2bNks/7+pqan63z4+Phg8eDAePHiApKQknDp1CvPnz9fYP+OK2ZEjR3D79m2UL18e+fLlQ82aNTFv3jzEx8fj4sWLmDJlitZzfe7E7sxn/r/EzJkz0aNHD2zduhV79+7FoEGDEBgYiFOnTqFw4cLZfryc/pln53HT0tLw7bffYsSIEVnuW7Ro0X+VIcPUqVMxbtw49OrVC5MmTYKVlRX09PQwZMiQzzppkZqaim+//RaxsbEYOXIkihcvjnz58uHhw4fo0aOHxmMMGTIEzZo1w5YtW7Bnzx6MGzcOgYGBOHDgAMqVK6feNyQkJMvujXny8FCIKLfgu5mIsqVVq1b43//+h1OnTmH9+vUf3M/JyQn79+/H69evNa7a3LhxQ31/Bj09PdSvXx/169fHrFmzMHXqVIwZMwYHDx6Et7d3tjoT2djYIH/+/Lhy5cpH93NycspyjZGs8kkpI8fNmzdRr149jftu3ryZ4zmtra2xceNGfPPNN6hfvz6OHTsGBwcHAICbmxsAIH/+/Ooz/B/TsWNH+Pn5Ye3atXjz5g3y5s2r0dkMSL/KUKRIERw9ehS3b99WD6WqVasW/Pz8sGHDBqSmpqJWrVrq/+Pk5IS0tDRERESor7ABwNOnTxEXF/dZr4mTkxOuXLkCIYTG79eH1p0pXbo0SpcujbFjx+LEiROoUaMGgoKCMHny5E8+V07JiQ5dbm5uiI+P/6yf3/syXteIiAi4urqqtz9//lzratPGjRtRt25dLFu2TGN7XFwcrK2t1V9/6Hu6fPkybt26hVWrVsHHx0e9PXNXxszc3NwwdOhQDB06FBEREShbtixmzpyJ1atXq39vbW1tP/l9swsakbJxKBoRZYupqSkWLlyIiRMnolmzZh/cr0mTJkhNTdU6Qz979myoVCo0btwYQHpb2PdlXA3IaL2bL18+AOkHRZ+ip6eHli1bYtu2bTh37pzW/Rlnr5s0aYIzZ87g5MmT6vsSEhKwePFiODs7w9PT85PPpQsVK1aEra0tgoKCNFoR79q1C9evX0fTpk1z/DkLFy6M/fv3482bN/j2228RExMDAKhQoQLc3Nzwyy+/ID4+Xuv/PX/+XONra2trNG7cGKtXr8bvv/+ORo0aaRzUZqhZsyYOHDiAM2fOqAubsmXLwszMDNOmTYOxsTEqVKig3r9JkyYAgDlz5mg8zqxZswDgs16TJk2a4NGjRxpzgBITE7F48WKN/V69eqU1X6p06dLQ09PLsjX015Sd98GHtG/fHidPnsSePXu07ouLi9P6XjPz9vZG3rx58euvv2pcBXr/5wCkXz16/wrUhg0btFqUf+h7yrj6lPkxhBCYO3euxn6JiYl4+/atxjY3NzeYmZmpfz4NGzZE/vz5MXXqVLx7904ra+bf25x4jYlIOrxiQ0TZ1r1790/u06xZM9StWxdjxozB3bt3UaZMGezduxdbt27FkCFD1GdRAwICcOTIETRt2hROTk549uwZfvvtNxQuXFg9TMnNzQ0WFhYICgqCmZkZ8uXLhypVqmQ5dwJIHwazd+9e1K5dG/369UOJEiXw+PFjbNiwAceOHYOFhQVGjRqFtWvXonHjxhg0aBCsrKywatUq3LlzB5s2bVLP55Ba3rx5MX36dPTs2RO1a9dGp06d8PTpU8ydOxfOzs7w9fX9Ks/r7u6OvXv3ok6dOmjYsCEOHDiA/PnzY+nSpWjcuDFKliyJnj17olChQnj48CEOHjyI/PnzY9u2bRqP4+Pjo56HNWnSpCyfq2bNmvj999+hUqnUP3N9fX1Ur14de/bsQZ06dWBgYKDev0yZMujevTsWL16MuLg41K5dG2fOnMGqVavQsmVL1K1b95PfX9++fTF//nz4+Pjg/PnzKFiwIEJCQmBiYqKx34EDBzBgwAC0a9cORYsWRUpKCkJCQqCvr482bdpk6zX9t8qWLQt9fX1Mnz4dL1++hKGhIerVqwdbW9vPfozhw4fjr7/+wnfffYcePXqgQoUKSEhIwOXLl7Fx40bcvXs3y+ITgHpNpMDAQHz33Xdo0qQJLl68iF27dmn9n++++w4BAQHo2bMnqlevjsuXL+P333/XuNIDfPi9Xbx4cbi5uWHYsGF4+PAh8ufPj02bNmldGbp16xbq16+P9u3bw9PTE3ny5MGff/6Jp0+fomPHjgDSrzAuXLgQ3bp1Q/ny5dGxY0fY2NggOjoaO3bsQI0aNdQnYDIK6EGDBqFhw4bQ19dXPw4RKYAkvdiISDEyt3v+mPfbPQuR3mbV19dXODg4iLx58woPDw/x888/a7SKDQ0NFS1atBAODg7CwMBAODg4iE6dOmm1o926davw9PQUefLk+azWz/fu3RM+Pj7CxsZGGBoaCldXV9G/f3+RlJSk3icqKkq0bdtWWFhYCCMjI1G5cmWxfft2jcfJaPf8frvfD70uEyZM0GpfDUD0799fY7+M1r/vt6n90POtX79elCtXThgaGgorKyvRpUsX8eDBA419unfvLvLly6f1WmRk+pSsfoanT58WZmZmolatWur2uxcvXhStW7cWBQoUEIaGhsLJyUm0b99ehIaGaj1mUlKSsLS0FObm5hrtqjO7evWqACBKlCihsX3y5MkCgBg3bpzW/3n37p3w9/cXLi4uIm/evMLR0VGMHj1avH379pPfU4Z79+6J5s2bCxMTE2FtbS0GDx4sdu/erdFS+fbt26JXr17Czc1NGBkZCSsrK1G3bl2xf//+rF/ETD7U7jmr1sQANNpgf8iSJUuEq6ur0NfX18j5oe+zdu3aonbt2hrbXr9+LUaPHi3c3d2FgYGBsLa2FtWrVxe//PLLR9fSEUKI1NRU4e/vLwoWLCiMjY1FnTp1xJUrV4STk5NWu+ehQ4eq96tRo4Y4efJklnk+9N6+du2a8Pb2FqampsLa2lr07dtXhIWFaezz4sUL0b9/f1G8eHGRL18+YW5uLqpUqaLRxjvDwYMHRcOGDYW5ubkwMjISbm5uokePHuLcuXPqfVJSUsTAgQOFjY2NUKlUbP1MpDAqIf7lbEUiIqIPSElJgYODA5o1a6Y134KIiCgnyWOsBRER5UpbtmzB8+fPNSaAExERfQ28YkNERDnu9OnTCA8Px6RJk2Btbf3ZizISERF9KV6xISKiHLdw4UL88MMPsLW1RXBwsNRxiIjoP4BXbIiIiIiISPF4xYaIiIiIiBSPhQ0RERERESme7BboTEtLw6NHj2BmZgaVSiV1HCIiIiIikogQAq9fv4aDg8MnF8+WXWHz6NEjODo6Sh2DiIiIiIhk4v79+yhcuPBH95FdYWNmZgYgPXz+/PklTkNERERERFJ59eoVHB0d1TXCx8iusMkYfpY/f34WNkRERERE9FlTVNg8gIiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFyyN1gH/DedSOHHusu9Oa5thjERERERGRbvGKDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlK8bBU2gYGBqFSpEszMzGBra4uWLVvi5s2bGvvUqVMHKpVK4/b999/naGgiIiIiIqLMslXYHD58GP3798epU6ewb98+vHv3Dg0aNEBCQoLGfn379sXjx4/VtxkzZuRoaCIiIiIioszyZGfn3bt3a3y9cuVK2Nra4vz586hVq5Z6u4mJCezt7XMmIRERERER0Sf8qzk2L1++BABYWVlpbP/9999hbW2NUqVKYfTo0UhMTPzgYyQlJeHVq1caNyIiIiIiouzI1hWbzNLS0jBkyBDUqFEDpUqVUm/v3LkznJyc4ODggPDwcIwcORI3b97E5s2bs3ycwMBA+Pv7f2kMIiIiIiIiqIQQ4kv+4w8//IBdu3bh2LFjKFy48Af3O3DgAOrXr4/IyEi4ublp3Z+UlISkpCT1169evYKjoyNevnyJ/PnzfzSD86gdXxI9S3enNc2xxyIiIiIion/v1atXMDc3/6za4Iuu2AwYMADbt2/HkSNHPlrUAECVKlUA4IOFjaGhIQwNDb8kBhEREREREYBsFjZCCAwcOBB//vknDh06BBcXl0/+n0uXLgEAChYs+EUBiYiIiIiIPiVbhU3//v2xZs0abN26FWZmZnjy5AkAwNzcHMbGxoiKisKaNWvQpEkTFChQAOHh4fD19UWtWrXg5eX1Vb4BIiIiIiKibBU2CxcuBJC+CGdmK1asQI8ePWBgYID9+/djzpw5SEhIgKOjI9q0aYOxY8fmWGAiIiIiIqL3ZXso2sc4Ojri8OHD/yoQERERERFRdv2rdWyIiIiIiIjkgIUNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixctWYRMYGIhKlSrBzMwMtra2aNmyJW7evKmxz9u3b9G/f38UKFAApqamaNOmDZ4+fZqjoYmIiIiIiDLLVmFz+PBh9O/fH6dOncK+ffvw7t07NGjQAAkJCep9fH19sW3bNmzYsAGHDx/Go0eP0Lp16xwPTkRERERElCFPdnbevXu3xtcrV66Era0tzp8/j1q1auHly5dYtmwZ1qxZg3r16gEAVqxYgRIlSuDUqVOoWrVqziUnIiIiIiL6f/9qjs3Lly8BAFZWVgCA8+fP4927d/D29lbvU7x4cRQpUgQnT57M8jGSkpLw6tUrjRsREREREVF2fHFhk5aWhiFDhqBGjRooVaoUAODJkycwMDCAhYWFxr52dnZ48uRJlo8TGBgIc3Nz9c3R0fFLIxERERER0X/UFxc2/fv3x5UrV7Bu3bp/FWD06NF4+fKl+nb//v1/9XhERERERPTfk605NhkGDBiA7du348iRIyhcuLB6u729PZKTkxEXF6dx1ebp06ewt7fP8rEMDQ1haGj4JTGIiIiIiIgAZPOKjRACAwYMwJ9//okDBw7AxcVF4/4KFSogb968CA0NVW+7efMmoqOjUa1atZxJTERERERE9J5sXbHp378/1qxZg61bt8LMzEw9b8bc3BzGxsYwNzdH79694efnBysrK+TPnx8DBw5EtWrV2BGNiIiIiIi+mmwVNgsXLgQA1KlTR2P7ihUr0KNHDwDA7NmzoaenhzZt2iApKQkNGzbEb7/9liNhiYiIiIiIspKtwkYI8cl9jIyMsGDBAixYsOCLQxEREREREWXHv1rHhoiIiIiISA5Y2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESletgubI0eOoFmzZnBwcIBKpcKWLVs07u/RowdUKpXGrVGjRjmVl4iIiIiISEu2C5uEhASUKVMGCxYs+OA+jRo1wuPHj9W3tWvX/quQREREREREH5Mnu/+hcePGaNy48Uf3MTQ0hL29/ReHIiIiIiIiyo6vMsfm0KFDsLW1RbFixfDDDz8gJibmg/smJSXh1atXGjciIiIiIqLsyPHCplGjRggODkZoaCimT5+Ow4cPo3HjxkhNTc1y/8DAQJibm6tvjo6OOR2JiIiIiIhyuWwPRfuUjh07qv9dunRpeHl5wc3NDYcOHUL9+vW19h89ejT8/PzUX7969YrFDRERERERZctXb/fs6uoKa2trREZGZnm/oaEh8ufPr3EjIiIiIiLKjq9e2Dx48AAxMTEoWLDg134qIiIiIiL6j8r2ULT4+HiNqy937tzBpUuXYGVlBSsrK/j7+6NNmzawt7dHVFQURowYAXd3dzRs2DBHgxMREREREWXIdmFz7tw51K1bV/11xvyY7t27Y+HChQgPD8eqVasQFxcHBwcHNGjQAJMmTYKhoWHOpSYiIiIiIsok24VNnTp1IIT44P179uz5V4GIiIiIiIiy66vPsSEiIiIiIvraWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpXrbbPdPncR61I8ce6+60pjn2WIC8sxERERERfQlesSEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSvDxSByDK4DxqR44+3t1pTXPssXIyW07mIiIiIqJ0vGJDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFC/bhc2RI0fQrFkzODg4QKVSYcuWLRr3CyEwfvx4FCxYEMbGxvD29kZERERO5SUiIiIiItKS7cImISEBZcqUwYIFC7K8f8aMGZg3bx6CgoJw+vRp5MuXDw0bNsTbt2//dVgiIiIiIqKs5Mnuf2jcuDEaN26c5X1CCMyZMwdjx45FixYtAADBwcGws7PDli1b0LFjx3+XloiIiIiIKAs5Osfmzp07ePLkCby9vdXbzM3NUaVKFZw8eTLL/5OUlIRXr15p3IiIiIiIiLIjRwubJ0+eAADs7Ow0ttvZ2anve19gYCDMzc3VN0dHx5yMRERERERE/wGSd0UbPXo0Xr58qb7dv39f6khERERERKQwOVrY2NvbAwCePn2qsf3p06fq+95naGiI/Pnza9yIiIiIiIiyI0cLGxcXF9jb2yM0NFS97dWrVzh9+jSqVauWk09FRERERESklu2uaPHx8YiMjFR/fefOHVy6dAlWVlYoUqQIhgwZgsmTJ8PDwwMuLi4YN24cHBwc0LJly5zMTUREREREpJbtwubcuXOoW7eu+ms/Pz8AQPfu3bFy5UqMGDECCQkJ6NevH+Li4vDNN99g9+7dMDIyyrnUREREREREmWS7sKlTpw6EEB+8X6VSISAgAAEBAf8qGBERERER0eeSvCsaERERERHRv8XChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPGy3e6ZiOTFedSOHHusu9Oa5thjAfLORkRERLkLr9gQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHi5ZE6ABGRrjmP2pGjj3d3WtMcfTwiIiLKPl6xISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESleHqkDEBHRP5xH7cixx7o7rWmOPRbAbEREJG+8YkNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFy/HCZuLEiVCpVBq34sWL5/TTEBERERERqeX5Gg9asmRJ7N+//58nyfNVnoaIiIiIiAjAVyps8uTJA3t7+6/x0ERERERERFq+yhybiIgIODg4wNXVFV26dEF0dPQH901KSsKrV680bkRERERERNmR41dsqlSpgpUrV6JYsWJ4/Pgx/P39UbNmTVy5cgVmZmZa+wcGBsLf3z+nYxAREUnOedSOHH28u9Oa5thj5WS2nMwFMNuX4O/al5FzNsq+HL9i07hxY7Rr1w5eXl5o2LAhdu7cibi4OPzxxx9Z7j969Gi8fPlSfbt//35ORyIiIiIiolzuq8/qt7CwQNGiRREZGZnl/YaGhjA0NPzaMYiIiIiIKBf76uvYxMfHIyoqCgULFvzaT0VERERERP9ROV7YDBs2DIcPH8bdu3dx4sQJtGrVCvr6+ujUqVNOPxURERERERGArzAU7cGDB+jUqRNiYmJgY2ODb775BqdOnYKNjU1OPxURERERERGAr1DYrFu3LqcfkoiIiIiI6KO++hwbIiIiIiKir42FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeLleLtnIiIiIiL6d5xH7cixx7o7rWmOPVZO5gJyNhuv2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPFY2BARERERkeKxsCEiIiIiIsVjYUNERERERIrHwoaIiIiIiBSPhQ0RERERESkeCxsiIiIiIlI8FjZERERERKR4LGyIiIiIiEjxWNgQEREREZHisbAhIiIiIiLFY2FDRERERESKx8KGiIiIiIgUj4UNEREREREpHgsbIiIiIiJSPBY2RERERESkeCxsiIiIiIhI8VjYEBERERGR4rGwISIiIiIixWNhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyIiIiIiUjwWNkREREREpHgsbIiIiIiISPG+WmGzYMECODs7w8jICFWqVMGZM2e+1lMREREREdF/3FcpbNavXw8/Pz9MmDABFy5cQJkyZdCwYUM8e/bsazwdERERERH9x32VwmbWrFno27cvevbsCU9PTwQFBcHExATLly//Gk9HRERERET/cXly+gGTk5Nx/vx5jB49Wr1NT08P3t7eOHnypNb+SUlJSEpKUn/98uVLAMCrV68++VxpSYk5kBif/XzZwWzZl5O5APlm+6/8PAH5ZuPv2pdhtuzj79qXYbbs4+/al2G27NP171rG/UKITz6WSnzOXtnw6NEjFCpUCCdOnEC1atXU20eMGIHDhw/j9OnTGvtPnDgR/v7+ORmBiIiIiIhykfv376Nw4cIf3SfHr9hk1+jRo+Hn56f+Oi0tDbGxsShQoABUKtW/fvxXr17B0dER9+/fR/78+f/14+UUueYCmO1LyTWbXHMBzPal5JpNrrkAZvtScs0m11wAs30puWaTay7gv5NNCIHXr1/DwcHhk/vmeGFjbW0NfX19PH36VGP706dPYW9vr7W/oaEhDA0NNbZZWFjkdCzkz59fdj90QL65AGb7UnLNJtdcALN9Kblmk2sugNm+lFyzyTUXwGxfSq7Z5JoL+G9kMzc3/6z9crx5gIGBASpUqIDQ0FD1trS0NISGhmoMTSMiIiIiIsopX2Uomp+fH7p3746KFSuicuXKmDNnDhISEtCzZ8+v8XRERERERPQf91UKmw4dOuD58+cYP348njx5grJly2L37t2ws7P7Gk/3UYaGhpgwYYLWcDepyTUXwGxfSq7Z5JoLYLYvJddscs0FMNuXkms2ueYCmO1LyTWbXHMBzJaVHO+KRkREREREpGtfZYFOIiIiIiIiXWJhQ0REREREisfChoiIiIiIFI+FDRERERERKR4LGyL6z3v37h3c3Nxw/fp1qaMQEeWoqKgojB07Fp06dcKzZ88AALt27cLVq1clTkaU81jYkOzVq1cPcXFxWttfvXqFevXq6T6QAqWmpuLSpUv4+++/pY4iS3nz5sXbt2+ljvFRoaGh+Omnn9CnTx/06tVL40aUU1xdXRETE6O1PS4uDq6urhIk0hYZGYk9e/bgzZs3AAA2d/2ww4cPo3Tp0jh9+jQ2b96M+Ph4AEBYWBgmTJggcTr5mjBhAu7duyd1jI+S4/ugV69eeP36tdb2hIQEnf2tyrWFTUpKCvbv349FixapX+RHjx6p39RSOXDggGwPoEJCQlCjRg04ODio39Bz5szB1q1bJc116NAhJCcna21/+/Ytjh49KkGif0RERGDx4sWYPHkyAgICNG5SGjJkCJYtWwYgvaipXbs2ypcvD0dHRxw6dEjSbHLVv39/TJ8+HSkpKVJH0eLv748GDRogNDQUL168wN9//61xo8/z6tUrbNmyhVfmPuLu3btITU3V2p6UlISHDx9KkOgfMTEx8Pb2RtGiRdGkSRM8fvwYANC7d28MHTpU0mzvk8vv2qhRozB58mTs27cPBgYG6u316tXDqVOnJEz2Dzker23duhVubm6oX78+1qxZg6SkJMmyvE/O74NVq1apC63M3rx5g+DgYJ1k+CoLdErt3r17aNSoEaKjo5GUlIRvv/0WZmZmmD59OpKSkhAUFCRZtubNmyMlJQWVKlVCnTp1ULt2bdSoUQPGxsaSZQKAhQsXYvz48RgyZAimTJmi/sNmYWGBOXPmoEWLFjrPFB4erv73tWvX8OTJE/XXqamp2L17NwoVKqTzXBmWLFmCH374AdbW1rC3t4dKpVLfp1KpMH78eMmybdy4EV27dgUAbNu2DXfu3MGNGzcQEhKCMWPG4Pjx45Jla9WqlcZrlUGlUsHIyAju7u7o3LkzihUrptNcZ8+eRWhoKPbu3YvSpUsjX758Gvdv3rxZp3kyCwoKwsqVK9GtWzfJMnzK0aNHsWjRIkRFRWHjxo0oVKgQQkJC4OLigm+++UaSTO3bt0etWrUwYMAAvHnzBhUrVsTdu3chhMC6devQpk0bSXJlCAkJQVBQEO7cuYOTJ0/CyckJc+bMgYuLi84/c//66y/1v/fs2QNzc3P116mpqQgNDYWzs7NOM73P19cXefLkQXR0NEqUKKHe3qFDB/j5+WHmzJmSZZPr79rly5exZs0are22trZ48eKFBIk0yfV47dKlS7h48SJWrFiBwYMHo3///ujYsSN69eqFSpUqSZIpgxzfB69evYIQAkIIvH79GkZGRur7UlNTsXPnTtja2uomjMiFWrRoIbp27SqSkpKEqampiIqKEkIIcfDgQeHu7i5ptuTkZHHs2DExZcoU0aBBA2FqaioMDAxE9erVxZgxYyTLVaJECfHnn38KIYTGa3b58mVRoEABSTKpVCqhp6cn9PT0hEql0rqZmJiIZcuWSZJNCCGKFCkipk2bJtnzf4yhoaG4f/++EEKIvn37isGDBwshhLh9+7YwMzOTMJkQ3bt3F+bm5sLJyUm0bt1atG7dWjg7OwsLCwvRvn17UaxYMWFoaCiOHTum01w9evT46E1KVlZWIjIyUtIMH7Nx40ZhbGws+vTpIwwNDdWfH7/++qto3LixZLns7OzEpUuXhBBC/P7778Ld3V0kJCSI3377TZQtW1ayXEII8dtvvwlra2sxefJkYWxsrH7NVqxYIerUqaPzPBmfq1l93hoYGIiiRYuKbdu26TxXZpl/npn/TkVFRYl8+fJJGU22v2uFChUSx48fF0JovmabN28Wrq6ukuXKIOfjtQzJycli06ZN4rvvvhN58+YVpUuXFnPmzBFxcXGS5JHj+yDz8VpWN319fTF58mSdZMmVhY2VlZW4ceOGEELzh37nzh1hbGwsZTQtV65cEd27dxd58uQRenp6kuUwMjISd+/eFUJovma3bt0SRkZGkmS6e/euuHPnjlCpVOLs2bPi7t276tujR49ESkqKJLkymJmZqV8nuSlSpIjYs2ePSElJEY6OjmL79u1CiPTfNwsLC0mzjRw5Uvzwww8iNTVVvS01NVUMGDBAjB49WqSlpYl+/fqJGjVqSJhSXkaMGCECAgKkjvFBZcuWFatWrRJCaH5+XLhwQdjZ2UmWy8jISERHRwshhOjWrZsYOXKkEEKIe/fuSX4gLMeTSUII4ezsLJ4/fy7Z83+MqampuHXrlvrfGa/Z2bNnhZWVlZTRZPu7NnToUPHNN9+Ix48fCzMzMxERESGOHTsmXF1dxcSJEyXLlUEJx2tJSUli3bp1okGDBiJPnjyiVq1awt3dXZiZmYl169bpPI8c3weHDh0SBw8eFCqVSmzevFkcOnRIfTtx4oR4+PChzrLkyqFoaWlpWY4RfvDgAczMzCRI9I9bt27h0KFDOHToEA4fPoykpCTUrFkTv/zyC+rUqSNZLhcXF1y6dAlOTk4a23fv3q1xqVOXMrKkpaVJ8vyf0q5dO+zduxfff/+91FG09OzZE+3bt0fBggWhUqng7e0NADh9+jSKFy8uabZly5bh+PHj0NP7Z4qfnp4eBg4ciOrVq2Pq1KkYMGAAatasKUm+58+f4+bNmwCAYsWKwcbGRpIcmb19+xaLFy/G/v374eXlhbx582rcP2vWLImSpbt58yZq1aqltd3c3DzLxh+64ujoiJMnT8LKygq7d+/GunXrAAB///23xlAJKdy5cwflypXT2m5oaIiEhAQJEqW7c+eOZM/9KTVr1kRwcDAmTZoEIH34alpaGmbMmIG6detKmk2uv2tTp05F//794ejoiNTUVHh6eiI1NRWdO3fG2LFjJcuVQc7Ha+fPn8eKFSuwdu1aGBoawsfHBwsWLIC7uzsA4Ndff8WgQYPQoUMHneaS4/ugdu3aANI/PxwdHTX+vutarixsGjRogDlz5mDx4sUA0n/o8fHxmDBhApo0aSJptuLFi8PGxgaDBw/GqFGjULp06SznG+ian58f+vfvj7dv30IIgTNnzmDt2rUIDAzE0qVLpY6HiIgIHDx4EM+ePdMqdKSay+Lu7o5x48bh1KlTKF26tNbB5qBBgyTJBQATJ05EqVKlcP/+fbRr1w6GhoYAAH19fYwaNUqyXED6RNEbN26gaNGiGttv3Lih/gNnZGSk8/dFQkICBg4ciODgYPXvmL6+Pnx8fPDrr7/CxMREp3kyCw8PR9myZQEAV65c0bhPDp8f9vb2iIyM1JqDcezYMUk7aQ0ZMgRdunSBqakpihQpoj55dOTIEZQuXVqyXIA8TyZlCA0NRWhoaJaft8uXL5coFTBjxgzUr18f586dQ3JyMkaMGIGrV68iNjZW0nmDgObvmpOTk2x+1wwMDLBkyRKMHz8ely9fRnx8PMqVKwcPDw/JMmUm1+O10qVL48aNG2jQoAGWLVuGZs2aQV9fX2OfTp06YfDgwTrPJuf3gZOTE+Li4nDmzJksPz98fHy+fgidXRvSofv37wtPT09RokQJkSdPHlG1alVRoEABUaxYMfH06VNJsw0ePFiUK1dOGBoaimrVqonRo0eLPXv2iISEBElzCSHE6tWrhbu7u3pcdaFChcTSpUuljiUWL14s9PX1hZ2dnShTpowoW7as+lauXDnJcjk7O3/w5uLiIlmu971580bqCBoGDhworK2txaxZs8TRo0fF0aNHxaxZs4S1tbUYNGiQEEKIJUuW6HwoWr9+/YSrq6vYuXOnePnypXj58qXYsWOHcHNzE99//71OsyjN1KlThaenpzh16pQwMzMTR48eFatXrxY2NjZi3rx5kmY7e/as2Lx5s3j9+rV62/bt23U+h+t9S5YsEYUKFRLr1q0T+fLlE2vXrhWTJ09W/1sqEydOFHp6eqJy5cqiRYsWomXLlho3qcXFxYnJkyeLdu3aicaNG4sxY8aIR48eSR1LCCHEuXPnZPm7JmdyPV4LCAgQDx48kOz5P0Wu74O//vpLmJmZCZVKJczNzYWFhYX6ZmlpqZMMubKwEUKId+/eiZCQEDF8+HDxww8/iCVLlojExESpY6n9/fff4q+//hJDhw4VFStWFMbGxqJ69epSxxJCCJGQkCB5AZiZnCfpy1VKSooICAgQDg4OQl9fXz0Gd+zYsZIXqykpKWLy5MnC3t5eXUTb29uLKVOmqOdN3bt3T938QFcKFCggDh48qLX9wIEDwtraWqdZPub+/fs6f20+JS0tTX1QnvEzNTIyEmPHjpU6mhAifYz8jRs3xLt376SOokGOJ5Ps7e1FcHCwpBko57Ru3TrLv5/Tp08Xbdu2lSCRNrkfr8nNvXv3RFpa2gfvk5KHh4cYPHiwpCfrVULIYEWf/6CYmBgcPnwYBw8exKFDh3Dt2jVYWlpK1n7xzp07SElJ0bo8HRERgbx580ra5jN//vy4dOmSbBaHy0rG20gOw4IAICAgAKtWrUJAQAD69u2LK1euwNXVFevXr8ecOXNw8uRJqSMCSG8RCaT/jKVmYmKC8+fPaw0Dunr1KipXrizpvIe0tDRMnjwZM2fOVK/tYGZmhqFDh2LMmDGSjmfOLDk5GZGRkYiPj4enpydMTU0lzZOYmIiBAwdi1apVANLnOLq6umLgwIEoVKiQ5MMyMyQmJiI+Pl537VA/okCBAjhz5gzc3NykjqLlyJEjH70/q3leuvTgwQP89ddfiI6O1lp7Tap5cDY2Njhw4IDWcLjLly/D29sbT58+lSRXhrdv30o+3y2Dn5/fZ+8r5bxGfX19PH78WOvzIiYmBra2tlnOWdKVfPny4fLly5Ier+XKOTaAPOdkAOnzLjIXMrVq1ULfvn1Rp04dScfh9ujRA7169dIqbE6fPo2lS5dKuqijnCfpBwcH4+eff0ZERAQAoGjRohg+fLjk640EBwdj8eLFqF+/vsbrVqZMGdy4cUPCZJrkUNBkqFatGiZMmIDg4GD1H9o3b97A398f1apVkzTbmDFjsGzZMkybNg01atQAkD5/ZeLEiXj79i2mTJkiab4MBgYG8PT0lDqG2ujRoxEWFoZDhw6hUaNG6u3e3t6YOHGipIVN5pNJJiYm6jlcUp9M6tOnD9asWYNx48ZJ8vwfk1WDncwnk6Q8oAsNDUXz5s3h6uqKGzduoFSpUup1bMqXLy9Zrvj4eI2FOTPkzZtXfWJJSra2tmjVqhW6du2K+vXrS3qS5uLFi5+1n9QnMIUQWWaIj4+XvEhs2LAhzp07x8Imp8l54cTHjx+jX79+qFOnDkqVKiVZjvddvHhRfcCUWdWqVTFgwAAJEv1DrpP0Z82ahXHjxmHAgAEaB5vff/89Xrx4AV9fX0lyAcDDhw/VnVsyS0tLw7t37yRI9I+nT59i2LBh6snJ7180lurgZO7cuWjYsCEKFy6MMmXKAADCwsJgZGSEPXv2SJIpw6pVq7B06VI0b95cvc3LywuFChXCjz/+KElh07p168/eV6rFTbds2YL169ejatWqGn8HSpYsiaioKEkyZZDrySQ5d+D7+++/Nb5+9+4dLl68iHHjxkle3I8ePRrDhg2Dv78/zMzMsGnTJtja2qJLly4aRbWulS5dGuvXr9c67lm3bp0sTkKsWrUKa9asQYsWLWBubo4OHTqga9euqFixos6zHDx4UOfPmR0ZV5RUKhXGjRun0dAmNTUVp0+fVjeZkUrTpk0xfPhwXLt2Lcvjtcx/w76WXDkUzcnJCT/++CNGjhwpdRTFMDc3x6FDh7Taj54/fx516tTB69evJUqW3j3oQ1QqFW7fvq3DNP9wcXGBv7+/VpePVatWYeLEiZK2Ta1QoQJ8fX3RtWtXmJmZISwsDK6urggICMC+fftw9OhRybI1btwY0dHRGDBggLoddWa6XnE9s8TERPz+++/qq1olSpRAly5dYGxsLFkmIL1LXHh4uFYnuZs3b6Js2bJ48+aNzjP17Nnzs/ddsWLFV0zyYSYmJuphmJnfB2FhYahVqxZevnwpSS4g/WrlhQsXtE5AREZGomLFipK1yf5Yu1iVSoUDBw7oMM3nOXz4MPz8/HD+/HnJMpiZmeHSpUtwc3ODpaUljh07hpIlSyIsLAwtWrTA3bt3Jcm1bds2tG7dGp07d0a9evUApF9dWrt2LTZs2ICWLVtKkut9r1+/xsaNG7F27VocOHAArq6u6Nq1q6QnouUm4715+PBhVKtWTeNKnIGBAZydnTFs2DBJO9597IqbSqXSzYlLyWb3fEVyXjhRCCGCg4NF9erVRcGCBdWLYs6ePVts2bJFskzfffedaNeuncailykpKaJNmzaiUaNGkuWSM0NDQxEREaG1/datW8LQ0FCCRP/YsmWLMDc3F9OmTRMmJibi559/Fn369BEGBgZi7969kmYzNTUVFy9elDSD0lSuXFkMHDhQa/uAAQNElSpVJEikDDVr1lR3ZTM1NRW3b98WQqS/bg0bNpQymsifP7+4cOGC1vZz584JU1NTCRIp1/Xr1yVfcNXOzk5cu3ZNCJG++OrWrVuFEEJcunRJ8mzbt28X1atXFyYmJqJAgQKibt264tChQ5Jm+pirV6+KsmXL6nzR8latWomXL1+q//2xm5R69OihzknacuVQNDnPyVi4cCHGjx+PIUOGYMqUKerq1cLCAnPmzJHsbPW0adNQu3ZtFCtWTL0w4tGjR/Hq1SvZnKFLTk7GnTt34Obmhjx5pP/VdXd3xx9//IGffvpJY/v69eslXyOgRYsW2LZtGwICApAvXz6MHz8e5cuXx7Zt2/Dtt99Kms3R0VFr+JkcBAYGws7ODr169dLYvnz5cjx//lzSK8AzZsxA06ZNsX//fvV8n5MnT+L+/fvYuXOnZLkyTJgwAb169dJak0VqU6dORePGjXHt2jWkpKRg7ty5uHbtGk6cOIHDhw9Lmq1WrVoIDAzE2rVr1etjpKamIjAwEN98842k2YD0K0dRUVGoVasWjI2NPziuX5fCw8M1vhZC4PHjx5g2bZrkQ3CqVq2KY8eOoUSJEmjSpAmGDh2Ky5cvY/Pmzahataqk2Zo2bYqmTZtKmuFT3r59i7/++gtr1qzB7t27YWdnh+HDh+s0g7m5ufp33NzcXKfPnR1SXQHPLqkaQ+TKoWiBgYGYNWsWmjZtKqs5GQDg6emJqVOnomXLlhpDI65cuYI6depI1hUNAB49eoT58+cjLCwMxsbG8PLywoABA2BlZSVZJkC+nY02bdqEDh06wNvbWz3H5vjx4wgNDcUff/yBVq1aSZJL7vbu3YuZM2di0aJFknbbe5+zszPWrFmD6tWra2w/ffo0OnbsKPmK7I8ePcKCBQs0hsn9+OOPcHBwkDQXAJQtWxZXrlxB7dq10bt3b7Rp00a9KKzUoqKiMG3aNISFhSE+Ph7ly5fHyJEjJV+g89q1a6hVqxYsLCyyPJkk1RzMmJgYtG/fHgcPHoRKpUJERARcXV3Rq1cvWFpaYubMmZLkAtKHuahUKq0TI1WrVsXy5ctRvHhxiZIBt2/fRnx8PLy8vJCQkIChQ4fixIkT8PDwwKxZsyQv+pOTk7NsplSkSBGJEqXbs2cP1qxZgy1btiBPnjxo27YtunTpInmHO7lp3bo1Vq5cifz5839yfqNUcxqB9JMzU6dORVBQEJ4+fao+Xhs3bhycnZ3Ru3fvr54hVxY2cp2TAQDGxsa4ceMGnJycNAqbiIgIeHl5STJW/t27d2jUqBGCgoIkv9KQlcGDB+P48eOYM2cOGjVqhPDwcLi6umLr1q2YOHHiZ3cy+RrOnz+P2bNn4/r16wDSDzaHDh2qNVeJ/mFpaYnExESkpKTAxMRE68RDbGysJLmMjIxw/fp1rc+P27dvw9PTE2/fvpUkl1JcvHgRK1aswNq1a5GSkoKOHTuiV69eqFSpktTRZEuOJ5N8fHzw7NkzLF26FCVKlFD/jdqzZw/8/Pxw9epVybLdu3dP42s9PT3Y2NhI3glKziIiItCrVy+cOHFCY3vGFTgpO8kB6fPgvvvuO3Tp0gVNmjTR+ntA6Xr27Il58+bBzMzsk/MbpbyiI4elJqQfz/MVSH1m9WNcXFxw6dIlrbM3u3fv1lo/Q1fy5s2rdYlfTuTc2ahChQpYvXq1pBkyWFpafvZQEamKBwCYM2eOZM/9MY6Ojjh+/LhWYXP8+HFJroqEh4ejVKlS0NPT++T708vLS0epPqxcuXIoV64cZs6ciW3btmHFihWoUaMGihcvjt69e6NHjx6SDO9ITU3Fn3/+qT754OnpiRYtWshiOKuDgwOmTp0qdQwNe/fuxZ49e1C4cGGN7R4eHlqFha5JfdXjU+Li4rBx40ZERUVh+PDhsLKywoULF2BnZ4dChQpJkqlHjx7IkycPtm/fnmWzFqk9ffoUZmZmUsfQEhMTg/Hjx39w2RBd/w3NKFaEEPD394eNjY3kTW2yIoelJqT/ZP+P8fPzQ//+/fH27VsIIXDmzBmsXbsWgYGBWLp0qWS5unbtql4nQ26eP3+e5cJ1CQkJOv+QfvXqlXrtlU+tAaDrNVrkWjC8r3v37lJHyFLfvn0xZMgQvHv3TqN70IgRIzB06FCd5ylbtiyePHkCW1tblC1bNsshOIAOO818JiEE3r17h+TkZAghYGlpifnz52PcuHFYsmQJOnTooLMsV69eRfPmzfHkyRMUK1YMADB9+nTY2Nhg27ZtOh/upYRiNSEhQaONbIbY2FhJhhfOmzfvs/eVcph5eHg4vL29YW5ujrt376Jv376wsrLC5s2bER0djeDgYElyXbp0CefPn5d0mN7HmJmZITU1FVu2bNE6+ZAx90wK3bp1Q2RkJHr37g07OzvZFIRCCLi7u+Pq1auyHGEjh6Umck1h4+fnh0mTJiFfvnyfXD1Wyj78ffr0gbGxMcaOHYvExER07twZDg4OmDt3Ljp27ChZrpSUFCxfvhz79+9HhQoVkC9fPo37pXzNKlasiB07dmDgwIEA/lkca+nSpTpfONHS0lK94q+FhUWWH3ZSXeKXa8EAyLsgzDB8+HDExMTgxx9/VK8abmRkhJEjR2L06NE6z3Pnzh3Y2Nio/y1358+fVw9FMzQ0hI+PDxYsWKD+I/frr79i0KBBOi1s+vTpg5IlS+LcuXOwtLQEkL4WSo8ePdCvXz+t4TlfmxKK1Zo1ayI4OBiTJk1SZ0lLS8OMGTM+2gr6a5k9e/Zn7adSqSQtbPz8/NCjRw/MmDFD4wpEkyZN0LlzZ8lyeXp6Sjp391MiIyPRpEkTPHz4UH3yITAwEI6OjtixYwfc3NwkyXX06FEcO3ZMvaaZXOjp6cHDwwMxMTGyLGw8PT1x9OhRraurGzdu1NkQ/VxT2Fy8eFFdDUo55+JzdOnSBV26dEFiYiLi4+OzvBqha1euXFGvjnzr1i2N+6Q+UyGnzkYHDhxQj3+X82JeO3fuhL6+Pho2bKixfe/evUhNTUXjxo11mkfOBWEGlUqF6dOnY9y4cbh+/TqMjY3h4eEh2ST4zH8Y7t27h+rVq2sNn0pJScGJEyckH6JTunRp3LhxAw0aNMCyZcvQrFkzrbOtnTp1wuDBg3Wa69KlSxpFDZD+uzhlyhRJ5v4ooVidMWMG6tevj3PnziE5ORkjRozA1atXERsbi+PHj+s8j1xfp/edPXsWixYt0tpeqFAhPHnyRIJE6aZPn44RI0Zg6tSpWTZTkupEUoZBgwbBzc0Np06dUv9tjYmJQdeuXTFo0CDs2LFDklzFixeXZM7z55g2bRqGDx+OhQsXymqhdwAYP348unfvjocPHyItLQ2bN2/GzZs3ERwcjO3bt+smhK77SxN9icjISNGnTx9RqVIlUaJECdGlSxcRHh4uaaZ79+6JtLQ0re1paWni3r17EiT6R+nSpcWOHTu0tu/atUt4eXnpPM+hQ4fEu3fv1P/+2E1qERERYvfu3SIxMVEIIbL8Geuanp6eePr0qdb2Fy9e6Hyth6wEBASIBw8eSB1Di5eXlwgNDdXaHhoaKkqVKiVBonTJycmiZ8+e6nV15CYuLk5MnjxZtGvXTjRu3FiMGTNGPHr0SOpYsmZjY6Nel8jU1FS9lt7evXtF4cKFJculUqmESqUSenp6GreMbVIzMTHJ8m+51Ov/nDlzRtSrV08cOnRIvHjxQrx8+VLjJiULCwthYGAg9PT0hJGRkbC0tNS4Se3IkSPC29tb2NjYCGNjY1GjRg2xZ88enT1/rrlik1lwcDAqVaqkNRn/7du3+OOPP7RWiv/aypcvj9DQUFhaWqJcuXIfvQJy4cIFHSbTJse1CwDAzc0NS5YskTqGBhcXF/VViMxiY2Ph4uIi6byHiIgIeHp6am0vXrw4IiMjdZ6ndu3aWf5bTj7U5rZ3796St7n90PswJiZGa9ioFMT/z6V535s3b/Dzzz9Ltnp4YGAgBg0ahIkTJ6rXEjl16hQCAgIwffp0jWGRujxznTdvXmzatAnjxo3T2XNmh7m5OcaMGSN1jCw9ePAAf/31F6Kjo9VDRjNIOWS6efPmCAgIwB9//AEg/QpwdHQ0Ro4ciTZt2kiWS84jCwDA0NAQr1+/1toeHx8PAwMDCRKls7CwwKtXr9TzLTMIGXSTk/t82po1a2Lfvn2SPX+ubPesp6eHfPnyYeXKlRofKE+fPoWDg4POfyH9/f0xfPhwmJiYYOLEiR8tFCZMmKDDZP+Q89oF+vr6WRYQMTExsLW1lewDRk9PD0+fPlUPLclw7949eHp6IiEhQZJcAGBvb481a9ZofSjv378fnTt3xrNnz3SaJztd96SaNC3HNrcZ6xVs3boVjRo10hgWl5qaivDwcBQrVgy7d+/WebbM5PwezZDxuZvxJy/z11LNiStbtix8fX11+ryf4+3btwgPD8+yG1Tz5s0lSpXezKN58+ZwdXXFjRs3UKpUKdy9exdCCJQvX17SxaRfvnyJtm3b4ty5c3j9+jUcHBzw5MkTVKtWDTt37pTFCQg58vHxwYULF7Bs2TJUrlwZQPraYX379kWFChWwcuVKSXJVrlwZefLkweDBg7NsHiDXE3RyEh8fr/X5oYsTSLnyig2QXkx069YNly9fxsSJEyXNkrlYkTrLh/j6+iJv3ryIjo7WuNLVoUMH+Pn5SX62OitJSUmSnNHJaE6hUqkwbtw4jQ5CqampOH36tOSrYLdo0QJDhgzBn3/+qZ58GRkZiaFDh0pyYJJ5ovSnrgBKdRAsxza3Ge2RhRAwMzPTaO9pYGCAqlWrom/fvpJky+xDP9ewsDBJ12SR89lqDw8PBAQE4Pjx41k2bJFqIvzu3bvh4+OT5YRzqc9Ujx49GsOGDYO/vz/MzMywadMm2NraokuXLmjUqJFkuYD09+q+fftw7NgxhIeHqxeD9fb2ljQXkD4RftGiRbh9+zY2bNiAQoUKISQkBC4uLvjmm28kzTZv3jx0794d1apVU8//effuHVq0aCHplYkrV67g4sWL6oYGcvN+J7mSJUuiefPmknaSA9LnxA0YMACHDh3SWPtNlyeQcm1h07VrV1SvXh2tWrXClStXEBISInUkAOlderp27Yo6depIHUWDHA/qMtp8qlQqLF26FKampur7UlNTceTIEUlaWGY0pxBC4PLlyxrFlYGBAcqUKYNhw4bpPFdmM2bMQKNGjVC8eHH1z/TBgweoWbMmfvnlF53nyTwB+OLFixg2bBiGDx+u7mp38uRJzJw5EzNmzNB5tgxya3ML/LN2gbOzs/qqr5xkrJ2kUqlQtGhRjeImNTUV8fHxGmsZ6Jqcz6ouW7YMFhYWOH/+PM6fP69xn5QdvgYOHIh27dph/PjxsLOzkyTDh1y/fh1r164FAOTJkwdv3ryBqakpAgIC0KJFC/zwww8SJwS++eYbyYuFzDZt2oRu3bqhS5cuuHDhApKSkgCkX2GaOnUqdu7cKWk+CwsLbN26FZGRkRoLXWfVMliXKlasiPv378uysJFrJzkg/dhbCIHly5dL1iY7Vw5FyzwsIjo6Gs2bN4dKpUJQUBCqV68u6RmnFi1aYM+ePbCxsUHHjh3RtWtXWbQTNDMzw4ULF+Dh4QEzMzP1MJxz586hYcOGiImJ0XmmjIUS7927h8KFC2uciTAwMICzszMCAgJQpUoVnWcD0lcCnjt3ruRdZT5ECIF9+/ZprGpeq1YtqWOhcuXKmDhxIpo0aaKxfefOnRg3bpzWQZ6uNGnSBBUqVMCkSZNgZmaG8PBwODk5oWPHjkhLS8PGjRslyQWkF4YpKSla7T0jIiKQN29eODs7S5Jr1apVEEKgV69emDNnjsYCnBnvUV23ZFfCWjHve394nJTy58+PixcvSnpw9CH29vY4ePAgSpQoAU9PT0ybNg3NmzdHWFgYatSogfj4eJ3mUcIaO+XKlYOvry98fHw0/rZfvHgRjRs3lqRj26eW5MhMqnlTGzZswMSJEzF8+PAsu8lJ+dnRpEkTCCHw+++/a3WS09PTk6yTHACYmpri/Pnz0haEOmtToEMqlUqjg1BCQoJo2bKlMDMzk0UXkNjYWLFo0SJRu3ZtoaenJzw9PcWUKVPEnTt3JMvUuHFjMXbsWCFEekeX27dvi9TUVNGuXTvRpk0byXIJIUSdOnVEbGyspBk+JTo6WkRHR0sdQxGMjIzEtWvXtLZfu3ZNGBkZSZAo3eXLl4Wtra1o1KiRMDAwEG3bthUlSpQQdnZ2IjIyUrJcQghRq1YtsXLlSq3tISEhonbt2roP9J7MXe+klvnzP6PzU0ZnqMw3OfwtWLp0qShZsqQwMDAQBgYGomTJkmLJkiWSZurZs6dYunSppBk+pEWLFmLx4sVCCCGGDh0q3N3dxeTJk0X58uVF/fr1dZ7H2dlZ45YvXz6hUqnU3alUKpXIly+fcHFx0Xm2DMbGxupji8zd2qKiooShoaEkmerUqfNZt7p160qSTwjxwc8MOXx2yLWTnBDpP9t9+/ZJmiFXDkWbMGGCxrAlExMT/Pnnn5gwYQKOHDkiYbJ0lpaW6NevH/r164cHDx5g7dq1WL58OcaPH4+UlBRJMslt7YLM5DpOPiUlBf7+/pg3b576TKGpqSkGDhyICRMmaJ3h+drmzZuHfv36wcjI6JNnEqVcyK5EiRIIDAzE0qVL1cP4kpOTERgYqNXJUJdKlSqFW7duYf78+TAzM0N8fDxat26N/v37o2DBgpLlAtKH79WoUUNre9WqVTFgwAAJEmkyMzPD9evXUbp0aQDpzQ5WrFgBT09PTJw4Uadz4ZSwVgyQvt7DrFmzMHDgQI0hmb6+voiOjkZAQIAkuebPn4927drh6NGjWZ6plvKzY9asWerPWn9/f8THx2P9+vXw8PCQ5Mx+5t+vNWvW4LfffsOyZcvUZ6tv3ryJvn374n//+5/Os2Wwt7dHZGSk1lXdY8eOwdXVVZJMcv2bnpmcPzvk2kkOSF84/fvvv8fDhw9RqlQpaa50SVpW/cclJyeLP//8U7Rp00YYGRkJBwcHSfPIde2ClJQUsXTpUtGpUydRv359UbduXY2bVL7//ntha2srgoKCRFhYmAgLCxNBQUHC3t5efP/99zrP4+zsLF68eKH+94duUp49FEKI06dPC1tbW2FjYyPq168v6tevL2xsbIStra04ffq0pNnkKn/+/Oo1MjI7d+6cMDU1lSCRpooVK4qNGzcKIf45E9ypUyfh7u4uBg8eLG04mbK2thZr1qzR2r5mzRpRoEABCRKlW7p0qciTJ48wNTUVTk5Osvrs6N27tzh48KCkGT7E1dX1g+9RZ2dnCRKlmzp1qvD09BSnTp0SZmZm4ujRo2L16tXCxsZGzJs3T7Jc9OW6desmSpYsKU6dOiXS0tJEWlqaOHnypChVqpTo3r27pNlOnjwpXFxcJL3SlSvn2GS4du2aVq97lUqFZs2aSZgq/WzFmjVrsGnTJqSlpaF169bo0qUL6tWrJ4sx1nIzYMAArFy5Ek2bNkXBggW1XqPZs2dLksvc3Bzr1q1D48aNNbbv3LkTnTp1wsuXLyXJpQQJCQn4/fffcePGDQDpV3E6d+6s85aoSmhDDQDNmjWDsbEx1q5dq55rlpqaig4dOiAhIQG7du2SLBuQ/l64cOEC3NzcMH36dBw4cAB79uzB8ePH0bFjR9y/f1+SXIGBgbCzs0OvXr00ti9fvhzPnz/HyJEjJckFpE+aPnv2rNa8qVu3bqFy5cqIi4uTJJe9vT0GDRqEUaNGabTLlgO5zlEF0keGHD58GJUqVdLYfubMGdSpUweJiYmS5BJCYOrUqQgMDFRnMDQ0xLBhwzBp0iRJMilJVseRgLRtz+Pi4tC9e3ds27ZNfUUkJSUFzZs3x8qVKzXmOuqap6cnSpQogREjRmTZPMDJyenrh9BJ+aRjUVFRwsvLS2t8dcaKu1JycHAQRkZGomXLlmLDhg3i7du3kubJ7M2bN+L06dNi27ZtYuvWrRo3KRUoUEDs2LFD0gxZsbGx+eBcEWtrawkS/cPf318kJCRobU9MTBT+/v4SJJKn988mZV6V+/1tUrp69aooUKCAcHNzEz169BA9evQQbm5uwsbGRly+fFnSbEIIYWZmJm7duiWEEMLb21vMmTNHCCHEvXv3JJ035eTkJI4fP661/dSpU5KeRRdCiAEDBghfX1+t7UOHDhU//vijBInSWVpaSj6n7GPkOEdVCCG+++47Ua5cOXH+/Hn1tnPnzony5cuLZs2aSZgsXVJSkrh69ao4ffq0eP36tdRxZE/Ox5EZbt26Jf766y/x119/iYiICKnjCCHS5/9InSVXXrFp1qwZ9PX1sXTpUri4uODMmTOIiYnB0KFD8csvv6BmzZqSZVuyZAnatWsHCwsLyTJkRc5rFzg4OODQoUMoWrSoZBmyEhAQgBs3bmDFihXqdsBJSUno3bs3PDw8JFtsFZDvgomZyeFMWOZW5p9qQ92yZUud5crKo0ePMH/+fI0udwMGDJB0nZgM9erVg6OjI7y9vdG7d29cu3YN7u7uOHz4MLp37467d+9KksvIyAjXr19Xd1jMcPv2bXh6emqss6BrAwcORHBwMBwdHVG1alUA6QsTRkdHw8fHR2Nsui7nj/j6+sLGxgY//fSTzp7zS2WeoxoRESHZHFUAeP78Obp3747du3drrMfSqFEjrFixQnats+nj5HwceezYMVm1FM+sWbNm6NGjB9q0aSNZhlxZ2FhbW+PAgQPw8vKCubk5zpw5g2LFiuHAgQMYOnSoeh0SKUVGRiIqKgq1atWCsbHxZy1c+DV5eHigQYMGsly7YObMmbh9+zbmz58vq6F6rVq1QmhoKAwNDdXDIcLCwpCcnIz69etr7Lt582adZtPT08PTp0/Vk6gzHDhwAB06dMDz5891miez27dvo1WrVrh8+bJ60U7gn1a3UhVdcm1DrQTh4eHo0qULoqOj4efnpy7qBw4ciJiYGKxZs0aSXBknGLp27aqxPSQkBBMmTMDt27clyQUAdevW/az9VCoVDhw48JXT/GPQoEEIDg5GmTJl4OXlpTX5V6r2u+979+4dduzYgdWrV2PHjh2wsrLCw4cPpY6FiIgI9XosxYsXl+SEXOvWrbFy5Urkz58frVu3/ui+uv7bpBRyPo40MDBAoUKF0KlTJ3Tt2hWenp6SZXnf4sWLMXnyZPTq1SvL5iO6OHGZK7uipaamwszMDED6L+ejR49QrFgxODk54ebNm5Jmi4mJQfv27XHw4EGoVCpERETA1dUVvXv3hqWlJWbOnClJrqdPn8LPz092RQ2Qfnbi4MGD2LVrF0qWLKn1RpHqg9nCwkLrrISjo6MkWTLIfcFEABg8eDBcXFwQGhqa5ZkwqVy+fFnrzD6Qvp7StWvXJEikLTExMcurXFKvx+Ll5YXLly9rbf/5558lXQm7b9++GDJkCN69e4d69eoBAEJDQzFixAgMHTpUslyAfDtDXb58GeXKlQOQvvp6ZnI4sZTVHNXt27erf7665Ofnh0mTJiFfvnxZrs1y6NAh9b91WRCam5urf1ZSzrdQMjkfRz569Ajr1q3D2rVrMW3aNHh5eaFLly7o1KmT1iLrupZxfJFVV0ddjf7JlYVNqVKlEBYWBhcXF1SpUgUzZsyAgYEBFi9eLFl7wwy+vr7ImzcvoqOjNVrbdujQAX5+fpIVNm3btsWhQ4dkuSibhYUFWrVqJXUMLRmrwsvJnDlz1Asm+vv7y2LBxPedPHkSBw4cgLW1NfT09KCnp4dvvvkGgYGBGDRokGRnwuTahhpIH+bSs2fPDzYJkMPQwri4OGzcuBFRUVEYPnw4rKyscO3aNdjZ2aFQoUKSZBo+fDhiYmLw448/qotBIyMjjBw5EqNHj5Ykk9zJteACgEKFCiE2NhaNGjXC4sWL0axZM/UwYClcvHgR7969U//7Q3RdEGb8bRJCwN/fHzY2NjA2NtZpBqWT83GktbU1BgwYgAEDBuDOnTtYs2YNVq1ahdGjR6NWrVo6vcL7vrS0NMmeW0266T1fz+7du8WmTZuEEEJERESIYsWKCZVKJaytrUVoaKik2ezs7MSlS5eEENqLZUm5sFJCQoJo0qSJ6N69u/jll1/E3LlzNW6kHO/evRMrV66U7YKhFhYW4vbt20KI9BapBw4cEEIIERkZKYyNjSXLJec21J07dxY1atQQZ8+eFfny5RN79+4VISEholixYmL79u2SZhNCiLCwMGFtbS3c3d1Fnjx51J9rY8aMEd26dZM4nRCvX78WZ86cEZcvX5ZVwxY5Wr58uUhMTJQ6RpYWL14s/v77b6ljKEZqaqrImzevurEHfVxYWJhITU0VQqQfR27evFkIIb/jyPelpKSIbdu2ibJly8qmsYGUcuUcm6zExsaqh+lIyczMDBcuXICHhwfMzMwQFhYGV1dXnDt3Dg0bNkRMTIwkuZYtW4bvv/8eRkZGKFCggMbrpFKpJB2LnuH58+fqS8DFihXTmj+iC+XLl0doaCgsLS1Rrly5j/4+XbhwQYfJNJmYmOD69eu6aa2YTTVr1sTQoUPRsmVLdO7cGX///TfGjh2LxYsX4/z581rDX3RJLm2o31ewYEFs3boVlStXRv78+XHu3DkULVoUf/31F2bMmIFjx45Jms/b2xvly5fHjBkzND7XTpw4gc6dO0vWPCCD3OY0ypmdnR3evHmDdu3aoXfv3qhevbrUkehfKFmyJJYtW6ZuUEEflrnpjqurK86ePYsCBQqo75fLcWSG48eP4/fff8fGjRvx9u1btGjRAl26dEGjRo0kzRUaGorQ0FA8e/ZM6wrO8uXLv/rz58qhaFmRQ+cgIP2gLjg4WN0/XqVSIS0tDTNmzPjsyaRfw5gxY+Dv7y/LtQsSEhLUHYQy3iT6+vrw8fHBr7/+ChMTE51ladGihXrog9Rdsj6mcuXKuHjxoiwLm7FjxyIhIQFA+jjc7777DjVr1kSBAgWwfv16SbPly5cP/fr1kzRDVhISEtQd7iwtLfH8+XMULVoUpUuXlrSAznD27FksWrRIa3uhQoXw5MkTCRKlk+ucRjl7+PAhtm3bhpUrV6JOnTpwdXVFz5490b17d9jb20sdj7Jp2rRpGD58OBYuXIhSpUpJHUfWLCwscOfOHdja2uLu3btaB+VyOY4cPXo01q1bh0ePHuHbb7/F3Llz0aJFC50eC32Iv78/AgICULFixSzXHdSFXFnYtGrVKssXU6VSwcjICO7u7ujcuTOKFSum82w///wz6tWrh3PnziE5ORkjRozA1atXERsbi+PHj+s8T4bk5GR06NBBdkUNkD5B8/Dhw9i2bRtq1KgBIL2hwKBBgzB06FAsXLhQZ1kyuj2lpqaibt268PLykl3rbgD48ccfMXToUDx48AAVKlTQuuIg5WTzhg0bqv/t7u6OGzduyO5MmNwUK1YMN2/ehLOzM8qUKYNFixbB2dkZQUFBKFiwoNTxYGhoiFevXmltv3XrliRXVjPIdU6jnOXJkwetWrVCq1at8PTpU6xevRqrVq3CuHHj0KhRI/Tu3RvNmjWT5d8K0ubj44PExESUKVMGBgYGWnNtYmNjJUomP23atEHt2rXVB+QVK1b8YPMTKUexHDlyBMOHD0f79u1hbW0tWY6sBAUFYeXKlejWrZtkGXLlULQePXpgy5YtsLCwQIUKFQCkDwuKi4tDgwYNEBYWhrt37yI0NFR9oKwLGT3tAwMDsW/fPoSFhSE+Ph7ly5dH//79JT1AkfPaBdbW1ti4cSPq1Kmjsf3gwYNo3769ZK2LP7RGhhx87KBD6nWJMnB40OdbvXo1UlJS0KNHD5w/fx6NGjVCbGwsDAwMsHLlSnTo0EHSfH369EFMTAz++OMPWFlZITw8HPr6+mjZsiVq1aqFOXPmSJLL3t4ee/bsQZkyZTSGyN2+fRteXl6Ij4+XJJeSnD59GsuXL8eqVatQsGBB/P3337C0tMSKFSu0PpNJflatWvXR+7t3766jJMqwe/duREZGYtCgQQgICFB3Rnvf4MGDdZxMGQoUKIAzZ85I2ogqV16xsbe3R+fOnTF//nz1AV5aWhoGDx4MMzMzrFu3Dt9//z1Gjhyp07HpefPmRXh4OCwtLTFmzBidPe/nSE1NxYwZM7Bnzx7ZrV2QmJiYZRtqW1tbJCYmSpAoXalSpXD79m1ZFjZ37tyROsIHcXjQ53n16hXy588PABrrsFSoUAH37t3DjRs3UKRIEVmcsZs5cybatm0LW1tbvHnzBrVr18aTJ09QrVo1TJkyRbJcCQkJWQ7PiI2NlbSbltw9ffoUISEhWLFiBW7fvo2WLVti+/bt8Pb2RkJCAgICAtC9e3eNBW5Jnli4ZE/G/JTz58+rjxnlSg6LXL+vT58+WLNmDcaNGydZhlx5xcbGxgbHjx/XWhjr1q1bqF69Ol68eIHLly+jZs2aiIuL02k2X19fGBoaYtq0aTp93k/52PweXS8Q97769eujQIECCA4OhpGREQDgzZs36N69O2JjY7F//35Jcu3evRujR4/GpEmTshzulXFQKqWsPvhUKhWaNWsmWSYfHx88e/YMS5cuRYkSJdRn0ffs2QM/Pz9cvXpVsmxyknkia7169bB582ZZDnvM7Pjx4xpXor29vSXN06RJE1SoUAGTJk2CmZkZwsPD4eTkhI4dOyItLQ0bN26UNJ8cNWvWDHv27EHRokXRp08f+Pj4aM0tePbsGezt7eXR2pU+KSoqCitWrEBUVBTmzp0LW1tb7Nq1C0WKFEHJkiWljkfZJNdFroH0K1nBwcHw8vKS7CR5rrxik5KSghs3bmgVNjdu3FD/wI2MjCQZ9pKSkoLly5dj//79WR4MS3VlRM5rF8yZMweNGjVC4cKFUaZMGQBAWFgYDA0NsXfvXslyZaxQ37x5c43fpYwhVVJ+uMj5g2/v3r3Ys2eP1kJiHh4ekp8BzmotlgsXLkiyFoupqSliYmJga2uLQ4cOqdfLkAsrKyvcunUL1tbW6NWrF+bOnYsaNWrodHjvp8h1TqOc2dra4vDhwx9d78rGxkbWV4XpH4cPH0bjxo1Ro0YNHDlyBFOmTIGtrS3CwsKwbNkyFvcKJNdFrgEgPDwcZcuWBSDdAr+5srDp1q0bevfujZ9++gmVKlUCkN61Z+rUqfDx8QGQ/maX4kzFlStXUL58eQDpV5Ay4/yCrJUuXRoREREabXg7deqELl26SLromJyLwfc/+E6fPo3Y2FhZfPDJdXhQeHg4vL29YW5ujrt376Jv376wsrLC5s2bER0djeDgYJ3m8fb2Rt26ddWT3lu1aqVeOPR9UlxRTU5OxqtXr2BtbY1Vq1Zh+vTpshq28e7dOwwaNAjbtm3Dvn37YGZmhvj4eLRu3VryOY1ytmzZsk/uo1KpZNlxkbSNGjUKkydPhp+fn8b7s169epg/f76EyehLyXWRa0Aex0W5srCZPXs27OzsMGPGDDx9+hRAem9+X19fjBw5EgDQoEEDSXp9y+GHnpW3b9/i119/xcGDB7PsPS5lS9nAwEDY2dmhb9++GtuXL1+O58+fq3+mula7dm1JnvdzvP/Bp6+vL5sPPrm2PPfz80OPHj3Ua7FkaNKkCTp37qzzPBndqKKiotQnYuTQzjNDtWrV0LJlS1SoUAFCCAwaNOiDJxp0sXbB++Q8p1HuDh8+jF9++QXXr18HAHh6emL48OGoWbOmxMkouy5fvow1a9Zobbe1tcWLFy8kSET/VmpqqvpvlLW1NR49eoRixYrByclJvdbff1muLGz09fUxZswYjBkzRt2C9P35DkWKFJEimmz17t0be/fuRdu2bVG5cmVZXT1atGhRlh/MJUuWRMeOHSUrbFasWAFTU1O0a9dOY/uGDRuQmJgo6aRNOX/wyXV4kNzWYjE2Nsb3338PADh37hymT58uqzk2q1evxuzZsxEVFQWVSoWXL1/i7du3UsfS0LVrVyxbtkx2cxrlbPXq1ejZsydat26NQYMGAUifO1W/fn2sXLlSkiKfvpyFhQUeP36s1eTm4sWLOh9eSzmjVKlSCAsLg4uLC6pUqYIZM2bAwMAAixcvhqurq87ztG7dGitXrkT+/PnRunXrj+67efPmr54nVxY2mclhArcSbN++HTt37pTV+PgMT548yXLYiI2NDR4/fixBonSBgYFZHgjb2tqiX79+khY2cvvgyyDn4UFyXYsF0L7Sm5qaisuXL8PJyQmWlpaSZLKzs1MXDC4uLggJCdFYpVsO5DqnUc6mTJmCGTNmwNfXV71t0KBBmDVrFiZNmsTCRmEyTv5t2LBBfXX8+PHjGDZsmHpoPslfeHg4SpUqBT09PYwdO1bdEVYOi1ybm5urT4abm5vr/Pnflyu7ogHAxo0b8ccff2TZCk8OK3XLjaenJ9atWyfpwo0f4uHhgQkTJmi0vAWAkJAQTJgwQbKFsoyMjHDjxg04OztrbL979y5KlCiBN2/eSJILAPbs2YOEhAS0bt0akZGR+O6773Dr1i31B1+9evUky2ZjY4MTJ07Aw8NDsgxZketaLAAwZMgQlC5dGr1790Zqaipq1aqFkydPwsTEBNu3b+d6Ih8g526PcmVoaIirV6/C3d1dY3tkZCRKlSolu6ty9HHJycno378/Vq5cidTUVOTJkwepqano3LkzVq5c+cEFKEleMnfJdHV1xdmzZzVOJHGR63/kyis28+bNw5gxY9CjRw9s3boVPXv2RFRUFM6ePYv+/ftLHU+WZs6ciZEjRyIoKEh2k0L79u2LIUOG4N27d+oD8tDQUIwYMQJDhw6VLJetrS3Cw8O1CpuwsDDJz1w3bNhQ/W93d3fcuHFDNh98ch0eJNe1WID04Y0Zhf22bdtw9+5d3LhxAyEhIRgzZowkQ/jmzZuHfv36wcjICPPmzfvovhlDmnRNrnMa5czR0RGhoaFahc3+/fvh6OgoUSr6UgYGBliyZAnGjRuHK1euID4+HuXKlZPdiSX6OAsLC9y5cwe2tra4e/eu1jzo91uy/5flyis2xYsXx4QJE9CpUyeN1abHjx+P2NhYdgLJwvPnz9G+fXscOXIEJiYmWr3HY2NjJUqW3j551KhRmDdvnvrqm5GREUaOHInx48dLlmvkyJFYv349VqxYgVq1agFIn3Tbq1cvtG3bVvLuY3I1cOBABAcHw8PDQ5bDg44dO4bw8HDZrMUCpP++R0ZGonDhwujXrx9MTEwwZ84c3LlzB2XKlMlyCN3X5uLignPnzqFAgQIfXaRWpVJJdlWVsm/hwoUYMmQIevXqherVqwNIn2OzcuVKzJ07F//73/8kTkhf6v22/6Qc/fr1Q3BwMAoWLIjo6GgULlz4g1fbpP68lXrEVK4sbExMTHD9+nU4OTnB1tYW+/btQ5kyZRAREYGqVasiJiZG6oiy4+3tjejoaPTu3Rt2dnZaH3xyWL04Pj4e169fh7GxMTw8PCRfOTw5ORndunXDhg0bkCdP+sXPtLQ0+Pj4ICgo6IOtef/rODwo+5ycnLBkyRLUr18fLi4uWLhwIZo2bYqrV6/im2++wd9//y11RMpF/vzzT8ycOVPdFa1EiRIYPnw4WrRoIXEy+hLLli3D7NmzERERASB9ePeQIUPQp08fiZNRduzevRuRkZEYNGgQAgICPthef/DgwTpO9o/MI6YWL16sNWJKF6MfcuVQNHt7e8TGxsLJyQlFihTBqVOnUKZMGdy5cwe5sI7LESdOnMDJkyfVC2DKkampqXpdIjkwMDDA+vXrMXnyZFy6dAnGxsYoXbq07IbyyY2chwedPXv2gy3PpbyS1LNnT7Rv3x4FCxaESqVSX0U6ffo0ihcvLkkmPz+/z9pPpVJh5syZXzkN5aRWrVqhVatWUsegHDB+/HjMmjULAwcOVC+6evLkSfj6+iI6OhoBAQESJ6TPlbFEyfnz5zF48GBZrRuW4bfffsPixYvRqVMnrFy5EiNGjNAYMaULubKwqVevHv766y+UK1cOPXv2hK+vLzZu3Ihz5859shXdf1Xx4sUlneyuZB4eHvDw8FB3qsqfP79knaroy02dOhVjx45FsWLFtK5aSj10Y+LEiShVqhTu37+Pdu3aqa9W6uvrY9SoUZJk+ty1kKR+7Yj+yxYuXIglS5agU6dO6m3NmzeHl5cXBg4cyMJGgVasWCF1hA+Kjo5WD2E1NjbG69evAQDdunVD1apVdTIVJFcORUtLS0NaWpp6eND69etx/PhxeHh44Pvvv9eaP0LA3r174e/vjylTpqB06dJarxHbZmt7v1NV7dq1ceLECXaqUig7OztMnz4dPXr0kDoKkU5ZWVnh1q1bsLa2/mSDEVNTU5QsWRLTp0+XZRdN0mRhYYGzZ89qNQu4desWKleujLi4OGmCUa7k6uqKTZs2oVy5cqhYsSL69u2L//3vf9i7dy86duyok6s2ubKwAYC3b98iPDxca0iJSqVCs2bNJEwmT3p6egC0z64KIaBSqZCamipFLFkrXLgwtmzZgooVK2LLli348ccfcejQIYSEhODAgQOSLjZJ2VewYEEcOXJENt2ClNB1jHKHVatWoWPHjjA0NMSqVas+um9SUhJ27tyJ+/fv4/z58zpKSF9q4MCByJs3r9ZQ2mHDhuHNmzdYsGCBRMkoN+rTpw8cHR0xYcIELFiwAMOHD0eNGjXUI6aWLVv21TPkysJm9+7d6NatW5ZNAniQnrXDhw9/9P7atWvrKIlyyLFTFX25GTNm4NGjR5KuV5MZu46RXN2/fx8VKlTAs2fPpI5Cn5DRhdLR0RFVq1YFkD43Lzo6Gj4+PhqjM6TuSEnK9/6IqXXr1qnXrfvf//6nk6ZKubKw8fDwQIMGDTB+/HjY2dlJHYdyKXaqyl3S0tLQtGlT3Lp1C56enlrDMTdv3ixRMiLdS05OzrKJRpEiRSRKRF/iY10oM2NHSsoJ0dHRcHR0zHL0z/3793Xy+ZErmwc8ffoUfn5+LGqyKS4uDsuWLVO3+CxZsiR69eoFc3NziZPJkxw7VdGXGzRoEA4ePIi6deuiQIECspr0HhAQgGHDhsHExERj+5s3b/Dzzz9Lup4T5S63bt1C7969ceLECY3tHJasTHLuQkm5j4uLCx4/fgxbW1uN7bGxsXBxcdHJ50euvGLTq1cv1KhRA71795Y6imKcO3cODRs2hLGxMSpXrgwgvfXtmzdvsHfvXpQvX17ihPK0ceNGdaeqwoULA0gfr25hYcE1HxTGzMwM69atQ9OmTaWOokVfXz/LPxYxMTGwtbXlwSblmBo1aiBPnjwYNWqU+qRNZnJeEoC0PX/+HDY2Nlned/nyZZQuXVrHiSg309PTw9OnT7V+5+7duwdPT08kJCR89Qy5srBJTExEu3btYGNjk2WHL0601VazZk24u7tjyZIl6rGRKSkp6NOnD27fvo0jR45InJDo63JycsKePXtkebXtQ38sDhw4gA4dOuD58+cSJaPcJl++fDh//rws3weUffb29li2bJnWCZtffvkF48aN4zIPlCMy1jWbO3cu+vbtqzG6IDU1FadPn4a+vr5OmirlyqFoa9euxd69e2FkZIRDhw5prUfBwkbbuXPnNIoaAMiTJw9GjBiBihUrSphM3kJDQzF79myNFbqHDBmiHpZGyjFx4kRMmDABK1as0BryJZWM1rsqlQpFixbV+CxLTU1FfHw8vv/+ewkTUm7j6emJFy9eSB2Dcoifnx/atGmDnj17YtasWYiNjYWPjw8uX76MNWvWSB2PcomMdc2EELh8+bJGkwADAwOUKVMGw4YN00mWXHnFxt7eHoMGDcKoUaPUbYzp4+zs7BASEoIGDRpobN+zZw98fHzw9OlTiZLJ12+//YbBgwejbdu26hWdT506hY0bN2L27Nno37+/xAkpO8qVK4eoqCgIIeDs7Kx1pffChQs6z7Rq1SoIIdCrVy/MmTNHY76bgYEBnJ2d1b97RDnhwIEDGDt2LKZOnco1zXKJixcvolu3bkhKSkJsbCyqVKmC5cuXw97eXupolMv07NkT8+bNg5mZmWQZcmVhY2VlhbNnz8LNzU3qKIoxaNAg/Pnnn/jll1/Uq8YeP34cw4cPR5s2bWTTAldOChcujFGjRmHAgAEa2xcsWICpU6fi4cOHEiWjL+Hv7//R+ydMmKCjJNoOHz6M6tWrc3Fh+uoynwzMfIWQzQOU6/Xr1+jbty82bdoEAFi6dCm6d+8ucSrKbd69ewdjY2NcunQJpUqVkixHrixsfH19YWNjg59++knqKIqRnJyM4cOHIygoCCkpKQCAvHnz4ocffsC0adNgaGgocUL5MTU1xaVLl+Du7q6xPSIiAuXKlUN8fLxEySg3e/v2LZKTkzW28Sw65RSuaZa7HD9+HF27doWVlRVWr16N48ePw8/PD40bN0ZQUBAsLS2ljki5iKurK/78809Jm4zkysJm0KBBCA4ORpkyZeDl5aV1lpOLUH1YYmIioqKiAABubm6ymWsgR507d0a5cuUwfPhwje2//PILzp07h3Xr1kmUjP6N8+fPa7Q8L1eunMSJ0t+XI0aMwB9//JHlwsM8i0456ejRo1i0aBGioqKwceNGFCpUCCEhIXBxccE333wjdTzKBkNDQ/j6+mLSpEnqY6GoqCh07doV9+/fx4MHDyROSLnJsmXLsHnzZoSEhMDKykqSDLmyecDly5fVByNXrlzRuE9Oa1PIycuXL5GamgorKyuN9o+xsbHIkycPzwj/v3nz5qn/7enpiSlTpuDQoUMac2yOHz+OoUOHShWRvtCzZ8/QsWNHHDp0CBYWFgDS13aqW7cu1q1b98GWqbowfPhwHDx4EAsXLkS3bt2wYMECPHz4EIsWLcK0adMky0W5z6ZNm9CtWzd06dIFFy9eRFJSEoD0vxFTp07Fzp07JU5I2bF3716tq2xubm44fvw4pkyZIlEqyq3mz5+PyMhIODg4wMnJCfny5dO4XxdzVXPlFRvKvsaNG6NZs2b48ccfNbYHBQXhr7/+4h+z/+fi4vJZ+6lUKty+ffsrp6Gc1KFDB9y+fRvBwcEoUaIEAODatWvo3r073N3dsXbtWsmyFSlSBMHBwahTpw7y58+PCxcuwN3dHSEhIVi7di3fn5RjypUrB19fX/j4+MDMzAxhYWFwdXXFxYsX0bhxYzx58kTqiPQFIiMjERUVhVq1asHY2Fg9Z4ooJ8lhrioLGwKQ3nDh+PHj6gO6DDdu3ECNGjWyHP5ClJuYm5tj//79qFSpksb2M2fOoEGDBoiLi5MmGNLnc127dg1FihRB4cKFsXnzZlSuXBl37txB6dKlOZ+LcoyJiQmuXbsGZ2dnjcLm9u3b8PT0xNu3b6WOSNkQExOD9u3b4+DBg1CpVIiIiICrqyt69eoFKysr/PLLL1JHJMpR7IVMAICkpCR104DM3r17xwW86D8hLS0ty65jefPmRVpamgSJ/uHq6oo7d+4AAIoXL44//vgDALBt2zb1sDminGBvb4/IyEit7ceOHYOrq6sEiejf8PX1Rd68eREdHa0xZ7ZDhw7YtWuXhMkot4qLi8PSpUsxevRoxMbGAkgfgqarTrG5co4NZV/lypWxePFi/Prrrxrbg4KCUKFCBYlSyVuvXr0+ev/y5ct1lIRyQr169TB48GCsXbsWDg4OAICHDx/C19cX9evXlzRbz549ERYWhtq1a2PUqFFo1qwZ5s+fj3fv3rEZCuWovn37YvDgwVi+fDlUKhUePXqEkydPYtiwYRg3bpzU8Sib9u7diz179qBw4cIa2z08PHDv3j2JUlFuFR4eDm9vb5ibm+Pu3bvo27cvrKyssHnzZkRHRyM4OPirZ2BhQwCAyZMnw9vbG2FhYeqDuNDQUJw9exZ79+6VOJ08/f333xpfv3v3DleuXEFcXBzq1asnUSr6UvPnz0fz5s3h7OwMR0dHAMD9+/dRqlQprF69WtJsvr6+6n97e3vjxo0bOH/+PNzd3eHl5SVhMsptRo0ahbS0NNSvXx+JiYmoVasWDA0NMWzYMAwcOFDqeJRNCQkJWXY3jY2N5TIOlOP8/PzQo0cPzJgxQ2ORziZNmqBz5846ycA5NqR26dIl/Pzzz7h06RKMjY3h5eWF0aNHw8PDQ+poipGWloYffvgBbm5uGDFihNRxKJuEENi/fz9u3LgBAChRogS8vb0lTpW1uLg4DkOjryY5ORmRkZGIj4+Hp6cnTE1NpY5EX6BJkyaoUKECJk2aBDMzM4SHh8PJyQkdO3ZEWloaNm7cKHVEykXMzc1x4cIFuLm5aczRu3fvHooVK6aTOXosbIhy2M2bN1GnTh08fvxY6iiUS0yfPh3Ozs7o0KEDAKB9+/bYtGkT7O3tsXPnTkkXQyMi+bpy5Qrq16+P8uXL48CBA2jevDmuXr2K2NhYHD9+HG5ublJHpFzE1tYWe/bsQbly5TQKm3379qFXr164f//+V8/AoWikpWnTpli6dCkKFiwodRRFioqKyrIRA8lfaGgoQkND8ezZM62GAVLOmQoKCsLvv/8OANi3bx/27duHXbt24Y8//sDw4cM5XJSIslSqVCncunUL8+fPh5mZGeLj49G6dWv079+ff+MpxzVv3hwBAQHqBjcqlQrR0dEYOXIk2rRpo5MMvGJDWjJX2fRhfn5+Gl8LIfD48WPs2LED3bt3x/z58yVKRl/C398fAQEBqFixIgoWLKi1xsOff/4pUTLA2NgYt27dgqOjIwYPHoy3b99i0aJFuHXrFqpUqaI134uIiEjXXr58ibZt2+LcuXN4/fo1HBwc8OTJE1SrVg07d+7UWrDza+AVG6IvdPHiRY2v9fT0YGNjg5kzZ36yYxrJT1BQEFauXIlu3bpJHUWLpaUl7t+/D0dHR+zevRuTJ08GkF5Mp6amSpyOiIgofY7Nvn37cPz4cYSFhSE+Ph7ly5fX6VxVFjakxcnJKcv1PEjTjh07IIRQn4G4e/cutmzZAicnJ+TJw7eW0iQnJ6N69epSx8hS69at0blzZ3h4eCAmJgaNGzcGkF5cu7u7S5yOiIgICA4ORocOHVCjRg3UqFFDvT05ORnr1q2Dj4/PV8/ABTpJ7ejRo+jatSvMzMygp5f+qxESEoJjx45JnEyeWrZsiZCQEADpHaqqVq2KmTNnomXLlli4cKHE6Si7+vTpgzVr1kgdI0uzZ8/GgAED4OnpiX379qk7VD1+/Bg//vijxOmIiIjS11x7+fKl1vbXr1+jZ8+eOsnA08oEANi0aRO6deuGLl264OLFi0hKSgKQPl5y6tSp2Llzp8QJ5efChQuYPXs2AGDjxo2ws7PDxYsXsWnTJowfPx4//PCDxAnpUzLPk0pLS8PixYuxf/9+eHl5aV21lHIhzLx582LYsGFa2zOvb0NElJkQAvfv34etrS2MjIykjkP/AUIIrfmpAPDgwQOYm5vrJAMLGwKQvkBnUFAQfHx8sG7dOvX2GjVqqMfzk6bExET1AlR79+5F69atoaenh6pVq3JFZ4V4f55U2bJlAaS3SM0sqw9qIiI5E0LA3d0dV69e5Xp09FWVK1cOKpUKKpUK9evX1xiOn5qaijt37qBRo0Y6ycLChgCkr71Sq1Ytre3m5uaIi4vTfSAFcHd3x5YtW9CqVSvs2bNHffb82bNnyJ8/v8Tp6HMcPHhQ6ghERF+Fnp6eel4eCxv6mlq2bAkgfaH3hg0baizoa2BgAGdnZ521e2ZhQwAAe3t7REZGwtnZWWP7sWPH2Pb5A8aPH4/OnTvD19cX9evXR7Vq1QCkX70pV66cxOmIiOi/btq0aRg+fDgWLlyIUqVKSR2HcqkJEyYAgHohaSmHPnIdGwIABAYGYvXq1Vi+fDm+/fZb7Ny5E/fu3YOvry/GjRuHgQMHSh1Rlp48eYLHjx+jTJky6oYLZ86cQf78+VG8eHGJ01FukJqaiuPHj8PLywsWFhZSxyEiBbG0tERiYiJSUlJgYGAAY2NjjftjY2MlSka5WXJycpYLXRcpUuSrPzcLGwKQPhZ36tSpCAwMRGJiIgDA0NAQw4YNw6RJkyROR/TfZmRkhOvXr8PFxUXqKESkIKtWrfro/d27d9dREvoviIiIQK9evXDixAmN7RlNBXSx7hoLG9KQnJyMyMhIxMfHw9PTU2OcJBFJo2LFipg+fTrq168vdRQiIqIs1ahRA3ny5MGoUaNQsGBBrcY7ZcqU+eoZWNgQEcnc7t27MXr0aEyaNAkVKlRQLwqbgc0qiOhDoqKisGLFCkRFRWHu3LmwtbXFrl27UKRIEZQsWVLqeJSL5MuXD+fPn5d0KD4X6CQikrkmTZogLCwMzZs3R+HChWFpaQlLS0tYWFjA0tJS6nhEJFOHDx9G6dKlcfr0aWzevBnx8fEAgLCwMPWEb6Kc4unpiRcvXkiagVdsiIhk7vDhwx+9v3bt2jpKQkRKUq1aNbRr1w5+fn4wMzNDWFgYXF1dcebMGbRu3RoPHjyQOiLlIgcOHMDYsWMxdepUlC5dWmuha12MLmBhQ0RERJQLmZqa4vLly3BxcdEobO7evYvixYvj7du3UkekXCSjOyygubC1LpsHcB0bIiIFOHr0KBYtWoTbt29jw4YNKFSoEEJCQuDi4oJvvvlG6nhEJEMWFhZ4/PixVkfFixcvolChQhKlotxKDotec44NEZHMbdq0CQ0bNoSxsTEuXLiApKQkAMDLly8xdepUidMRkVx17NgRI0eOxJMnT6BSqZCWlobjx49j2LBh8PHxkToe5TK1a9eGnp4elixZglGjRsHd3R21a9dGdHQ09PX1dZKBhQ0RkcxNnjwZQUFBWLJkicaY5Ro1auDChQsSJiMiOZs6dSqKFy8OR0dH9TIOtWrVQvXq1TF27Fip41Euk/kk3MWLFyU5Ccc5NkREMmdiYoJr167B2dlZY5z87du34enpyXHyRPRR9+/fx+XLlxEfH49y5crBw8ND6kiUC5UrVw6+vr7w8fHR+Fv1f+3de1DVdf4/8Oc53A6goigqIoGIyiVBjGVLvC2YSi2rTlmjhKhII+MNFV2anVwvo6irRVhhul5T002zLRGzDNDITZSjchNDEV3DdUwUEQU8vL5/9OPz43TUYDM/H9znY8aZzvvzPp/Pk7fNyOu8L8doNCIiIgJXrlz5zTNwjw0RkcZ17doVpaWl8PT0NGv/5ptv4OXlpU4oImo13N3d4e7uDpPJhPz8fFRWVvKoeHrkSkpKMHjwYIt2Jycn3Lhx47Fk4FI0IiKNi4uLw6xZs/Ddd99Bp9Phhx9+wPbt25GYmIj4+Hi14xGRRiUkJGDDhg0AAJPJhCFDhqB///5wd3dHVlaWuuHoidP4IdzPPc4P4ThjQ0SkcUlJSWhoaEB4eDhqamowePBg2NnZITExETNmzFA7HhFp1O7du/Haa68BAD7//HOcP38eZ86cwYcffoi//OUvyMnJUTkhPUkaP4TbuHGj8iHc0aNHkZiYiDfffPOxZOAeGyKiVqKurg6lpaXKJuA2bdqoHYmINMxgMKC0tBTdu3fH66+/DgcHB6SkpKCsrAyBgYGoqqpSOyI9QUQEy5YtQ3JyMmpqagBA+RBuyZIljyUDCxsiIiKiJ5CHhwfWr1+P8PBw9OjRA2lpaXjxxRdRWFiIgQMHorKyUu2I9ARS80M4LkUjItK4u3fvYs2aNcjMzMTVq1fR0NBgdp1HPhPR/UyaNAmvvPIKXF1dodPpMGzYMADAd999Bx8fH5XT0ZPK1tYWfn5+qjybhQ0RkcbFxsbi4MGDePnllxESEgKdTqd2JCJqBRYuXIinn34aly5dwtixY2FnZwcAsLKyQlJSksrpiB49LkUjItI4Jycn7N+/H6GhoWpHISIi0izO2BARaZybmxvatm2rdgwiamUWL1780OsLFix4TEmIHg/O2BARaVxGRgZSU1Oxdu1aeHh4qB2HiFqJoKAgs9f19fUoKyuDtbU1evbsyf159MThjA0RkcYFBwfj7t278PLygoODA2xsbMyuX79+XaVkRKRlRqPRoq2qqgoTJ07EmDFjVEhE9NvijA0RkcYNGzYMFy9eRGxsLLp06WJxeEBMTIxKyYioNcrPz0dkZCQuXLigdhSiR4ozNkREGvftt9/i6NGjCAwMVDsKET0Bbt68iZs3b6odg+iRY2FDRKRxPj4+uHPnjtoxiKiVSU1NNXstIqioqMCHH36IiIgIlVIR/Xa4FI2ISOMOHjyIRYsWYenSpejbt6/FHpt27dqplIyItKxHjx5mr/V6PVxcXBAWFoY33niDpy3SE4eFDRGRxun1egCw2FsjItDpdDCZTGrEIiIi0hQuRSMi0rjMzEy1IxAREWkeZ2yIiIiIiKjV44wNEVErcOPGDWzYsAHFxcUAAH9/f0yePBlOTk4qJyMiItIGztgQEWnc8ePHMWLECNjb2yMkJAQAkJubizt37uDgwYPo37+/ygmJiIjUx8KGiEjjBg0aBG9vb6xfvx7W1j9NtN+7dw9TpkzB+fPncfjwYZUTEhERqY+FDRGRxtnb28NoNMLHx8esvaioCMHBwaipqVEpGRERkXbo1Q5AREQP165dO1y8eNGi/dKlS/weCiIiov+HhQ0Rkca9+uqriI2Nxa5du3Dp0iVcunQJO3fuxJQpUzBu3Di14xEREWkCT0UjItK4VatWQafTYcKECbh37x4AwMbGBvHx8Vi+fLnK6YiIiLSBe2yIiFqJmpoanDt3DgDQs2dPODg4qJyIiIhIO7gUjYhI4yZPnoxbt27BwcEBffv2Rd++feHg4IDbt29j8uTJascjIiLSBM7YEBFpnJWVFSoqKtC5c2ez9mvXrqFr167K8jQiIqL/ZdxjQ0SkUVVVVRARiAhu3boFg8GgXDOZTNi/f79FsUNERPS/ioUNEZFGtW/fHjqdDjqdDr1797a4rtPpsGjRIhWSERERaQ+XohERaVR2djZEBGFhYdizZw+cnZ2Va7a2tvDw8EC3bt1UTEhERKQdLGyIiDSuvLwcTz31FHQ6ndpRiIiINIunohERaVxxcTFycnKU1++99x769euH8ePHo7KyUsVkRERE2sHChohI4+bNm4eqqioAQH5+PubMmYMXXngBZWVlmDNnjsrpiIiItIGHBxARaVxZWRn8/PwAAHv27EFkZCSWLVuGvLw8vPDCCyqnIyIi0gbO2BARaZytrS1qamoAAF999RWGDx8OAHB2dlZmcoiIiP7XccaGiEjjBg4ciDlz5iA0NBTHjh3Drl27AABnz55F9+7dVU5HRESkDZyxISLSuHfffRfW1tbYvXs30tLS4ObmBgDIyMjAyJEjVU5HRESkDTzumYiIiIiIWj0uRSMi0riLFy8+9PpTTz31mJIQERFpF2dsiIg0Tq/XP/TLOU0m02NMQ0REpE2csSEi0jij0Wj2ur6+HkajEW+99RaWLl2qUioiIiJt4YwNEVErlZ6ejr/97W/IyspSOwoREZHqeCoaEVEr1adPH+Tm5qodg4iISBO4FI2ISON+/iWcIoKKigosXLgQvXr1UikVERGRtrCwISLSuPbt21scHiAicHd3x86dO1VKRUREpC3cY0NEpHFZWVlmhY1er4eLiwu8vb1hbc3Pp4iIiAAWNkRERERE9ATg4QFERBqXnJyMjRs3WrRv3LgRK1asUCERERGR9rCwISLSuA8++AA+Pj4W7f7+/li7dq0KiYiIiLSHhQ0RkcZduXIFrq6uFu0uLi6oqKhQIREREZH2sLAhItI4d3d35OTkWLTn5OSgW7duKiQiIiLSHh6nQ0SkcXFxcUhISEB9fT3CwsIAAIcOHcL8+fMxd+5cldMRERFpA09FIyLSOBFBUlISUlNTUVdXBwAwGAz485//jAULFqicjoiISBtY2BARtRLV1dUoLi6Gvb09evXqBTs7O7UjERERaQYLGyIiIiIiavV4eAAREREREbV6LGyIiIiIiKjVY2FDREREREStHgsbIiIiIiJq9VjYEBFpiKenJ1JSUtSO8chduHABOp0OJ0+eVDvKr6LT6fDpp5+qHQMAMHHiRIwePbrZ/bOysqDT6XDjxo3fLBMRkZr4BZ1ERL+RzZs3IyEhgb9IPkEqKirQoUMHtWMAAN555x3wYFMiov+PhQ0RET0ydXV1sLW1VTuGGRGByWSCtfWv/yeva9eujyDRo+Hk5KR2BCIiTeFSNCKiB7h16xaioqLg6OgIV1dXvP322xg6dCgSEhIAALW1tUhMTISbmxscHR3x+9//HllZWQB+WvYzadIk3Lx5EzqdDjqdDgsXLmxxhr///e9o3749Dh06BAAoKChAREQE2rRpgy5duiA6OhrXrl0DAGzduhUdO3ZEbW2t2T1Gjx6N6Oho3Lx5E1ZWVjh+/DgAoKGhAc7Oznj22WeVvtu2bYO7u7vyOj8/H2FhYbC3t0fHjh3x+uuvo7q6WrneuBxq6dKl6NatG/r06QMAOHbsGIKCgmAwGBAcHAyj0WiWqbKyElFRUXBxcVG+cHTTpk2/OB6NS9p27tyJAQMGwGAw4Omnn0Z2drbSp3HJVUZGBp555hnY2dnhm2++QUNDA5KTk9GjRw/Y29sjMDAQu3fvVsaie/fuSEtLM3ue0WiEXq9HeXk5AMulaL80Pk3/f2n69zFx4kTl9fvvv49evXrBYDCgS5cuePnll39xHADLpWi1tbWYOXMmOnfuDIPBgIEDByI3N9fifTk5OQgICIDBYMCzzz6LgoIC5Vp5eTkiIyPRoUMHODo6wt/fH/v3729WHiIitbGwISJ6gDlz5iAnJwefffYZvvzySxw5cgR5eXnK9enTp+Po0aPYuXMnTp8+jbFjx2LkyJH4/vvvMWDAAKSkpKBdu3aoqKhARUUFEhMTW/T8lStXIikpCQcPHkR4eDhu3LiBsLAwBAUF4fjx4zhw4AD+85//4JVXXgEAjB07FiaTCZ999plyj6tXryI9PR2TJ0+Gk5MT+vXrpxRf+fn50Ol0MBqNyi/j2dnZGDJkCADg9u3bGDFiBDp06IDc3Fx8/PHH+OqrrzB9+nSznIcOHUJJSQm+/PJL7Nu3D9XV1fjjH/8IPz8/nDhxAgsXLrT42d98800UFRUhIyMDxcXFSEtLQ6dOnZo9NvPmzcPcuXNhNBrx3HPPITIyEj/++KNZn6SkJCxfvhzFxcUICAhAcnIytm7dirVr16KwsBCzZ8/Ga6+9huzsbOj1eowbNw47duwwu8f27dsRGhoKDw8PiwzNHZ+HOX78OGbOnInFixejpKQEBw4cwODBg5v9/qbmz5+PPXv2YMuWLcjLy4O3tzdGjBiB69evm/WbN28eVq9ejdzcXLi4uCAyMhL19fUAgGnTpqG2thaHDx9Gfn4+VqxYgTZt2vxXeYiIHjshIiILVVVVYmNjIx9//LHSduPGDXFwcJBZs2ZJeXm5WFlZyeXLl83eFx4eLm+88YaIiGzatEmcnJxa9FwPDw95++23Zf78+eLq6ioFBQXKtSVLlsjw4cPN+l+6dEkASElJiYiIxMfHS0REhHJ99erV4uXlJQ0NDSIiMmfOHHnxxRdFRCQlJUVeffVVCQwMlIyMDBER8fb2lnXr1omIyLp166RDhw5SXV2t3C89PV30er1cuXJFRERiYmKkS5cuUltbq/T54IMPpGPHjnLnzh2lLS0tTQCI0WgUEZHIyEiZNGlSi8ZGRKSsrEwAyPLly5W2+vp66d69u6xYsUJERDIzMwWAfPrpp0qfu3fvioODg3z77bdm94uNjZVx48aJiIjRaBSdTifl5eUiImIymcTNzU3S0tKU/gBk7969zR6fIUOGyKxZs8yeOWrUKImJiRERkT179ki7du2kqqqqxWMRExMjo0aNEhGR6upqsbGxke3btyvX6+rqpFu3brJy5Uqzcdm5c6fS58cffxR7e3vZtWuXiIj07dtXFi5c2OIsRERawD02RET3cf78edTX1yMkJERpc3JyUpZa5efnw2QyoXfv3mbvq62tRceOHX/Vs1evXo3bt2/j+PHj8PLyUtpPnTqFzMzM+36Cfu7cOfTu3RtxcXH43e9+h8uXL8PNzQ2bN2/GxIkTodPpAABDhgzBhg0bYDKZkJ2djeHDh6Nr167IyspCQEAASktLMXToUABAcXExAgMD4ejoqDwnNDQUDQ0NKCkpQZcuXQAAffv2NdtX0zhDYjAYlLbnnnvOLG98fDxeeukl5OXlYfjw4Rg9ejQGDBjQ7DFqej9ra2sEBwejuLjYrE9wcLDy36WlpaipqcHzzz9v1qeurg5BQUEAgH79+sHX1xc7duxAUlISsrOzcfXqVYwdO/a+GZo7Pg/z/PPPw8PDA15eXhg5ciRGjhyJMWPGwMHB4ZcHoYlz586hvr4eoaGhSpuNjQ1CQkIsxqXp2Dk7O6NPnz5Kn5kzZyI+Ph4HDx7EsGHD8NJLLyEgIKBFWYiI1MKlaERE/4Xq6mpYWVnhxIkTOHnypPKnuLgY77zzzq+696BBg2AymfCPf/zD4pmRkZFmzzt58iS+//57ZflSUFAQAgMDsXXrVpw4cQKFhYVm+zkGDx6MW7duIS8vD4cPH8bQoUMxdOhQZGVlITs7G926dUOvXr1alLfpL/bNFRERgfLycsyePRs//PADwsPDW7xUryW5Gpfapaenm41dUVGRss8GAKKiopTlaDt27MDIkSN/VaGq1+stTi5rXPYFAG3btkVeXh4++ugjuLq6YsGCBQgMDFTtJL0pU6bg/PnziI6ORn5+PoKDg7FmzRpVshARtRQLGyKi+/Dy8oKNjY3Z5uubN2/i7NmzAH4qIEwmE65evQpvb2+zP40nZ9na2sJkMrX42SEhIcjIyMCyZcuwatUqpb1///4oLCyEp6enxTOb/hI/ZcoUbN68GZs2bcKwYcPMDgNo3749AgIC8O6778LGxgY+Pj4YPHgwjEYj9u3bp+yvAQBfX1+cOnUKt2/fVtpycnKg1+uVmav78fX1xenTp3H37l2l7V//+pdFPxcXF8TExGDbtm1ISUnBunXrmj1GTe937949nDhxAr6+vg/s7+fnBzs7O1y8eNFi7JqOz/jx41FQUIATJ05g9+7diIqKeujP+Uvj4+LigoqKCuW6yWQy26wP/DTjNGzYMKxcuRKnT5/GhQsX8PXXXzd7LACgZ8+esLW1RU5OjtJWX1+P3Nxc+Pn5mfVtOnaVlZU4e/as2di5u7tj6tSp+OSTTzB37lysX7++RVmIiNTCwoaI6D7atm2LmJgYzJs3D5mZmSgsLERsbCz0ej10Oh169+6NqKgoTJgwAZ988gnKyspw7NgxJCcnIz09HcBPX7ZZXV2NQ4cO4dq1a6ipqWn28wcMGID9+/dj0aJFyhd2Tps2DdevX8e4ceOQm5uLc+fO4YsvvsCkSZPMCqjx48fj3//+N9avX4/Jkydb3Hvo0KHYvn27UsQ4OzvD19cXu3btMitsoqKiYDAYEBMTg4KCAmRmZmLGjBmIjo5+6DKr8ePHQ6fTIS4uDkVFRdi/f79ZgQYACxYswD//+U+UlpaisLAQ+/bte2hh8nPvvfce9u7dizNnzmDatGmorKy878/aqG3btkhMTMTs2bOxZcsWnDt3Dnl5eVizZg22bNmi9PP09MSAAQMQGxsLk8mEP/3pTw+8Z3PGJywsDOnp6UhPT8eZM2cQHx9vNhuzb98+pKam4uTJkygvL8fWrVvR0NDw0MLxfhwdHREfH4958+bhwIEDKCoqQlxcHGpqahAbG2vWd/HixTh06BAKCgowceJEdOrUSTldLSEhAV988QXKysqQl5eHzMzMFv29EBGpSu1NPkREWlVVVSXjx48XBwcH6dq1q7z11lsSEhIiSUlJIvLT5uwFCxaIp6en2NjYiKurq4wZM0ZOnz6t3GPq1KnSsWNHASB//etff/GZjYcHNMrOzhZHR0dJTU0VEZGzZ8/KmDFjpH379mJvby8+Pj6SkJCgHA7QKDo6WpydneXu3bsWz9i7d68AMNsUP2vWLAEgZ86cMet7+vRp+cMf/iAGg0GcnZ0lLi5Obt26pVxvuoG9qaNHj0pgYKDY2tpKv379ZM+ePWaHByxZskR8fX3F3t5enJ2dZdSoUXL+/PlfHJ/GwwN27NghISEhYmtrK35+fvL1118rfRo3yVdWVpq9t6GhQVJSUqRPnz5iY2MjLi4uMmLECMnOzjbr9/777wsAmTBhgsXz0eTwgOaMT11dncTHx4uzs7N07txZkpOTzQ4POHLkiAwZMkQ6dOgg9vb2EhAQoGzk/yU/H/s7d+7IjBkzpFOnTmJnZyehoaFy7Ngxi3H5/PPPxd/fX2xtbSUkJEROnTql9Jk+fbr07NlT7OzsxMXFRaKjo+XatWvNykNEpDadCL+2mIioOW7fvg03NzesXr3a4lNwrQkPD4e/vz9SU1PVjvJIXbhwAT169IDRaES/fv3UjqOqcePGwcrKCtu2bVM7ChGRJnApGhHRAxiNRnz00UfKsqXG/RajRo1SOdmDVVZWYu/evcjKysK0adPUjkO/gXv37qGoqAhHjx6Fv7+/2nGIiDSDxz0TET3EqlWrUFJSAltbWzzzzDM4cuRIi75IsqkjR44gIiLigdebfmP9fysoKAiVlZVYsWJFi/dpaMGyZcuwbNmy+14bNGgQ0tLSHnMidVy8eNFi039TNTU1iIiIwNSpUx9jKiIibeNSNCKix+TOnTu4fPnyA697e3s/xjTadP36dVy/fv2+1+zt7eHm5vaYE6nj3r17uHDhwgOve3p6wtqan00SETXFwoaIiIiIiFo97rEhIiIiIqJWj4UNERERERG1eixsiIiIiIio1WNhQ0RERERErR4LGyIiIiIiavVY2BARERERUavHwoaIiIiIiFq9/wM+FRku2WWYJQAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 1000x500 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "# Display results\n",
+        "results_df = workload.results_df()\n",
+        "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
+        "\n",
+        "keywords_to_count = (\n",
+        "    augmented_messages_df.explode(\"get_keywords_previous_jobs\")\n",
+        "    .groupby(\"get_keywords_previous_jobs\")\n",
+        "    .size()\n",
+        "    .sort_values(ascending=False)\n",
+        ")\n",
+        "keywords_to_count.head(20).plot(\n",
+        "    kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\"\n",
+        ")\n",
+        "\n",
+        "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords_previous_jobs\"].explode().nunique())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "In this notebook, we showed how to use phospho lab to\n",
+        "\n",
+        "1. Load a dataset \n",
+        "2. Parallelize calls to LLM providers (OpenAI)\n",
+        "3. Respect API providers rate limits\n",
+        "4. Use the results of the current job or of previous jobs\n",
+        "5. Use config and sampling to switch from expensive to cheap model\n",
+        "\n",
+        "Discover more about phospho in the [documentation!](https://phospho-app.github.io/docs/)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": []
     }
-   ],
-   "source": [
-    "# Display results\n",
-    "results_df = workload.results_df()\n",
-    "augmented_messages_df = results_df.merge(messages_df, left_index=True, right_on=\"id\")\n",
-    "\n",
-    "keywords_to_count = (\n",
-    "    augmented_messages_df.explode(\"get_keywords_previous_jobs\")\n",
-    "    .groupby(\"get_keywords_previous_jobs\")\n",
-    "    .size()\n",
-    "    .sort_values(ascending=False)\n",
-    ")\n",
-    "keywords_to_count.head(20).plot(\n",
-    "    kind=\"bar\", figsize=(10, 5), title=\"Most common keywords in the dataset\"\n",
-    ")\n",
-    "\n",
-    "print(\"Number of different keywords extracted:\", augmented_messages_df[\"get_keywords_previous_jobs\"].explode().nunique())"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "phospho-env-min",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.7"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "In this notebook, we showed how to use phospho lab to\n",
-    "\n",
-    "1. Load a dataset \n",
-    "2. Parallelize calls to LLM providers (OpenAI)\n",
-    "3. Respect API providers rate limits\n",
-    "4. Use the results of the current job or of previous jobs\n",
-    "5. Use config and sampling to switch from expensive to cheap model\n",
-    "\n",
-    "Discover more about phospho in the [documentation!](https://docs.phospho.ai)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "phospho-env-min",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/internal-tools/cronemails/email_templates.py
+++ b/internal-tools/cronemails/email_templates.py
@@ -6,7 +6,7 @@ email_1_task = """
         <p>The next steps:</p>
         <ul>
             <li>Invite your team members to join your organization</li>
-            <li>Setup <a href="https://phospho-app.github.io/docs/guides/events">custom events</a> to better understand your users</li>
+            <li>Setup <a href="https://phospho-app.github.io/docs/analytics/events/">custom events</a> to better understand your users</li>
             <li>Check out our <a href="https://phospho-app.github.io/docs/guides">guides</a> to discover the features of phospho</li>
         </ul>
         <p>If you have any questions, feel free to reach out to me at <a href="mailto:paul-louis@phospho.ai">paul-louis@phospho.ai</a></p>
@@ -22,7 +22,7 @@ email_100_tasks = """
     <body>
         <p>Hi,</p>
         <p>You have logged 100 tasks on Phospho. You are a true power user!</p>
-        <p>Did you know you could also group tasks into sessions, and add user id metadata? Check out our <a href="https://phospho-app.github.io/docs/guides/sessions-and-users">guide</a>!</p>
+        <p>Did you know you could also group tasks into sessions, and add user id metadata? Check out our <a href="https://phospho-app.github.io/docs/analytics/sessions-and-users/">guide</a>!</p>
         <p>If you wonder what else can phospho do for you, reach out at <a href="mailto:paul-louis@phospho.ai">paul-louis@phospho.ai</a></p>
         <p>Best,</p>
         <p>Paul, CEO of phospho</p>

--- a/phospho-python/README.md
+++ b/phospho-python/README.md
@@ -4,7 +4,7 @@ Phospho is an open source platform to help you monitor LLM apps.
 
 With phospho, monitor every user interaction with your LLM app to identify issues and improve performance. Understand how users use your app and which versions of your product are the most successful.
 
-Read the docs at [docs.phospho.ai](https://phospho-app.github.io/docs/).
+Read the docs at [phospho-app.github.io/docs/](https://phospho-app.github.io/docs/).
 
 > _Warning_ : This project is still under active development!
 
@@ -66,5 +66,5 @@ See the [phospho lab documentation](https://phospho-app.github.io/docs/local/pho
 
 ## Usage
 
-Read the docs at [docs.phospho.ai](https://phospho-app.github.io/docs/) for more information.
+Read the docs at [phospho-app.github.io/docs/](https://phospho-app.github.io/docs/) for more information.
 Use your phospho dashboard to monitor your agent, score interactions and detect events.

--- a/phospho-python/docs/source/index.rst
+++ b/phospho-python/docs/source/index.rst
@@ -29,7 +29,7 @@ Welcome to phospho!
 
 `phospho`_ is a platform to monitor what your users are talking about on your LLM app.
 
-You're reading the documentation for the phospho Python module. The full documentation for phospho `is available here <http://docs.phospho.ai>`_.
+You're reading the documentation for the phospho Python module. The full documentation for phospho `is available here <http://phospho-app.github.io/docs/>`_.
 
 Getting started
 ---------------

--- a/phospho-python/phospho/main.py
+++ b/phospho-python/phospho/main.py
@@ -79,7 +79,7 @@ def callback(
     """
     phospho: a command line interface for the phospho platform
 
-    Learn more: https://docs.phospho.ai
+    Learn more: https://phospho-app.github.io/docs/
     """
     print("[green][bold]Welcome to 🧪phospho[/bold][/green] ")
     print("-> API keys & Project ids: https://platform.phospho.ai")

--- a/phospho-python/pyproject.toml
+++ b/phospho-python/pyproject.toml
@@ -5,7 +5,7 @@ description = "Text Analytics for LLM apps"
 authors = ["phospho <contact@phospho.ai>"]
 readme = "README.md"
 homepage = "https://github.com/phospho-app/phospho"
-documentation = "https://docs.phospho.ai"
+documentation = "https://phospho-app.github.io/docs/"
 keywords = ['LLM', 'Agents', 'gen ai', 'phospho', 'analytics', 'nlp']
 
 [tool.poetry.scripts]

--- a/platform/app/org/insights/events/page.tsx
+++ b/platform/app/org/insights/events/page.tsx
@@ -116,7 +116,7 @@ export default function Page() {
             Your data is automatically augmented using these event detectors.{" "}
             <Link
               className="underline "
-              href="https://phospho-app.github.io/docs/guides/events"
+              href="https://phospho-app.github.io/docs/analytics/events/"
             >
               Learn more
             </Link>
@@ -138,7 +138,7 @@ export default function Page() {
                 set up below.{" "}
                 <Link
                   className="underline "
-                  href="https://phospho-app.github.io/docs/guides/events"
+                  href="https://phospho-app.github.io/docs/analytics/events/"
                 >
                   Learn more
                 </Link>
@@ -169,7 +169,7 @@ export default function Page() {
         <AlertDescription>
           Read our{" "}
           <Link
-            href="https://phospho-app.github.io/docs/guides/events"
+            href="https://phospho-app.github.io/docs/analytics/events/"
             className="underline"
           >
             guide to events

--- a/platform/components/callouts/label-tasks.tsx
+++ b/platform/components/callouts/label-tasks.tsx
@@ -73,7 +73,7 @@ export function LabelTasksCallout() {
                   API.
                 </p>
                 <Link
-                  href="https://phospho-app.github.io/docs/guides/evaluation"
+                  href="https://phospho-app.github.io/docs/analytics/user-feedback/"
                   target="_blank"
                 >
                   <Button variant="default">Learn more</Button>

--- a/platform/components/callouts/setup-abtesting.tsx
+++ b/platform/components/callouts/setup-abtesting.tsx
@@ -49,7 +49,7 @@ function SetupABTestingCallout() {
                 </CardDescription>
               </div>
               <Link
-                href="https://phospho-app.github.io/docs/guides/ab-test"
+                href="https://phospho-app.github.io/docs/analytics/ab-test/"
                 target="_blank"
               >
                 <Button>Setup AB Testing</Button>

--- a/platform/components/callouts/setup-users.tsx
+++ b/platform/components/callouts/setup-users.tsx
@@ -51,7 +51,7 @@ function SetupUsersCallout() {
                   </CardDescription>
                 </div>
                 <Link
-                  href="https://phospho-app.github.io/docs/guides/sessions-and-users#users"
+                  href="https://phospho-app.github.io/docs/analytics/sessions-and-users/"
                   target="_blank"
                 >
                   <Button variant="default">Set up user tracking</Button>

--- a/platform/components/events/run-event.tsx
+++ b/platform/components/events/run-event.tsx
@@ -226,7 +226,7 @@ export default function RunEvent({
                     <HoverCardContent className="w-72">
                       You are billed based on the number of detections.{" "}
                       <Link
-                        href="https://phospho-app.github.io/docs/guides/events"
+                        href="https://phospho-app.github.io/docs/analytics/events/"
                         target="_blank"
                         className="underline"
                       >

--- a/platform/components/navbar/help.tsx
+++ b/platform/components/navbar/help.tsx
@@ -67,7 +67,7 @@ export function NavBarHelp() {
         <DropdownMenuContent align="end">
           <DropdownMenuItem>
             <Link
-              href="https://docs.phospho.ai"
+              href="https://phospho-app.github.io/docs/"
               target="_blank"
               onClick={() =>
                 posthog.capture("navbar_to_docs", {


### PR DESCRIPTION
## Summary

### Situation before

### What's here now

## Check list

- [ ] typing, linting, docstrings (cicd will fail)
- [ ] If adding an external service, include the relevant API keys in deployment scripts in `.github/workflows` (staging and prod) and GH actions
- [ ] If changing data models in `phospho-python` that are used in the backend, run `poetry lock` in `phospho-python` so the `backend` tests CICD cache is invalidated
- [ ] If creating an API endpoint, add it to `v3` so that you can easily document it in `phospho-app.github.io/docs/`
